### PR TITLE
[Issue] Control details fail to reload on modifying control

### DIFF
--- a/src/Pixel.Automation.Core.Components/Entities/ControlEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Entities/ControlEntity.cs
@@ -18,9 +18,12 @@ namespace Pixel.Automation.Core.Components
     [Serializable]
     public abstract class ControlEntity : Entity, IControlEntity
     {
-        [DataMember]
+        private string controlId;
         [Browsable(false)]
-        public string ControlId { get; set; }
+        public string ControlId
+        {
+            get => this.controlId;
+        }
 
         /// <summary>
         /// Control file inside the repository 
@@ -142,6 +145,7 @@ namespace Pixel.Automation.Core.Components
             {
                 ISerializer serializer = this.EntityManager.GetServiceOfType<ISerializer>();
                 var controlDescription = serializer.Deserialize<ControlDescription>(this.ControlFile);
+                this.controlId = controlDescription.ControlId;
                 var controlDetails = controlDescription.ControlDetails;             
                 return controlDetails;
             }

--- a/src/Pixel.Automation.Core/Interfaces/IControlEntity.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IControlEntity.cs
@@ -10,7 +10,7 @@ namespace Pixel.Automation.Core.Interfaces
         /// <summary>
         /// Identifier of the control
         /// </summary>
-        string ControlId { get; set; }
+        string ControlId { get; }
 
         /// <summary>
         /// Target file where control identification details are saved

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
@@ -290,7 +290,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 
         #region property grid     
 
-        public async void SetSelectedItem(Object obj)
+        public async Task SetSelectedItem(Object obj)
         {
             if(obj is GroupEntity groupEntity)
             {
@@ -307,26 +307,39 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 
         public async Task HandleAsync(ControlUpdatedEventArgs updatedControl, CancellationToken cancellationToken)
         {
-            var controlEntities = this.EntityManager.RootEntity.GetComponentsOfType<ControlEntity>(Core.Enums.SearchScope.Descendants);
-            var controlsToBeReloaded = controlEntities.Where(c => c.ControlId.Equals(updatedControl.ControlId));
-            foreach(var control in controlsToBeReloaded)
+            try
             {
-                control.Reload();
-                logger.Information($"Control : {control.Name} with Id : {control.ControlId} has been reloaded");
-                await Task.CompletedTask;
+                var controlEntities = this.EntityManager.RootEntity.GetComponentsOfType<ControlEntity>(Core.Enums.SearchScope.Descendants);
+                var controlsToBeReloaded = controlEntities.Where(c => c.ControlId.Equals(updatedControl.ControlId));
+                foreach (var control in controlsToBeReloaded)
+                {
+                    control.Reload();
+                    logger.Information($"Control : {control.Name} with Id : {control.ControlId} has been reloaded");
+                    await Task.CompletedTask;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, ex.Message);
             }
         }
 
         public async Task HandleAsync(ApplicationUpdatedEventArgs updatedApplication, CancellationToken cancellationToken)
         {
-
-            var applicationEntities = this.EntityManager.RootEntity.GetComponentsOfType<ApplicationEntity>(Core.Enums.SearchScope.Descendants);
-            var applicationsToReload = applicationEntities.Where(a => a.ApplicationId.Equals(updatedApplication.ApplicationId));
-            foreach (var application in applicationsToReload)
+            try
             {
-                application.Reload();
-                logger.Information($"Application : {application.Name} with Id : {application.ApplicationId} has been reloaded");
-                await Task.CompletedTask;
+                var applicationEntities = this.EntityManager.RootEntity.GetComponentsOfType<ApplicationEntity>(Core.Enums.SearchScope.Descendants);
+                var applicationsToReload = applicationEntities.Where(a => a.ApplicationId.Equals(updatedApplication.ApplicationId));
+                foreach (var application in applicationsToReload)
+                {
+                    application.Reload();
+                    logger.Information($"Application : {application.Name} with Id : {application.ApplicationId} has been reloaded");
+                    await Task.CompletedTask;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, ex.Message);
             }
         }
 


### PR DESCRIPTION
**Description**
On modifying a control from control explorer, AutomationEditor should reload control details. However, control details are not refreshed.

**Analsysis**
A previous change in ComponentDropHandler removed code which used to assign ControlEntity.ControlId. Due to this,  on control modified notification , when editor tries to compare controlId, it fails with a NullReferenceException.

**Fix**
When loading the control details, assign the ControlId of ControlEntity as well. 