### PR TITLE
Add support for Initialization script for Process data model

### DIFF
--- a/src/Pixel.Automation.Core/Constants.cs
+++ b/src/Pixel.Automation.Core/Constants.cs
@@ -1,11 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Pixel.Automation.Core
+﻿namespace Pixel.Automation.Core
 {
     public static class Constants
     {   
-        public static readonly string PrefabDataModelName = "PrefabDataModel";      
+        /// <summary>
+        /// Data model name for the auto generated Prefab data model
+        /// </summary>
+        public static readonly string PrefabDataModelName = "PrefabDataModel";
+       
+        /// <summary>
+        /// Data model name for the data model associated with the automation process.
+        /// This data model acts as a global for scripts within Environment Setup and Environment TearDown
+        /// </summary>
+        public static readonly string ProcessDataModelName = "ProcessDataModel";
+       
+        /// <summary>
+        /// Default name for the Initialization script for configuring ProcessDaaModel used at design time.
+        /// A custom initialization script can be provided as a command line argument to test runner process.
+        /// </summary>
+        public static readonly string InitializeEnvironmentScript = "InitializeEnvironment.csx";
     }
 }

--- a/src/Pixel.Automation.Designer.ViewModels/AppBootStrapper.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AppBootStrapper.cs
@@ -19,7 +19,7 @@ namespace Pixel.Automation.Designer.ViewModels
 {
     public class AppBootstrapper : BootstrapperBase
     {
-        private readonly ILogger logger = Log.ForContext<AppBootstrapper>();
+        private ILogger logger;
 
         private IKernel kernel;
    
@@ -32,7 +32,7 @@ namespace Pixel.Automation.Designer.ViewModels
              .WriteTo.ColoredConsole()
              .WriteTo.RollingFile("logs\\Pixel-Automation-{Date}.txt")
              .CreateLogger();
-
+            logger = Log.ForContext<AppBootstrapper>();
             Initialize();
         }
 

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
@@ -230,7 +230,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 
         public abstract Task Manage();
 
-        public abstract Task EditDataModel();
+        public abstract Task EditDataModelAsync();
 
         protected void UpdateWorkFlowRoot()
         {

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
@@ -56,8 +56,11 @@ namespace Pixel.Automation.Designer.ViewModels
          
         }
 
-
-        public override async Task EditDataModel()
+        /// <summary>
+        /// Edit the PrefabDataModel that was generated while creating the Prefab.
+        /// </summary>
+        /// <returns></returns>
+        public override async Task EditDataModelAsync()
         {
             var editorFactory = this.EntityManager.GetServiceOfType<ICodeEditorFactory>();
             using (var editor = editorFactory.CreateMultiCodeEditorScreen())

--- a/src/Pixel.Automation.Designer.ViewModels/Shell/ShellViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Shell/ShellViewModel.cs
@@ -171,13 +171,34 @@ namespace Pixel.Automation.Designer.ViewModels
             }
         }
 
-        public void EditDataModel()
+        public async Task EditDataModelAsync()
         {
             var activeItem = this.ActiveItem as IEditor;
             if (activeItem == null)
+            {
                 return;
-            activeItem.EditDataModel();
-        }     
+            }
+            await activeItem.EditDataModelAsync();
+        }
+
+
+        public bool CanEditScript
+        {
+            get
+            {
+                return this.ActiveItem != null && this.ActiveItem is IAutomationEditor;
+            }
+        }
+
+        public async Task EditScriptAsync()
+        {
+            var activeItem = this.ActiveItem as IAutomationEditor;
+            if (activeItem == null)
+            {
+                return;
+            }
+            await activeItem.EditScriptAsync();
+        }
 
         public bool CanManage
         {
@@ -210,6 +231,7 @@ namespace Pixel.Automation.Designer.ViewModels
             {
                 await base.ActivateItemAsync(item, cancellationToken);
                 NotifyOfPropertyChange(() => CanEditDataModel);
+                NotifyOfPropertyChange(() => CanEditScript);
                 NotifyOfPropertyChange(() => CanSave);
                 NotifyOfPropertyChange(() => CanSaveAll);
                 NotifyOfPropertyChange(() => CanManage);           

--- a/src/Pixel.Automation.Designer.Views/Shell/ShellView.xaml
+++ b/src/Pixel.Automation.Designer.Views/Shell/ShellView.xaml
@@ -89,7 +89,8 @@
             
             <MenuItem x:Name="Project" Header="Project"  Style="{StaticResource MahApps.Styles.MenuItem}">
                 <MenuItem x:Name="Manage" Header="Manage" ToolTip="Manage versions and their deployment"/>               
-                <MenuItem x:Name="EditDataModel" Header="Edit Model" ToolTip="Open DataModel for editing using inbuilt editor"/>             
+                <MenuItem x:Name="EditDataModelAsync" Header="Edit Model" ToolTip="Open DataModel for editing using inbuilt editor"/>
+                <MenuItem x:Name="EditScriptAsync" Header="Edit Script" ToolTip="Open default initialization script for editing"/>
             </MenuItem>
            
             <MenuItem x:Name="ScreenScrappers"  Header="Screen Scrappers"

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IAutomationEditor.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IAutomationEditor.cs
@@ -16,6 +16,13 @@ namespace Pixel.Automation.Editor.Core.Interfaces
         /// </summary>
         /// <param name="project"></param>
         Task DoLoad(AutomationProject project, VersionInfo versionInfo = null);
-     
+
+
+        /// <summary>
+        /// Open script editor that can be used to modify the initialization script for the automation project.
+        /// </summary>
+        /// <returns></returns>
+        Task EditScriptAsync();
+
     }
 }

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IEditor.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IEditor.cs
@@ -29,9 +29,8 @@ namespace Pixel.Automation.Editor.Core.Interfaces
         void DeleteComponent(IComponent component);
 
         /// <summary>
-        /// Open data model associated with project for editing
+        /// Open code editor that can be used to add , remove or modify existing data models for the project
         /// </summary>
-        Task EditDataModel();
-    
+        Task EditDataModelAsync();    
     }
 }

--- a/src/Pixel.Automation.Test.Runner/Pixel.Automation.Test.Runner.csproj
+++ b/src/Pixel.Automation.Test.Runner/Pixel.Automation.Test.Runner.csproj
@@ -27,7 +27,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj" />
     <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
+    <ProjectReference Include="..\Pixel.Automation.Image.Matching.Components\Pixel.Automation.Image.Matching.Components.csproj" />
     <ProjectReference Include="..\Pixel.Automation.Input.Devices\Pixel.Automation.Input.Devices.csproj" />
+    <ProjectReference Include="..\Pixel.Automation.Java.Access.Bridge.Components\Pixel.Automation.Java.Access.Bridge.Components.csproj" />
     <ProjectReference Include="..\Pixel.Automation.Native.Windows\Pixel.Automation.Native.Windows.csproj" />
     <ProjectReference Include="..\Pixel.Automation.RunTime\Pixel.Automation.RunTime.csproj" />
     <ProjectReference Include="..\Pixel.Automation.Scripting.Components\Pixel.Automation.Scripting.Components.csproj" />


### PR DESCRIPTION
**Summary**
A data model is created by default named ProcessDataModel when we create an Automation Process Project. This data model  acts as the globals for the script engine available at the root entity manager . Any components inside ApplicationPool,  EnvironmentSetup and EnvironmentTearDown, etc. can use C# properties declared on ProcessDataModel through their arguments. 
It is desirable to have ProcessDataModel values initialized differently in design time vs run time. For ex: We would like to start a different browser on machine running the test or a executable might be located at different location on maching running the test. 

**Change**
1. When creating an automation project, create a initialization script by default. This initialization script can be used to setup values on ProcessDataModel. At runtime, this default initialization script can be over-ridden by passing a new script file as an argument parameter.

2. Additionally renamed DataModel to ProcessDataModel to indicate in a better way that this is the default data model for the Automation process.
