### PR TITLE
Arguments in DataBound mode loose their bindings 

### DIFF
--- a/src/Pixel.Automation.RunTime/TestRunner.cs
+++ b/src/Pixel.Automation.RunTime/TestRunner.cs
@@ -115,7 +115,7 @@ namespace Pixel.Automation.RunTime
                 oneTimeSetupEntity.ResetHierarchy();
                 await ProcessEntity(oneTimeSetupEntity);
               
-                Log.Information("One time setup completed for fixture : {0}", fixture);
+                logger.Information("One time setup completed for fixture : {0}", fixture);
 
             }
             catch (Exception ex)
@@ -137,8 +137,12 @@ namespace Pixel.Automation.RunTime
              
                 IScriptEngine scriptEngine = fixture.TestFixtureEntity.EntityManager.GetScriptEngine();
                 scriptEngine.ClearState();
-             
-                Log.Information("One time teardown completed for fixture : {0}", fixture);
+
+                //Execute the script file again. This is required at design time so that any arguments bound to variables in this script file
+                //still have access to them.
+                await scriptEngine.ExecuteFileAsync(fixture.ScriptFile);
+
+                logger.Information("One time teardown completed for fixture : {0}", fixture);
 
             }
             catch (Exception ex)
@@ -356,7 +360,11 @@ namespace Pixel.Automation.RunTime
                     }
 
                     requireFixture.AddComponent(testCaseEntity);
-                    await Task.CompletedTask;                
+
+                    //This is required so that any argument that was configured in previous session should have access to variables.
+                    var scriptEngine = testEntityManager.GetScriptEngine();
+                    await scriptEngine.ExecuteFileAsync(fixture.ScriptFile);
+                    await scriptEngine.ExecuteFileAsync(testCase.ScriptFile);
 
                     logger.Information("Added test case : {testCase} to Fixture.", testCase);
 

--- a/src/Pixel.Scripting.Engine.CSharp/ScriptEngine.cs
+++ b/src/Pixel.Scripting.Engine.CSharp/ScriptEngine.cs
@@ -118,6 +118,10 @@ namespace Pixel.Scripting.Engine.CSharp
             var scriptVariable = (lastExecutionResult?.CurrentState as ScriptState).GetVariable(variableName);
             if(scriptVariable != null)
             {
+                if(value == null)
+                {
+                    return;
+                }
                 if (scriptVariable.Type.IsAssignableFrom(value.GetType()))
                 {
                     scriptVariable.Value = value;


### PR DESCRIPTION
**Summary**
Declare some variables in fixture script and test script. Bind actor arguments to these variables in test case, one-time setup, etc.
Save and close fixture ( which closes any test inside it as well).
1. Open the test case again. Actors argument show empty binding at this point.  
2. Execute the test case while the bindings are intact. In some case, test case fails and Actor argument bindings are cleared out. 

**Analysis**
1. Script files are not executed when test is opened.
2. Script state is cleared out for fixture when test is completed.
3. When any fixture variable is not initialized and test is executed,  trying to copy over fixture variables to script variables causes exception leaving state corrupted.
 