### PR TITLE
#4 Automation project fails to re-open after it is closed.

### DIFF
--- a/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -17,8 +17,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
     {
         private readonly IProjectFileSystem projectFileSystem;       
         private AutomationProject activeProject;     
-        private Entity rootEntity;
-        private int compilationIteration = 0;
+        private Entity rootEntity;     
 
         public AutomationProjectManager(ISerializer serializer, IProjectFileSystem projectFileSystem, ITypeProvider typeProvider, IScriptEditorFactory scriptEditorFactory, IScriptEngineFactory scriptEngineFactory, ICodeEditorFactory codeEditorFactory, ICodeGenerator codeGenerator) : base(serializer, projectFileSystem, typeProvider, scriptEditorFactory, scriptEngineFactory, codeEditorFactory, codeGenerator)
         {
@@ -49,14 +48,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 string dataModelInitialContent = classGenerator.GetGeneratedCode();
                 File.WriteAllText(Path.Combine(this.fileSystem.DataModelDirectory, "DataModel.cs"), dataModelInitialContent);               
             }             
-        }
-      
-        protected override string GetNewDataModelAssemblyName()
-        {
-            compilationIteration++;
-            string dataModelAssemblyName = $"{this.activeProject.Name.Trim().Replace(' ', '_')}_{compilationIteration}";
-            return dataModelAssemblyName;
-        }
+        }      
 
         private void Initialize(EntityManager entityManager, AutomationProject automationProject)
         {
@@ -173,6 +165,10 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
         {
             throw new System.NotImplementedException();
         }
-       
+
+        protected override string GetProjectName()
+        {
+            return this.activeProject.Name;
+        }
     }
 }

--- a/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -7,8 +7,6 @@ using Pixel.Automation.Core.Models;
 using Pixel.Scripting.Editor.Core.Contracts;
 using System;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 
 namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 {
@@ -18,8 +16,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
     
         private PrefabDescription prefabDescription;
         private Entity rootEntity;
-        private Entity prefabbedEntity;
-        private int compilationIteration = 0;
+        private Entity prefabbedEntity;      
 
         public PrefabProjectManager(ISerializer serializer, IPrefabFileSystem prefabFileSystem, ITypeProvider typeProvider, IScriptEditorFactory scriptEditorFactory, IScriptEngineFactory scriptEngineFactory, ICodeEditorFactory codeEditorFactory, ICodeGenerator codeGenerator) : base(serializer, prefabFileSystem, typeProvider, scriptEditorFactory, scriptEngineFactory, codeEditorFactory, codeGenerator)
         {
@@ -126,24 +123,11 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
         public override void SaveAs()
         {
             throw new NotImplementedException();
-        }        
+        }
 
-        protected override string GetNewDataModelAssemblyName()
+        protected override string GetProjectName()
         {
-            var assemblyFiles = Directory.GetFiles(this.fileSystem.TempDirectory, "*.dll").Select(f => new FileInfo(Path.Combine(this.fileSystem.TempDirectory, f)));
-            if(assemblyFiles.Any())
-            {
-                var mostRecentAssembly = assemblyFiles.OrderBy(a => a.CreationTime).Last();
-                string assemblyName = Path.GetFileNameWithoutExtension(mostRecentAssembly.Name);
-                if(int.TryParse(assemblyName.Split('_', StringSplitOptions.RemoveEmptyEntries).Last(), out int lastIteration))
-                {
-                    compilationIteration = lastIteration;
-                }
-            }
-
-            compilationIteration++;
-            string dataModelAssemblyName = $"{this.prefabDescription.PrefabName.Trim().Replace(' ', '_')}_{compilationIteration}";
-            return dataModelAssemblyName;
+            return this.prefabDescription.PrefabName;
         }
     }
 }


### PR DESCRIPTION
When re-opening a automation project, compiled assembly name must be unique . Earlier assembly name sequence was getting reset causing same assembly name to be used which was already loaded. Hence, new assembly could not be saved on disk. This was already handled for Prefab Projects. Refactored method into based Project Manager class.