### PR TITLE
#6 Several buttons and list box items in Application explorer and Tes…

### DIFF
--- a/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabExplorerViewModel.cs
+++ b/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabExplorerViewModel.cs
@@ -195,7 +195,9 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
         public void ToggleRename(PrefabDescription prefabItem)
         {
             if (SelectedPrefab == prefabItem)
+            {
                 CanEdit = !CanEdit;
+            }
         }
 
         /// <summary>

--- a/Pixel.Automation.AppExplorer.Views/Application/ApplicationExplorerView.xaml
+++ b/Pixel.Automation.AppExplorer.Views/Application/ApplicationExplorerView.xaml
@@ -17,27 +17,36 @@
         <local:ApplicationTemplateSelector x:Key="AppTemplateSelector"/>
 
         <DataTemplate x:Key="DefaultApplication">
-            <iconPacks:PackIconMaterial Width="{TemplateBinding Width}"
+            <Border IsHitTestVisible="True" Background="{DynamicResource  MahApps.Brushes.Control.Background}" BorderThickness="0">
+                <iconPacks:PackIconMaterial Width="{TemplateBinding Width}"
                                         Height="{TemplateBinding Height}"
+                                        IsHitTestVisible="False"
                                         Margin="2"
                                         Padding="4"                                      
                                         Kind="Application" />
+            </Border>          
         </DataTemplate>
 
         <DataTemplate x:Key="WinApplication">
-            <iconPacks:PackIconSimpleIcons Width="{TemplateBinding Width}"
+            <Border IsHitTestVisible="True" Background="{DynamicResource  MahApps.Brushes.Control.Background}" BorderThickness="0">
+                <iconPacks:PackIconMaterial Width="{TemplateBinding Width}"
                                         Height="{TemplateBinding Height}"
+                                        IsHitTestVisible="False"
                                         Margin="2"
                                         Padding="4"                                      
                                         Kind="Windows" />
+            </Border>
         </DataTemplate>
 
         <DataTemplate x:Key="WebApplication">
-            <iconPacks:PackIconEntypo Width="{TemplateBinding Width}" IsHitTestVisible="True"
+            <Border IsHitTestVisible="True" Background="{DynamicResource  MahApps.Brushes.Control.Background}" BorderThickness="0">
+                <iconPacks:PackIconEntypo Width="{TemplateBinding Width}"
                                         Height="{TemplateBinding Height}"
+                                        IsHitTestVisible="False"
                                         Margin="2"
-                                        Padding="4"                                     
+                                        Padding="4"                                      
                                         Kind="Browser" />
+            </Border>          
         </DataTemplate>
 
         <Style x:Key="AddApplicationButtonStyle" TargetType="{x:Type Button}">
@@ -48,15 +57,15 @@
             <Setter Property="Height" Value="32"/>
             <Setter Property="Template">
                 <Setter.Value>
-                    <ControlTemplate>
-                        <StackPanel Orientation="Horizontal" Background="{DynamicResource MahApps.Brushes.Control.Background}">
-                            <iconPacks:PackIconMaterial x:Name="PlusIcon" Width="{TemplateBinding Width}"
-                                        Height="{TemplateBinding Height}"
+                    <ControlTemplate>                      
+                            <Border IsHitTestVisible="True" Background="{DynamicResource  MahApps.Brushes.Control.Background}" BorderThickness="0">
+                                <iconPacks:PackIconMaterial x:Name="PlusIcon" Width="{TemplateBinding Width}"
+                                        Height="{TemplateBinding Height}" IsHitTestVisible="False"
                                         Margin="2"
                                         Padding="4"
                                         Foreground="{DynamicResource MahApps.Brushes.Accent}"
                                         Kind="PlusCircleOutline" />
-                        </StackPanel>
+                            </Border>                    
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsEnabled" Value="False">
                                 <Setter TargetName="PlusIcon" Property="Foreground" Value="Gray"/>

--- a/Pixel.Automation.Designer.ViewModels/AppBootStrapper.cs
+++ b/Pixel.Automation.Designer.ViewModels/AppBootStrapper.cs
@@ -23,13 +23,10 @@ namespace Pixel.Automation.Designer.ViewModels
 {
     public class AppBootstrapper : BootstrapperBase
     {
-
         private IKernel kernel;
 
         public AppBootstrapper()
         {
-           
-
             ConsoleManager.Show();
 
             Log.Logger = new LoggerConfiguration()
@@ -39,7 +36,6 @@ namespace Pixel.Automation.Designer.ViewModels
              .CreateLogger();
 
             Initialize();
-
         }
 
         protected override void OnStartup(object sender, StartupEventArgs e)
@@ -72,21 +68,7 @@ namespace Pixel.Automation.Designer.ViewModels
                         viewAssemblies.Add(Assembly.LoadFrom(System.IO.Path.Combine(Environment.CurrentDirectory, item)));
                         break;
                 }
-            }
-            //if(Directory.Exists("Editors"))
-            //{
-            //    foreach (var item in Directory.GetFiles("Editors", "Pixel.*.dll"))
-            //    {
-            //        viewAssemblies.Add(Assembly.LoadFrom(System.IO.Path.Combine(Environment.CurrentDirectory, item)));
-            //    }
-            //}
-            //if (Directory.Exists("Scripting"))
-            //{
-            //    foreach (var item in Directory.GetFiles("Scripting", "Pixel.*.dll"))
-            //    {
-            //        viewAssemblies.Add(Assembly.LoadFile(System.IO.Path.Combine(Environment.CurrentDirectory, item)));
-            //    }
-            //}
+            }       
             return viewAssemblies;
         }
 
@@ -173,9 +155,7 @@ namespace Pixel.Automation.Designer.ViewModels
             {
                 Log.Error(ex, ex.Message);
                 throw ex;
-            }
-
-            
+            }        
 
         }
 
@@ -204,7 +184,7 @@ namespace Pixel.Automation.Designer.ViewModels
         {
             e.Handled = true;
             Trace.WriteLine(e.Exception.Message);
-            Debug.Assert(false);
+            Debug.Assert(false,e.Exception.Message);
         }
 
 

--- a/Pixel.Automation.Designer.Views/Pixel.Automation.Designer.Views.csproj
+++ b/Pixel.Automation.Designer.Views/Pixel.Automation.Designer.Views.csproj
@@ -7,6 +7,10 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>E:\Git\Pixel.Automation\.builds\</OutputPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="Images\OffsetPicker.png" />
     <None Remove="Images\PrefabIcon.jpg" />

--- a/Pixel.Automation.Designer.Views/Properties/launchSettings.json
+++ b/Pixel.Automation.Designer.Views/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "Pixel.Automation.Designer.Views": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "workingDirectory": "E:\\Git\\Pixel.Automation\\.builds\\netcoreapp3.1"
     }
   }
 }

--- a/Pixel.Automation.Editor.Core/ToolBox.cs
+++ b/Pixel.Automation.Editor.Core/ToolBox.cs
@@ -4,8 +4,8 @@ namespace Pixel.Automation.Editor.Core
 {
     public abstract class ToolBox : ScreenBase, IToolBox
     {
-        bool isActiveItem;
-        public bool IsActiveItem
+        protected bool isActiveItem;
+        public virtual bool IsActiveItem
         {
             get => isActiveItem;
             set

--- a/Pixel.Automation.TestData.Repository/ViewModels/TestDataRepository.cs
+++ b/Pixel.Automation.TestData.Repository/ViewModels/TestDataRepository.cs
@@ -26,7 +26,16 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
 
         public BindableCollection<TestDataSource> TestDataSourceCollection { get; set; } = new BindableCollection<TestDataSource>();
 
-        public TestDataSource SelectedTestDataSource { get; set; }
+        private TestDataSource selectedTestDataSource;
+        public TestDataSource SelectedTestDataSource
+        {
+            get => this.selectedTestDataSource;
+            set
+            {
+                this.selectedTestDataSource = value;
+                NotifyOfPropertyChange(() => SelectedTestDataSource);
+            }
+        }
 
         #region Constructor
         public TestDataRepository(ISerializer serializer, IProjectFileSystem projectFileSystem, IScriptEditorFactory scriptEditorFactory, IWindowManager windowManager, IArgumentTypeProvider argumentTypeProvider)

--- a/Pixel.Automation.TestData.Repository/ViewModels/TestDataRepositoryViewModel.cs
+++ b/Pixel.Automation.TestData.Repository/ViewModels/TestDataRepositoryViewModel.cs
@@ -12,6 +12,21 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
 
         public override PaneLocation PreferredLocation => PaneLocation.Bottom;
 
+        public override bool IsActiveItem
+        {
+            get => this.isActiveItem;
+            set
+            {
+                this.isActiveItem = value;
+                NotifyOfPropertyChange(() => IsActiveItem);
+                //whenever this is no more ActiveItem, set selected test data source to null.
+                if (value == false && this.ActiveInstance != null)
+                {
+                    this.ActiveInstance.SelectedTestDataSource = null;
+                }
+            }
+        }
+
         public TestDataRepositoryViewModel(IEventAggregator eventAggregator)
         {
             this.DisplayName = "Test Data Repository";
@@ -50,6 +65,16 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
 
             }
             return Task.CompletedTask;
+        }
+
+
+        /// <summary>
+        /// One of the list box item can be directly selected without actually activating the view.
+        /// Make sure that whenever an item is selected, we set IsActiveItem to true.
+        /// </summary>
+        public void Activate()
+        {
+            this.IsActiveItem = true;
         }
     }
 }

--- a/Pixel.Automation.TestData.Repository/Views/TestDataRepositoryView.xaml
+++ b/Pixel.Automation.TestData.Repository/Views/TestDataRepositoryView.xaml
@@ -23,14 +23,14 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate>
-                        <StackPanel Orientation="Horizontal">
+                        <Border  Background="{DynamicResource  MahApps.Brushes.Control.Background}" BorderThickness="0" IsHitTestVisible="True">
                             <iconPacks:PackIconMaterial x:Name="PlusIcon" Width="{TemplateBinding Width}"
-                                        Height="{TemplateBinding Height}"
+                                        Height="{TemplateBinding Height}" IsHitTestVisible="False"
                                         Margin="2"
                                         Padding="4"
                                         Foreground="{DynamicResource MahApps.Brushes.Accent}"
                                         Kind="PlusCircleOutline" />
-                        </StackPanel>
+                        </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsEnabled" Value="False">
                                 <Setter TargetName="PlusIcon" Property="Foreground" Value="Gray"/>
@@ -68,19 +68,23 @@
         </Style>
 
         <DataTemplate DataType="{x:Type core:DataSourceConfiguration}">
-            <iconPacks:PackIconOcticons Width="{TemplateBinding Width}"
-                                        Height="{TemplateBinding Height}"
+            <Border  Background="{DynamicResource  MahApps.Brushes.Control.Background}" BorderThickness="0" IsHitTestVisible="True">
+                <iconPacks:PackIconOcticons Width="{TemplateBinding Width}"
+                                        Height="{TemplateBinding Height}" IsHitTestVisible="False"
                                         Margin="2"
                                         Padding="4"                                      
                                         Kind="FileCode" />
+            </Border>            
         </DataTemplate>
 
         <DataTemplate DataType="{x:Type core:CsvDataSourceConfiguration}">
-            <iconPacks:PackIconMaterial Width="{TemplateBinding Width}"
+            <Border  Background="{DynamicResource  MahApps.Brushes.Control.Background}" BorderThickness="0" IsHitTestVisible="True">
+                <iconPacks:PackIconMaterial Width="{TemplateBinding Width}" IsHitTestVisible="False"
                                         Height="{TemplateBinding Height}"
                                         Margin="2"
                                         Padding="4"                                     
                                         Kind="FileDelimited" />
+            </Border>          
         </DataTemplate>
 
         <Style x:Key="TestDataListStyle" TargetType="ListBox">
@@ -127,7 +131,7 @@
 
     <Grid Margin="5,5,0,0" Background="{DynamicResource MahApps.Brushes.Control.Background}">
 
-        <StackPanel x:Name="TestDataSourceView" HorizontalAlignment="Stretch"
+        <StackPanel x:Name="TestDataSourceView" HorizontalAlignment="Stretch"  cal:Message.Attach="[Event PreviewMouseLeftButtonDown] = [Action Activate()]"
                     Margin="0,4,0,6"  Orientation="Vertical">
             <StackPanel DataContext="{Binding ActiveInstance}">
 
@@ -146,7 +150,7 @@
                     ItemsSource="{Binding TestDataSourceCollection}"
                     SelectedItem="{Binding SelectedTestDataSource}"
                     Width="{Binding Path=Width, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}"                
-                    Style="{StaticResource TestDataListStyle}" BorderThickness="0" Background="{DynamicResource MahApps.Brushes.Control.Background}"
+                    Style="{StaticResource TestDataListStyle}" BorderThickness="0" Background="{DynamicResource MahApps.Brushes.Control.Background}"                 
                     ScrollViewer.VerticalScrollBarVisibility="Auto"
                     ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                 </ListBox>


### PR DESCRIPTION
Buttons and list box items that use icon having transparent areas can't be clicked or selected when pointer is over transparent area. Wrapped these icons in a border with hit test visible and changed hit test visible for icons to false. Also, renamed Build folder to .builds and pointed output directory of main project to .builds. Additionally, moved TypeCache file location to root of application from Components folder.