### PR TITLE
Allow executable path, working directory and preferred browser to be over-ridden

### DIFF
--- a/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/Application/CloseApplicationActorComponent.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/Application/CloseApplicationActorComponent.cs
@@ -12,7 +12,7 @@ namespace Pixel.Automation.Java.Access.Bridge.Components.ActorComponents
     /// </summary>
     [DataContract]
     [Serializable]
-    [ToolBoxItem("Close", "Java", "Application", iconSource: null, description: "Close target application", tags: new string[] { "Close", "Java" })]
+    [ToolBoxItem("Close", "Application", "Java", iconSource: null, description: "Close target application", tags: new string[] { "Close", "Java" })]
 
     public class CloseApplicationActorComponent : ActorComponent
     {

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/Application/AttachActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/Application/AttachActorComponent.cs
@@ -21,7 +21,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
     /// </summary>
     [DataContract]
     [Serializable]
-    [ToolBoxItem("Attach", "UIA", "Application", iconSource: null, description: "Attach to target application", tags: new string[] { "Attach", "UIA" })]
+    [ToolBoxItem("Attach", "Application", "UIA", iconSource: null, description: "Attach to target application", tags: new string[] { "Attach", "UIA" })]
     public class AttachActorComponent : ActorComponent
     {
         private readonly ILogger logger = Log.ForContext<AttachActorComponent>();
@@ -37,8 +37,47 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             {
                 return this.EntityManager.GetOwnerApplication<WinApplication>(this);
             }
-        }      
-      
+        }
+
+
+        AttachMode attachMode = AttachMode.AttachToExecutable;
+        /// <summary>
+        /// Indicaets how the application to be attached to is identifed.
+        /// </summary>
+        [DataMember]
+        [Display(Name = "Attach Mode", GroupName = "Configuration", Order = 10, Description = "Indicates how the application to be attached to is identified.")]
+        [RefreshProperties(RefreshProperties.All)]
+        public AttachMode AttachMode
+        {
+            get => this.attachMode;
+            set
+            {
+                switch (value)
+                {
+                    case AttachMode.AttachToExecutable:
+                        if (!this.AttachTarget.ArgumentType.Equals(typeof(string).Name))
+                        {
+                            this.AttachTarget = new InArgument<string>() { Mode = ArgumentMode.Default, DefaultValue = string.Empty };
+                        }
+                        break;
+                    case AttachMode.AttachToWindow:
+                        if (!this.AttachTarget.ArgumentType.Equals(typeof(ApplicationWindow).Name))
+                        {
+                            this.AttachTarget = new InArgument<ApplicationWindow>() { Mode = ArgumentMode.DataBound };
+                        }
+                        break;
+                    case AttachMode.AttachToAutomationElement:
+                        if (!this.AttachTarget.ArgumentType.Equals(typeof(AutomationElement).Name))
+                        {
+                            this.AttachTarget = new InArgument<AutomationElement>() { Mode = ArgumentMode.DataBound };
+                        }
+                        break;
+                }
+                this.attachMode = value;
+                OnPropertyChanged();
+            }
+        }
+
 
         Argument attachTarget = new InArgument<ApplicationWindow>();        
         /// <summary>
@@ -47,8 +86,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         /// you need to lookup ApplicationWindow first and setup this as an argument.
         /// </summary>
         [DataMember]       
-        [Display(Name = "Attach To", GroupName = "Configuration", Order = 10, Description = "Details of the target application to be attached to")]       
-        [RefreshProperties(RefreshProperties.All)]
+        [Display(Name = "Attach To", GroupName = "Configuration", Order = 20, Description = "Details of the target application to be attached to")]      
         public Argument AttachTarget
         {
             get => this.attachTarget;
@@ -58,34 +96,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
                 OnPropertyChanged();
             }
         }
-
-        AttachMode attachMode = AttachMode.AttachToExecutable;
-       /// <summary>
-       /// Indicaets how the application to be attached to is identifed.
-       /// </summary>
-        [DataMember]         
-        [Display(Name = "Attach Mode", GroupName = "Configuration", Order = 30, Description = "Indicates how the application to be attached to is identified.")]
-        public AttachMode AttachMode
-        {
-            get => this.attachMode;
-            set
-            {
-                switch(value)
-                {
-                    case AttachMode.AttachToExecutable:
-                        this.AttachTarget = new InArgument<string>() { Mode = ArgumentMode.Default, DefaultValue = string.Empty };
-                        break;
-                    case AttachMode.AttachToWindow:
-                        this.AttachTarget = new InArgument<ApplicationWindow>() { Mode = ArgumentMode.DataBound };
-                        break;
-                    case AttachMode.AttachToAutomationElement:
-                        this.AttachTarget = new InArgument<AutomationElement>() { Mode = ArgumentMode.DataBound };
-                        break;
-                }
-                this.attachMode = value;               
-            }
-        }     
-
+     
         /// <summary>
         /// Default constructor
         /// </summary>

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/Application/CloseApplicationActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/Application/CloseApplicationActorComponent.cs
@@ -13,7 +13,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
     /// </summary>
     [DataContract]
     [Serializable]
-    [ToolBoxItem("Close", "UIA", "Application", iconSource: null, description: "Close target application", tags: new string[] { "Close", "UIA" })]
+    [ToolBoxItem("Close", "Application", "UIA", iconSource: null, description: "Close target application", tags: new string[] { "Close", "UIA" })]
     public class CloseApplicationActorComponent : ActorComponent
     {
         private readonly ILogger logger = Log.ForContext<CloseApplicationActorComponent>();

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/Application/LaunchApplicationActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/Application/LaunchApplicationActorComponent.cs
@@ -1,8 +1,10 @@
 ﻿using Pixel.Automation.Core;
+using Pixel.Automation.Core.Arguments;
 using Pixel.Automation.Core.Attributes;
 using Serilog;
 using System;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Runtime.Serialization;
 
@@ -13,7 +15,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
     /// </summary>
     [DataContract]
     [Serializable]
-    [ToolBoxItem("Launch", "UIA", "Application", iconSource: null, description: "Launch target application", tags: new string[] { "Launch", "UIA" })]
+    [ToolBoxItem("Launch", "Application", "UIA", iconSource: null, description: "Launch target application", tags: new string[] { "Launch", "UIA" })]
     public class LaunchApplicationActorComponent : ActorComponent
     {
         private readonly ILogger logger = Log.ForContext<LaunchApplicationActorComponent>();
@@ -32,6 +34,21 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         }
 
         /// <summary>
+        /// Optional argument that can be used to over-ride the location of executable set on application.
+        /// </summary>
+        [DataMember]
+        [Display(Name = "Executable Override", GroupName = "Configuration", Order = 10, Description = "[Optional] Override the executable path set on application")]
+        public Argument ExecutableOverride { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+
+        /// <summary>
+        /// Optional argument that can be used to over-ride the working directory of application
+        /// </summary>
+        [DataMember]
+        [Display(Name = "Working Directory Override", GroupName = "Configuration", Order = 10, Description = "[Optional] Override the working directory of application.")]
+        public Argument WorkingDirectoryOverride { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         public LaunchApplicationActorComponent() : base("Launch", "WinApplicationLauncher")
@@ -45,13 +62,27 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         public override void Act()
         {
             var appDetails = ApplicationDetails;
+            
             string executablePath = appDetails.ExecutablePath;
-            if(!string.IsNullOrEmpty(executablePath))
+            if(this.ExecutableOverride.IsConfigured())
+            {
+                executablePath = this.ArgumentProcessor.GetValue<string>(this.ExecutableOverride);
+                logger.Information("Executable location was over-ridden to {executablePath}", executablePath);
+            }
+
+            string workingDirectory = appDetails.WorkingDirectory;
+            if(this.WorkingDirectoryOverride.IsConfigured())
+            {
+                workingDirectory = this.ArgumentProcessor.GetValue<string>(this.WorkingDirectoryOverride);
+                logger.Information("Working directory was over-ridden to {workingDirectory}", workingDirectory);
+            }
+
+            if (!string.IsNullOrEmpty(executablePath))
             {
                 ProcessStartInfo procInfo = new ProcessStartInfo(executablePath);
                 procInfo.WindowStyle = appDetails.WindowStyle;
                 procInfo.UseShellExecute = appDetails.UseShellExecute;
-                procInfo.WorkingDirectory = appDetails.WorkingDirectory;
+                procInfo.WorkingDirectory = workingDirectory;
                 procInfo.Arguments = appDetails.LaunchArguments;
 
                 Application targetApp = Application.Launch(procInfo);

--- a/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/Browser/CloseBrowserActorComponent.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/Browser/CloseBrowserActorComponent.cs
@@ -10,7 +10,7 @@ namespace Pixel.Automation.Web.Selenium.Components
     /// </summary>
     [DataContract]
     [Serializable]
-    [ToolBoxItem("Close Browser", "Selenium", "Browser", iconSource: null, description: "Closes a Selenium based browser", tags: new string[] { "Close", "Shutdown", "Dispose", "Web" })]
+    [ToolBoxItem("Close Browser", "Application", "Browser", iconSource: null, description: "Closes a Selenium based browser", tags: new string[] { "Close", "Shutdown", "Dispose", "Web" })]
     public class CloseBrowserActorComponent : SeleniumActorComponent
     {
         private readonly ILogger logger = Log.ForContext<CloseBrowserActorComponent>();


### PR DESCRIPTION
**Description** :
For a window and java based application, executable path and working directory are set on WindowApplication and JavaApplication types when these application are added. Similarly, For a web application PreferredBrowser is set  when a browser application is added. However, at run time it might be required to change these values due to some constraints on the target machine where test will be executed e.g. PreferredBrowser was configured as chrome but target machine only has Firefox. 

**Solution** : 
Allow respective launch actors for each application type to provide some over-rides through argument. These can be optionally set. An initilalization script can set value of these arguments before environment setup. 
Note : Initialization scripts are not supported at the moment. This will be a future work.

**Additionally** : 
1. Fixed an issue with attach to actor component , where  value of AttachTarget property was  reset on opening the automation process.
2. Moved all Launch / Close / Attach actors to a new group "Application" in component toolbar for ease of access.