### PR TITLE
Make changing ControlType for a WinControlIdentity user friendly from Control Editor.

### DIFF
--- a/Pixel.Automation.sln
+++ b/Pixel.Automation.sln
@@ -153,6 +153,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Automation.Image.Scra
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Automation.Editors.Image.Capture", "src\Pixel.Automation.Editors.Image.Capture\Pixel.Automation.Editors.Image.Capture.csproj", "{51AFD9D4-F163-4132-B7DA-5A6ADFA1F1AF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pixel.Automation.UIA.Components.Tests", "src\Unit.Tests\Pixel.Automation.UIA.Components.Tests\Pixel.Automation.UIA.Components.Tests.csproj", "{402259E1-BA43-4747-94FA-9ECB1862C564}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -355,6 +357,10 @@ Global
 		{51AFD9D4-F163-4132-B7DA-5A6ADFA1F1AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51AFD9D4-F163-4132-B7DA-5A6ADFA1F1AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51AFD9D4-F163-4132-B7DA-5A6ADFA1F1AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{402259E1-BA43-4747-94FA-9ECB1862C564}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{402259E1-BA43-4747-94FA-9ECB1862C564}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{402259E1-BA43-4747-94FA-9ECB1862C564}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{402259E1-BA43-4747-94FA-9ECB1862C564}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -414,6 +420,7 @@ Global
 		{65EC6EA0-6289-4F43-8EAE-484CA6C55982} = {2B0C7388-18D7-4E3C-8BDF-B7A414520615}
 		{A854EA47-E25C-4412-B983-BC5C49E02F8E} = {2CDDC9CB-DC5E-4E43-9C6C-DBC379581B34}
 		{51AFD9D4-F163-4132-B7DA-5A6ADFA1F1AF} = {94422BB0-2426-4FA2-B9C4-29F94A3CAD7F}
+		{402259E1-BA43-4747-94FA-9ECB1862C564} = {242744A0-4C9B-4B89-9AC0-4188D186D4D2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DEAA90E2-A175-4FAA-99F1-30B64D8D3125}

--- a/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ControlEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ControlEditorViewModel.cs
@@ -144,7 +144,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.ControlEditor
                if(root.Next != null)
                 {
                     this.rootControl = root.Next;
-                    this.rootControl.ControlType = ControlType.Relative;
+                    this.rootControl.LookupType = LookupType.Relative;
                 }
                 return;
             }

--- a/src/Pixel.Automation.Core.Components/ControlDetails/ControlIdentity.cs
+++ b/src/Pixel.Automation.Core.Components/ControlDetails/ControlIdentity.cs
@@ -106,29 +106,28 @@ namespace Pixel.Automation.Core.Components
 
         #endregion Clickable Point Offset
 
+
         #region Search Strategy
-               
+
         [DataMember]
-        [Display(Name = "Search Scope", Order = 30, GroupName = "Search Strategy")]
+        [Display(Name = "Look Up Type", GroupName = "Search Strategy", Order = 10)]
+        [Description("Whether control should be looked relative to Application root or relative to a parent control")]
+        public LookupType LookupType { get; set; } = LookupType.Default;
+
+       
+        [DataMember]
+        [Display(Name = "Search Scope", Order = 20, GroupName = "Search Strategy")]
         public virtual SearchScope SearchScope { get; set; } = SearchScope.Descendants;
 
         [DataMember]
         [Browsable(false)]
-        [Display(Name = "Index", GroupName = "Search Mode", Order = 40)]
+        [Display(Name = "Index", GroupName = "Search Strategy", Order = 30)]
         [Description("Bind to current Iteration when used inside loop")]
         public int Index { get; set; } = 1;
 
         #endregion Search Strategy
 
-        #region Lookup Mode
-
-        [DataMember]
-        [Display(Name = "Look Up Type", GroupName = "Search Mode", Order = 10)]       
-        [Description("Whether control should be looked relative to Application root or relative to a parent control")]
-        public ControlType ControlType { get; set; } = ControlType.Default;     
-
-        #endregion Lookup Mode
-
+      
         [DataMember]
         [Browsable(false)]
         public IControlIdentity Next { get; set; }

--- a/src/Pixel.Automation.Core.Components/Controls/HighlightControlActorComponent.cs
+++ b/src/Pixel.Automation.Core.Components/Controls/HighlightControlActorComponent.cs
@@ -43,7 +43,7 @@ namespace Pixel.Automation.Core.Components.Controls
             if (this.Parent.GetComponentsOfType<IControlEntity>(SearchScope.Descendants).Any())
             {
                 var controlEntity = this.Parent.GetFirstComponentOfType<IControlEntity>(SearchScope.Descendants);
-                if(controlEntity.ControlDetails.ControlType.Equals(ControlType.Relative))
+                if(controlEntity.ControlDetails.LookupType.Equals(LookupType.Relative))
                 {
                     throw new InvalidOperationException("Highlight Control Actor doesn't support Relative controls");
                 }

--- a/src/Pixel.Automation.Core.Components/Entities/ControlEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Entities/ControlEntity.cs
@@ -167,7 +167,7 @@ namespace Pixel.Automation.Core.Components
         public override bool ValidateComponent()
         {
             base.ValidateComponent();
-            if (this.ControlDetails.ControlType.Equals(Core.Enums.ControlType.Relative) && !(this.Parent is ControlEntity))
+            if (this.ControlDetails.LookupType.Equals(Core.Enums.LookupType.Relative) && !(this.Parent is ControlEntity))
             {
                 IsValid = false;
             }

--- a/src/Pixel.Automation.Core.Components/Pixel.Automation.Core.Components.csproj
+++ b/src/Pixel.Automation.Core.Components/Pixel.Automation.Core.Components.csproj
@@ -6,6 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Properties\**" />
+    <EmbeddedResource Remove="Properties\**" />
+    <None Remove="Properties\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>$(AssemblyName).Tests</_Parameter1>
     </AssemblyAttribute>
@@ -29,10 +35,6 @@
       <IncludeAssets>All</IncludeAssets>
       <Private>false</Private>
     </ProjectReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Core/Enums/LookupType.cs
+++ b/src/Pixel.Automation.Core/Enums/LookupType.cs
@@ -5,7 +5,7 @@ namespace Pixel.Automation.Core.Enums
 {
     [DataContract]
     [Serializable]
-    public enum ControlType
+    public enum LookupType
     {
         Default,   // Default controls are always looked up in default search root of application
         Relative   // Control is looked up relative to it's parent control.

--- a/src/Pixel.Automation.Core/Interfaces/IControlIdentity.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IControlIdentity.cs
@@ -79,7 +79,7 @@ namespace Pixel.Automation.Core.Interfaces
         /// <summary>
         /// Controls how the control lookup will be performed by <see cref="IControlLocator{T}"/>
         /// </summary>
-        ControlType ControlType
+        LookupType LookupType
         {
             get;
             set;

--- a/src/Pixel.Automation.JAB.Scrapper/JavaControlScrapperComponent.cs
+++ b/src/Pixel.Automation.JAB.Scrapper/JavaControlScrapperComponent.cs
@@ -242,7 +242,7 @@ namespace Pixel.Automation.JAB.Scrapper
                             var startingNode = (isRelativeScraping ? controlPath.ElementAt(0) : accessibleWindow);
                             JavaControlIdentity rootNodeIdentity = CreateControlComponent(startingNode as AccessibleContextNode, 1, executable);
                             rootNodeIdentity.SearchScope = Core.Enums.SearchScope.Children;
-                            rootNodeIdentity.ControlType = (isRelativeScraping ? Core.Enums.ControlType.Relative : Core.Enums.ControlType.Default);
+                            rootNodeIdentity.LookupType = (isRelativeScraping ? Core.Enums.LookupType.Relative : Core.Enums.LookupType.Default);
                             JavaControlIdentity currentNodeIdentity = rootNodeIdentity;
                             int pathLength = controlPath.Count;
                             AccessibleContextNode lastCapturedAncestorNode = accessibleWindow;

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/JavaControlEntity.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/JavaControlEntity.cs
@@ -53,7 +53,7 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
             {
                 searchRoot = this.ArgumentProcessor.GetValue<UIControl>(this.SearchRoot)?.GetApiControl<AccessibleContextNode>();
             }
-            else if (this.GetControlDetails().ControlType.Equals(ControlType.Relative))
+            else if (this.GetControlDetails().LookupType.Equals(LookupType.Relative))
             {
                 searchRoot = (this.Parent as JavaControlEntity).GetTargetControl<AccessibleContextNode>();
             }
@@ -102,7 +102,7 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
             {
                 searchRoot = this.ArgumentProcessor.GetValue<UIControl>(this.SearchRoot)?.GetApiControl<AccessibleContextNode>();
             }
-            else if (this.GetControlDetails().ControlType.Equals(ControlType.Relative))
+            else if (this.GetControlDetails().LookupType.Equals(LookupType.Relative))
             {
                 searchRoot = (this.Parent as JavaControlEntity).GetTargetControl<AccessibleContextNode>();
             }

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/JavaControlIdentity.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/JavaControlIdentity.cs
@@ -128,7 +128,7 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
                 Role = this.Role,              
                 Depth = this.Depth, 
                 Index = this.Index,
-                ControlType = this.ControlType,
+                LookupType = this.LookupType,
                 OwnerApplication = this.OwnerApplication,
                 Next = this.Next?.Clone() as JavaControlIdentity
             };

--- a/src/Pixel.Automation.UIA.Components/ControlTypeConverter.cs
+++ b/src/Pixel.Automation.UIA.Components/ControlTypeConverter.cs
@@ -1,0 +1,99 @@
+﻿extern alias uiaComWrapper;
+using Pixel.Automation.UIA.Components.Enums;
+using System;
+using uiaComWrapper::System.Windows.Automation;
+
+namespace Pixel.Automation.UIA.Components
+{
+    /// <summary>
+    /// Convert from a <see cref="WinControlType"/> to a <see cref="ControlType"/> and vice-versa.
+    /// This is required to avoid use of controlId which is not user-friendly to change.
+    /// </summary>
+    public static class ControlTypeConverter
+    {
+        public static ControlType ToUIAControlType(this WinControlType controlType)
+        {           
+            switch(controlType)
+            {
+                case WinControlType.Button:
+                    return ControlType.Button;
+                case WinControlType.Separator:
+                    return ControlType.Separator;
+                case WinControlType.Slider:
+                    return ControlType.Slider;
+                case WinControlType.SplitButton:
+                    return ControlType.SplitButton;
+                case WinControlType.StatusBar:
+                    return ControlType.StatusBar;
+                case WinControlType.Tab:
+                    return ControlType.Tab;
+                case WinControlType.TabItem:
+                    return ControlType.TabItem;
+                case WinControlType.ScrollBar:
+                    return ControlType.ScrollBar;
+                case WinControlType.Table:
+                    return ControlType.Table;
+                case WinControlType.Thumb:
+                    return ControlType.Thumb;
+                case WinControlType.TitleBar:
+                    return ControlType.TitleBar;
+                case WinControlType.ToolTip:
+                    return ControlType.ToolTip;
+                case WinControlType.Tree:
+                    return ControlType.Tree;
+                case WinControlType.TreeItem:
+                    return ControlType.TreeItem;
+                case WinControlType.Window:
+                    return ControlType.Window;
+                case WinControlType.Text:
+                    return ControlType.Text;
+                 case WinControlType.ProgressBar:
+                    return ControlType.ProgressBar;
+                case WinControlType.RadioButton:
+                    return ControlType.RadioButton;
+                case WinControlType.MenuItem:
+                    return ControlType.MenuItem;
+                case WinControlType.Calendar:
+                    return ControlType.Calendar;
+                case WinControlType.CheckBox:
+                    return ControlType.CheckBox;
+                case WinControlType.ComboBox:
+                    return ControlType.ComboBox;
+                case WinControlType.Custom:
+                    return ControlType.Custom;
+                case WinControlType.DataGrid:
+                    return ControlType.DataGrid;
+                case WinControlType.Document:
+                    return ControlType.Document;
+                case WinControlType.Pane:
+                    return ControlType.Pane;
+                case WinControlType.Group:
+                    return ControlType.Group;
+                case WinControlType.Edit:
+                    return ControlType.Edit;
+                case WinControlType.HeaderItem:
+                    return ControlType.HeaderItem;
+                case WinControlType.HyperLink:
+                    return ControlType.Hyperlink;
+                case WinControlType.Image:
+                    return ControlType.Image;
+                case WinControlType.List:
+                    return ControlType.List;
+                case WinControlType.ListItem:
+                    return ControlType.ListItem;
+                case WinControlType.Menu:
+                    return ControlType.Menu;
+                case WinControlType.MenuBar:
+                    return ControlType.MenuBar;
+                case WinControlType.Header:
+                    return ControlType.Header;        
+            }
+            throw new ArgumentException($"{controlType} can't be mapped to UIA ControlType");
+        }
+
+        public static WinControlType ToWinControlType(this ControlType controlType)
+        {
+            return Enum.Parse<WinControlType>(controlType.ProgrammaticName.Replace("ControlType.", ""));
+        }
+    }
+}

--- a/src/Pixel.Automation.UIA.Components/Enums/WinControlType.cs
+++ b/src/Pixel.Automation.UIA.Components/Enums/WinControlType.cs
@@ -1,0 +1,43 @@
+﻿namespace Pixel.Automation.UIA.Components.Enums
+{
+    public enum WinControlType
+    {
+        Button,
+        Separator,
+        Slider,
+        SplitButton,
+        StatusBar,
+        Tab,
+        TabItem,
+        ScrollBar,
+        Table,
+        Thumb,
+        TitleBar,
+        ToolTip,
+        Tree,
+        TreeItem,
+        Window,
+        Text,
+        ProgressBar,
+        RadioButton,
+        MenuItem,
+        Calendar,
+        CheckBox,
+        ComboBox,
+        Custom,
+        DataGrid,
+        DataItem,
+        Document,
+        Pane,
+        Group,
+        Edit,
+        HeaderItem,
+        HyperLink,
+        Image,
+        List,
+        ListItem,
+        Menu,
+        MenuBar,
+        Header
+    }
+}

--- a/src/Pixel.Automation.UIA.Components/Pixel.Automation.UIA.Components.csproj
+++ b/src/Pixel.Automation.UIA.Components/Pixel.Automation.UIA.Components.csproj
@@ -19,6 +19,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  
+  <ItemGroup>
     <Reference Include="Interop.UIAutomationClient">
       <HintPath>..\Libs\Interop.UIAutomationClient.dll</HintPath>
       <EmbedInteropTypes>false</EmbedInteropTypes>

--- a/src/Pixel.Automation.UIA.Components/UIAControlLocatorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/UIAControlLocatorComponent.cs
@@ -459,7 +459,7 @@ namespace Pixel.Automation.UIA.Components
 
         private Condition BuildSearchCondition(WinControlIdentity controlIdentity)
         {
-            Condition searchCondition = ConditionFactory.FromControlType(uiaComWrapper.System.Windows.Automation.ControlType.LookupById(controlIdentity.ControlTypeId));
+            Condition searchCondition = ConditionFactory.FromControlType(controlIdentity.WinControlType.ToUIAControlType());
             if (MatchProcessId)
             {
                 searchCondition = searchCondition.AndProcessId(TargetApplication.ProcessId);

--- a/src/Pixel.Automation.UIA.Components/WinControlEntity.cs
+++ b/src/Pixel.Automation.UIA.Components/WinControlEntity.cs
@@ -56,7 +56,7 @@ namespace Pixel.Automation.UIA.Components
             {
                 searchRoot = this.ArgumentProcessor.GetValue<UIControl>(this.SearchRoot)?.GetApiControl<AutomationElement>();
             }
-            else if (this.GetControlDetails().ControlType.Equals(Core.Enums.ControlType.Relative))
+            else if (this.GetControlDetails().LookupType.Equals(Core.Enums.LookupType.Relative))
             {
                 searchRoot = (this.Parent as WinControlEntity).GetTargetControl<AutomationElement>();
             }
@@ -105,7 +105,7 @@ namespace Pixel.Automation.UIA.Components
             {         
                 searchRoot = this.ArgumentProcessor.GetValue<UIControl>(this.SearchRoot)?.GetApiControl<AutomationElement>();
             }
-            else if (this.GetControlDetails().ControlType.Equals(Core.Enums.ControlType.Relative))
+            else if (this.GetControlDetails().LookupType.Equals(Core.Enums.LookupType.Relative))
             {
                 searchRoot = (this.Parent as WinControlEntity).GetTargetControl<AutomationElement>();
             }

--- a/src/Pixel.Automation.UIA.Components/WinControlIdentity.cs
+++ b/src/Pixel.Automation.UIA.Components/WinControlIdentity.cs
@@ -1,11 +1,12 @@
 ﻿extern alias uiaComWrapper;
 using Pixel.Automation.Core.Attributes;
 using Pixel.Automation.Core.Components;
+using Pixel.Automation.UIA.Components.Enums;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
-using uiaComWrapper::System.Windows.Automation;
+using System.ComponentModel.DataAnnotations;
 
 namespace Pixel.Automation.UIA.Components
 {
@@ -34,31 +35,10 @@ namespace Pixel.Automation.UIA.Components
         [Category("Identification")]
         public string NameProperty { get; set; }
         
-        int controlTypeId;
         [DataMember]
-        [Category("Identification")]
-        public int ControlTypeId
-        {
-            get
-            {
-                return controlTypeId;
-            }
-
-            set
-            {
-                controlTypeId = value;
-                OnPropertyChanged("ControlTypeId");
-                OnPropertyChanged("ControlType");
-            }
-        }      
-
-        public string ProgrammaticName
-        {
-            get
-            {
-                return uiaComWrapper::System.Windows.Automation.ControlType.LookupById(this.ControlTypeId).ProgrammaticName;
-            }           
-        }
+        [Category("Identification")]   
+        [Display(Name = "Control Type")]
+        public WinControlType WinControlType { get; set; }
 
         [DataMember]
         [Category("Identification")]
@@ -72,18 +52,7 @@ namespace Pixel.Automation.UIA.Components
         [DataMember]
         [Category("Identification")]
         public bool IsControlElement { get; set; }
-
-
-        System.Windows.Rect boundingRectangle;
-        [DataMember]
-        [Category("Visibility")]
-        public System.Windows.Rect BoundingRectangle
-        {
-            get { return boundingRectangle; }
-            set { boundingRectangle = value; }
-        }
-
-        
+                
         [DataMember]
         [Browsable(false)]
         public int Depth { get; set; }
@@ -129,7 +98,7 @@ namespace Pixel.Automation.UIA.Components
                 Name = this.Name,     
                 Index = this.Index,
                 Depth = this.Depth,
-                ControlType = this.ControlType,
+                LookupType = this.LookupType,
                 ApplicationId = this.ApplicationId,
                 ControlImage = this.ControlImage,
                 BoundingBox = this.BoundingBox,
@@ -141,9 +110,9 @@ namespace Pixel.Automation.UIA.Components
                 AcceleratorKey = this.AcceleratorKey,
                 AccessKey = this.AccessKey,
                 AutomationId = this.AutomationId,
-                boundingRectangle = this.boundingRectangle,
+                boundingBox = this.BoundingBox,
                 ClassName = this.ClassName,
-                controlTypeId = this.controlTypeId,
+                WinControlType = this.WinControlType,
                 HelpText = this.HelpText,              
                 IsContentElement = this.IsContentElement,
                 IsControlElement = this.IsControlElement,
@@ -158,7 +127,7 @@ namespace Pixel.Automation.UIA.Components
 
         public override string ToString()
         {
-            return $"{this.Name} -> Name:{this.NameProperty}|AutomationId:{this.AutomationId}|ClassName:{this.ClassName}|ControlType:{this.ProgrammaticName}|LookUpType:{this.ControlType}|SearchScope:{this.SearchScope}";
+            return $"{this.Name} -> Name:{this.NameProperty}|AutomationId:{this.AutomationId}|ClassName:{this.ClassName}|ControlType:{this.WinControlType}|LookUpType:{this.LookupType}|SearchScope:{this.SearchScope}";
         }
     }
 }

--- a/src/Pixel.Automation.UIA.Scrapper/UIAControlScrapper.cs
+++ b/src/Pixel.Automation.UIA.Scrapper/UIAControlScrapper.cs
@@ -266,13 +266,13 @@ namespace Pixel.Automation.UIA.Scrapper
                         case MouseButtons.Left:
                             if (containerNode != null)
                             {
-                                rootNodeIdentity.ControlType = Core.Enums.ControlType.Relative;
+                                rootNodeIdentity.LookupType = Core.Enums.LookupType.Relative;
                             }
                             break;
 
                         case MouseButtons.Right:
                             containerNode = trackedElement;
-                            rootNodeIdentity.ControlType = Core.Enums.ControlType.Default;
+                            rootNodeIdentity.LookupType = Core.Enums.LookupType.Default;
                             ShowContainerHighlightRectangle(containerNode.Current.BoundingRectangle, Color.Purple);
                             break;
                     }
@@ -283,7 +283,7 @@ namespace Pixel.Automation.UIA.Scrapper
 
                     controlHighlight.BorderColor = Color.Green;
 
-                    Log.Information("Captured control : {$capturedControl} as {$controlType}", current, rootNodeIdentity.ControlType);
+                    Log.Information("Captured control : {$capturedControl} as {$controlType}", current, rootNodeIdentity.LookupType);
 
                 }
                 catch (Exception ex)
@@ -361,7 +361,7 @@ namespace Pixel.Automation.UIA.Scrapper
             capturedControl.NameProperty = trackedElement.Current.Name;
             capturedControl.AutomationId = trackedElement.Current.AutomationId;
             capturedControl.ClassName = trackedElement.Current.ClassName;
-            capturedControl.ControlTypeId = trackedElement.Current.ControlType.Id;
+            capturedControl.WinControlType = ControlType.LookupById(trackedElement.Current.ControlType.Id).ToWinControlType();
             var boundingRectangle = trackedElement.Current.BoundingRectangle;
             capturedControl.BoundingBox = new Rectangle((int)boundingRectangle.X, (int)boundingRectangle.Y,
                             (int)boundingRectangle.Width, (int)boundingRectangle.Height);

--- a/src/Pixel.Automation.Web.Selenium.Components/WebControlEntity.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/WebControlEntity.cs
@@ -63,7 +63,7 @@ namespace Pixel.Automation.Web.Selenium.Components
             {
                 searchRoot = this.ArgumentProcessor.GetValue<UIControl>(this.SearchRoot)?.GetApiControl<IWebElement>();
             }
-            else if (this.GetControlDetails().ControlType.Equals(ControlType.Relative))
+            else if (this.GetControlDetails().LookupType.Equals(LookupType.Relative))
             {
                 searchRoot = (this.Parent as WebControlEntity).GetTargetControl<IWebElement>();
             }
@@ -119,7 +119,7 @@ namespace Pixel.Automation.Web.Selenium.Components
             {              
                 searchRoot = this.ArgumentProcessor.GetValue<UIControl>(this.SearchRoot)?.GetApiControl<IWebElement>();
             }
-            else if (this.GetControlDetails().ControlType.Equals(ControlType.Relative))
+            else if (this.GetControlDetails().LookupType.Equals(LookupType.Relative))
             {
                 searchRoot = (this.Parent as WebControlEntity).GetTargetControl<IWebElement>();
             }

--- a/src/Pixel.Automation.Web.Selenium.Components/WebControlIdentity.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/WebControlIdentity.cs
@@ -104,7 +104,7 @@ namespace Pixel.Automation.Web.Selenium.Components
             {
                 Name = this.Name,     
                 Index = this.Index,
-                ControlType = this.ControlType,
+                LookupType = this.LookupType,
                 ApplicationId = this.ApplicationId,
                 ControlImage = this.ControlImage,
                 BoundingBox = this.BoundingBox,              
@@ -127,7 +127,7 @@ namespace Pixel.Automation.Web.Selenium.Components
      
         public override string ToString()
         {
-            return $"{this.Name} -> FindBy:{this.findByStrategy}|Identifier:{this.Identifier}|LookUpType:{this.ControlType}|SearchScope:{this.SearchScope}";
+            return $"{this.Name} -> FindBy:{this.findByStrategy}|Identifier:{this.Identifier}|LookUpType:{this.LookupType}|SearchScope:{this.SearchScope}";
         }      
     }
 }

--- a/src/Unit.Tests/Pixel.Automation.UIA.Components.Tests/ControlTypeConverterFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.UIA.Components.Tests/ControlTypeConverterFixture.cs
@@ -1,0 +1,25 @@
+extern alias uiaComWrapper;
+using NUnit.Framework;
+using Pixel.Automation.UIA.Components.Enums;
+using uiaComWrapper::System.Windows.Automation;
+
+namespace Pixel.Automation.UIA.Components.Tests
+{
+    public class Tests
+    {
+     
+        [Test]
+        public void ValidateThatControlTypeCanBeConvertedToWinControlType()
+        {
+            WinControlType winControlType = ControlType.Button.ToWinControlType();
+            Assert.AreEqual(WinControlType.Button, winControlType);
+        }
+
+        [TestCase(WinControlType.Button)]
+        public void ValidatethatWinControlTypeCanBeConvertedToControlType(WinControlType winControlType)
+        {
+            ControlType controlType = winControlType.ToUIAControlType();
+            Assert.AreEqual($"ControlType.{winControlType}", controlType.ProgrammaticName);
+        }
+    }
+}

--- a/src/Unit.Tests/Pixel.Automation.UIA.Components.Tests/Pixel.Automation.UIA.Components.Tests.csproj
+++ b/src/Unit.Tests/Pixel.Automation.UIA.Components.Tests/Pixel.Automation.UIA.Components.Tests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0-windows</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Pixel.Automation.UIA.Components\Pixel.Automation.UIA.Components.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Interop.UIAutomationClient">
+      <HintPath>..\..\Libs\Interop.UIAutomationClient.dll</HintPath>
+      <EmbedInteropTypes>false</EmbedInteropTypes>
+      <Aliases>uiaAutomationClient</Aliases>
+      <Private>true</Private>
+    </Reference>
+    <Reference Include="UIAComWrapper">
+      <HintPath>..\..\Libs\UIAComWrapper.dll</HintPath>
+      <EmbedInteropTypes>false</EmbedInteropTypes>
+      <Aliases>uiaComWrapper</Aliases>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+  
+</Project>


### PR DESCRIPTION
1. It was difficult to change control type for a windows control using control editor since it required entering controlId which is not friendly to a user. Replaced ControlID with a WinControlType enum that has one to one mapping with ControlType defined in UIA.
2. Renamed ControlType enum to LookUpType to avoid confusion with UIA ControlType.
3. Removed BoundingRectangle property from WinControlIdentity since this was not used anywhere.