### PR TITLE
Replacement for xccedSoftware/wpftoolkit due to licensing

### DIFF
--- a/src/Pixel.Automation.Designer.Views/Shell/ShellView.xaml
+++ b/src/Pixel.Automation.Designer.Views/Shell/ShellView.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"      
         xmlns:docking="clr-namespace:Pixel.Automation.Editor.Core.Docking;assembly=Pixel.Automation.Editor.Core"
         xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
-        xmlns:avalonDock="http://schemas.xceed.com/wpf/xaml/avalondock"
+        xmlns:avalonDock="https://github.com/Dirkster99/AvalonDock"
         xmlns:cal="http://www.caliburnproject.org" 
         xmlns:avalonTheme="clr-namespace:Xceed.Wpf.AvalonDock.Themes;assembly=Xceed.Wpf.AvalonDock.Themes.MahApps"
         mc:Ignorable="d" ShowActivated="True" WindowState="Maximized"

--- a/src/Pixel.Automation.Editor.Controls/Pixel.Automation.Editor.Controls.csproj
+++ b/src/Pixel.Automation.Editor.Controls/Pixel.Automation.Editor.Controls.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Caliburn.Micro" Version="4.0.136-rc" />
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.0.1" />
+    <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="4.6.97" />
     <PackageReference Include="MahApps.Metro" Version="2.3.1" />
     <PackageReference Include="MahApps.Metro.IconPacks" Version="3.3.0" />
   </ItemGroup>

--- a/src/Pixel.Automation.Editor.Controls/Resources/PropertyGridStyle.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Resources/PropertyGridStyle.xaml
@@ -1,15 +1,15 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
-                    xmlns:themes="clr-namespace:Xceed.Wpf.Toolkit.Themes;assembly=Xceed.Wpf.Toolkit"
+                    xmlns:themes="clr-namespace:Xceed.Wpf.Toolkit.Themes;assembly=DotNetProjects.Wpf.Extended.Toolkit"
                     xmlns:metro="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
                     xmlns:metroControls="http://metro.mahapps.com/winfx/xaml/controls"
                     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
-                    xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
-                    xmlns:converters="clr-namespace:Xceed.Wpf.Toolkit.PropertyGrid.Converters;assembly=Xceed.Wpf.Toolkit"
-                    xmlns:utilities="clr-namespace:Xceed.Wpf.Toolkit.Core.Utilities;assembly=Xceed.Wpf.Toolkit"
-                    xmlns:editor="clr-namespace:Xceed.Wpf.Toolkit.PropertyGrid.Editors;assembly=Xceed.Wpf.Toolkit"
-                    xmlns:commands="clr-namespace:Xceed.Wpf.Toolkit.PropertyGrid.Commands;assembly=Xceed.Wpf.Toolkit">
+                    xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"                   
+                    xmlns:converters="clr-namespace:Xceed.Wpf.Toolkit.PropertyGrid.Converters;assembly=DotNetProjects.Wpf.Extended.Toolkit"
+                    xmlns:utilities="clr-namespace:Xceed.Wpf.Toolkit.Core.Utilities;assembly=DotNetProjects.Wpf.Extended.Toolkit"
+                    xmlns:editor="clr-namespace:Xceed.Wpf.Toolkit.PropertyGrid.Editors;assembly=DotNetProjects.Wpf.Extended.Toolkit"
+                    xmlns:commands="clr-namespace:Xceed.Wpf.Toolkit.PropertyGrid.Commands;assembly=DotNetProjects.Wpf.Extended.Toolkit">
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <xctk:InverseBoolConverter x:Key="InverseBoolConverter" />
@@ -543,22 +543,22 @@
                             <Setter Property="MinWidth"  Value="15" TargetName="_expandableButtonColumn" />
                         </Trigger>-->
                         <DataTrigger Binding="{Binding ElementName=_optionsImage, Path=ToolTip}" Value="{x:Static xctk:StringConstants.Local}">
-                            <Setter TargetName="_optionsImage"   Property="Source"  Value="pack://application:,,,/Xceed.Wpf.Toolkit;component/PropertyGrid/Images/Local11.png" />
+                            <Setter TargetName="_optionsImage"   Property="Source"  Value="pack://application:,,,/DotNetProjects.Wpf.Extended.Toolkit;component/PropertyGrid/Images/Local11.png" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding ElementName=_optionsImage, Path=ToolTip}"  Value="{x:Static xctk:StringConstants.Resource}">
-                            <Setter TargetName="_optionsImage" Property="Source" Value="pack://application:,,,/Xceed.Wpf.Toolkit;component/PropertyGrid/Images/Resource11.png" />
+                            <Setter TargetName="_optionsImage" Property="Source" Value="pack://application:,,,/DotNetProjects.Wpf.Extended.Toolkit;component/PropertyGrid/Images/Resource11.png" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding ElementName=_optionsImage, Path=ToolTip}" Value="{x:Static xctk:StringConstants.Databinding}">
-                            <Setter TargetName="_optionsImage" Property="Source" Value="pack://application:,,,/Xceed.Wpf.Toolkit;component/PropertyGrid/Images/Database11.png" />
+                            <Setter TargetName="_optionsImage" Property="Source" Value="pack://application:,,,/DotNetProjects.Wpf.Extended.Toolkit;component/PropertyGrid/Images/Database11.png" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding ElementName=_optionsImage, Path=ToolTip}" Value="{x:Static xctk:StringConstants.Inheritance}">
-                            <Setter TargetName="_optionsImage" Property="Source" Value="pack://application:,,,/Xceed.Wpf.Toolkit;component/PropertyGrid/Images/Inheritance11.png" />
+                            <Setter TargetName="_optionsImage" Property="Source" Value="pack://application:,,,/DotNetProjects.Wpf.Extended.Toolkit;component/PropertyGrid/Images/Inheritance11.png" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding ElementName=_optionsImage, Path=ToolTip}" Value="{x:Static xctk:StringConstants.StyleSetter}">
-                            <Setter TargetName="_optionsImage" Property="Source" Value="pack://application:,,,/Xceed.Wpf.Toolkit;component/PropertyGrid/Images/Style11.png" />
+                            <Setter TargetName="_optionsImage" Property="Source" Value="pack://application:,,,/DotNetProjects.Wpf.Extended.Toolkit;component/PropertyGrid/Images/Style11.png" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding ElementName=_optionsImage, Path=ToolTip}"  Value="{x:Static xctk:StringConstants.Default}">
-                            <Setter TargetName="_optionsImage"  Property="Source" Value="pack://application:,,,/Xceed.Wpf.Toolkit;component/PropertyGrid/Images/AdvancedProperties11.png" />
+                            <Setter TargetName="_optionsImage"  Property="Source" Value="pack://application:,,,/DotNetProjects.Wpf.Extended.Toolkit;component/PropertyGrid/Images/AdvancedProperties11.png" />
                         </DataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/Pixel.Automation.Editor.Core/Docking/LayoutInitializer.cs
+++ b/src/Pixel.Automation.Editor.Core/Docking/LayoutInitializer.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using AvalonDock.Layout;
+using System;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using Xceed.Wpf.AvalonDock.Layout;
 
 
 namespace Pixel.Automation.Editor.Core.Docking

--- a/src/Pixel.Automation.Editor.Core/Pixel.Automation.Editor.Core.csproj
+++ b/src/Pixel.Automation.Editor.Core/Pixel.Automation.Editor.Core.csproj
@@ -10,7 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Caliburn.Micro" Version="4.0.136-rc" />
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.0.1" />
+    <PackageReference Include="Dirkster.AvalonDock" Version="4.50.2" />
+    <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="4.6.97" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Pixel.Scripting.Script.Editor/Editor/MultiEditor/MultiEditorControlView.xaml
+++ b/src/Pixel.Scripting.Script.Editor/Editor/MultiEditor/MultiEditorControlView.xaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Pixel.Scripting.Script.Editor.MultiEditor"           
-             xmlns:avalonDock="http://schemas.xceed.com/wpf/xaml/avalondock"
+             xmlns:avalonDock="https://github.com/Dirkster99/AvalonDock"
              xmlns:avalonTheme="clr-namespace:Xceed.Wpf.AvalonDock.Themes;assembly=Xceed.Wpf.AvalonDock.Themes.MahApps"
              xmlns:docking="clr-namespace:Pixel.Automation.Editor.Core.Docking;assembly=Pixel.Automation.Editor.Core"
              xmlns:cal="http://www.caliburnproject.org"  

--- a/src/Pixel.Scripting.Script.Editor/Editor/MultiEditor/MultiEditorScreenView.xaml
+++ b/src/Pixel.Scripting.Script.Editor/Editor/MultiEditor/MultiEditorScreenView.xaml
@@ -3,7 +3,7 @@
                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                      xmlns:avalonDock="http://schemas.xceed.com/wpf/xaml/avalondock"
+                      xmlns:avalonDock="https://github.com/Dirkster99/AvalonDock"
                       xmlns:cal="http://www.caliburnproject.org"
                       xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
                       xmlns:docking="clr-namespace:Pixel.Automation.Editor.Core.Docking;assembly=Pixel.Automation.Editor.Core"

--- a/src/Pixel.Scripting.Script.Editor/Pixel.Scripting.Script.Editor.csproj
+++ b/src/Pixel.Scripting.Script.Editor/Pixel.Scripting.Script.Editor.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="AvalonEdit" Version="6.0.1">      
     </PackageReference>
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.0.1" />
+    <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="4.6.97" />
     <PackageReference Include="System.Reactive" Version="5.0.0">    
     </PackageReference>
   </ItemGroup>

--- a/src/Xceed.Wpf.AvalonDock.Themes.MahApps/MahAppsTheme.cs
+++ b/src/Xceed.Wpf.AvalonDock.Themes.MahApps/MahAppsTheme.cs
@@ -1,23 +1,8 @@
-﻿/*************************************************************************************
-
-   Extended WPF Toolkit
-
-   Copyright (C) 2007-2013 Xceed Software Inc.
-
-   This program is provided to you under the terms of the Microsoft Public
-   License (Ms-PL) as published at http://wpftoolkit.codeplex.com/license 
-
-   For more features, controls, and fast professional support,
-   pick up the Plus Edition at http://xceed.com/wpf_toolkit
-
-   Stay informed: follow @datagrid on Twitter or Like http://facebook.com/datagrids
-
-  ***********************************************************************************/
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using AvalonDock.Themes;
 
 namespace Xceed.Wpf.AvalonDock.Themes
 {

--- a/src/Xceed.Wpf.AvalonDock.Themes.MahApps/Theme.xaml
+++ b/src/Xceed.Wpf.AvalonDock.Themes.MahApps/Theme.xaml
@@ -17,12 +17,12 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:localThemes="clr-namespace:Xceed.Wpf.AvalonDock.Themes"                 
-                    xmlns:shell="clr-namespace:Microsoft.Windows.Shell;assembly=Xceed.Wpf.AvalonDock"
-                    xmlns:avalonDock="clr-namespace:Xceed.Wpf.AvalonDock;assembly=Xceed.Wpf.AvalonDock"
-                    xmlns:avalonDockLayout="clr-namespace:Xceed.Wpf.AvalonDock.Layout;assembly=Xceed.Wpf.AvalonDock"
-                    xmlns:avalonDockControls="clr-namespace:Xceed.Wpf.AvalonDock.Controls;assembly=Xceed.Wpf.AvalonDock"
-                    xmlns:avalonDockConverters="clr-namespace:Xceed.Wpf.AvalonDock.Converters;assembly=Xceed.Wpf.AvalonDock"
-                    xmlns:avalonDockProperties="clr-namespace:Xceed.Wpf.AvalonDock.Properties;assembly=Xceed.Wpf.AvalonDock">
+                    xmlns:shell="clr-namespace:Microsoft.Windows.Shell;assembly=AvalonDock"
+                    xmlns:avalonDock="clr-namespace:AvalonDock;assembly=AvalonDock"
+                    xmlns:avalonDockLayout="clr-namespace:AvalonDock.Layout;assembly=AvalonDock"
+                    xmlns:avalonDockControls="clr-namespace:AvalonDock.Controls;assembly=AvalonDock"
+                    xmlns:avalonDockConverters="clr-namespace:AvalonDock.Converters;assembly=AvalonDock"
+                    xmlns:avalonDockProperties="clr-namespace:AvalonDock.Properties;assembly=AvalonDock">
 
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="Brushes.xaml" />

--- a/src/Xceed.Wpf.AvalonDock.Themes.MahApps/Xceed.Wpf.AvalonDock.Themes.MahApps.csproj
+++ b/src/Xceed.Wpf.AvalonDock.Themes.MahApps/Xceed.Wpf.AvalonDock.Themes.MahApps.csproj
@@ -47,7 +47,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.0.1" />
+    <PackageReference Include="Dirkster.AvalonDock" Version="4.50.2" />
+    <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="4.6.97" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Description** : 
Removed references to xceedsoftware/wpftoolkit due to licensing

**Solution**: 
Replace with https://github.com/dotnetprojects/WpfExtendedToolkit and https://github.com/Dirkster99/AvalonDock which 