### PR TITLE
PrefabEntity can not be deleted

### DIFF
--- a/src/Pixel.Automation.Core.Components/Prefabs/PrefabEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Prefabs/PrefabEntity.cs
@@ -13,7 +13,7 @@ namespace Pixel.Automation.Core.Components.Prefabs
     [Serializable]
     [Scriptable(nameof(InputMappingScript), nameof(OutputMappingScript))]
     [Initializer(typeof(ScriptFileInitializer))]
-    public class PrefabEntity : Entity, IDisposable
+    public class PrefabEntity : Entity
     {
         [DataMember]
         [Browsable(false)]
@@ -116,19 +116,5 @@ namespace Pixel.Automation.Core.Components.Prefabs
         }
 
         #endregion overridden methods
-
-        protected virtual void Dispose(bool isDisposing)
-        {
-            if(this.prefabLoader != null)
-            {
-                (this.prefabLoader as IDisposable).Dispose();
-            }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-        }
-
     }
 }


### PR DESCRIPTION
**Description**
Add a Prefab Entity to a test case. Try to delete it.

**Expected Behavior**
PrefabEntity should be deleted.

**Actual Behavior**
PrefabEntity is not deleted.

**Analysis and Fix**
PrefabEntity was implementing IDisposable which in-turn tries to Dispose IPrefabLoader.
However, IPrefabLoader doesn't implement IDisposable after changes were made to it to re-use Prefabs.
As a result, there is an exception when PrefabEntity tries to Dispose IPrefabLoader and hence PrefabEntity is not removed from test case. Removed IDisposable on PrefabEntity as there is nothing to Dispose and this allows PrefabEntity to be deleted now.

