### PR TITLE
Enable Code Actions and Diagnostics for Script Editor Window

### DIFF
--- a/src/Pixel.Automation.AppExplorer.Views/PrefabBuilder/PrefabBuilderView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/PrefabBuilder/PrefabBuilderView.xaml
@@ -8,7 +8,7 @@
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks" cal:Bind.AtDesignTime="True"
              xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro" 
              mc:Ignorable="d" ResizeMode="CanResizeWithGrip" GlowBrush="{DynamicResource AccentColorBrush}"
-             MinHeight="400" MaxWidth="800"
+             MinHeight="400"
              d:DesignHeight="450" d:DesignWidth="800">
     <controls:MetroWindow.Resources>
         <Thickness x:Key="ControlMargin">10 10 10 10</Thickness>

--- a/src/Pixel.Automation.AppExplorer.Views/PrefabBuilder/PrefabDataModelBuilderView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/PrefabBuilder/PrefabDataModelBuilderView.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Pixel.Automation.AppExplorer.Views.PrefabBuilder"
              xmlns:cal="http://www.caliburnproject.org"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks" cal:Bind.AtDesignTime="True"
-             MinHeight="400" Height="400" Width="Auto" MaxWidth="800"
+             MinHeight="400" Height="Auto" Width="Auto"
              mc:Ignorable="d" VerticalAlignment="Top" x:Name="PrefabDataModelBuilder"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>

--- a/src/Pixel.Automation.AppExplorer.Views/PrefabBuilder/PrefabScriptsImporterView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/PrefabBuilder/PrefabScriptsImporterView.xaml
@@ -7,7 +7,7 @@
              xmlns:cal="http://www.caliburnproject.org"
              xmlns:metro="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks" cal:Bind.AtDesignTime="True"
-             MinHeight="400" Height="400" Width="Auto" MaxWidth="800"
+             MinHeight="400" Height="Auto" Width="Auto"
              mc:Ignorable="d" VerticalAlignment="Top"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>

--- a/src/Pixel.Automation.Designer.Views/Resources/Scripting.Components.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Scripting.Components.xaml
@@ -61,9 +61,9 @@
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.AccentBase}"/>
             </DataTrigger>
         </DataTemplate.Triggers>
-    </DataTemplate>   
+    </DataTemplate>
 
-    <DataTemplate x:Key="AssignScriptTemplate">
+    <DataTemplate x:Key="ExecuteInlineScriptTemplate">
         <Border x:Name="brdContainer"  BorderThickness="2" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"
                 HorizontalAlignment="Stretch" Margin="0,4,0,4" dd:DragDrop.IsDragSource="True"
                 Background="{DynamicResource MahApps.Brushes.Control.Background}">
@@ -96,7 +96,7 @@
                 <Border BorderThickness="2" Height="1" Grid.Row="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"
                     HorizontalAlignment="Stretch" Background="{DynamicResource MahApps.Brushes.Control.Background}"/>
                 <se:InlineScriptEditorUserControl Grid.Row="2" VerticalContentAlignment="Center"  Margin="2"     
-                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
+                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" dd:DragDrop.DragSourceIgnore="true"
                     OwnerComponent="{Binding}" ScriptFile="{Binding ScriptFile}"/>
             </Grid>
         </Border>

--- a/src/Pixel.Automation.Designer.Views/Resources/TemplateMapping.xml
+++ b/src/Pixel.Automation.Designer.Views/Resources/TemplateMapping.xml
@@ -111,12 +111,12 @@
   </ComponentTemplate>
   <!--Scripted Components-->
   <ComponentTemplate>
-    <Name>ScriptedAssignActorComponent</Name>
-    <DataTemplateKey>AssignScriptTemplate</DataTemplateKey>
+    <Name>ExecuteInlineScriptActorComponent</Name>
+    <DataTemplateKey>ExecuteInlineScriptTemplate</DataTemplateKey>
     <StyleKey>SlimStyle</StyleKey>
   </ComponentTemplate>   
   <ComponentTemplate>
-    <Name>ScriptedActionActorComponent</Name>
+    <Name>ExecuteScriptActorComponent</Name>
     <DataTemplateKey>ExecuteScriptTemplate</DataTemplateKey>
     <StyleKey>SlimStyle</StyleKey>
   </ComponentTemplate> 

--- a/src/Pixel.Automation.Scripting.Components/ActorComponents/ExecuteInlineScriptActorComponent.cs
+++ b/src/Pixel.Automation.Scripting.Components/ActorComponents/ExecuteInlineScriptActorComponent.cs
@@ -6,12 +6,15 @@ using System.Threading.Tasks;
 
 namespace Pixel.Automation.Scripting.Components
 {
+    /// <summary>
+    /// Use <see cref="ExecuteInlineScriptActorComponent"/> to execute a short inline script e.g. to assing some data to a variable or making an assertion , etc.
+    /// </summary>
     [DataContract]
     [Serializable]
     [ToolBoxItem("Execute [Inline]", "Scripting", iconSource: null, description: "Assign value to a variable", tags: new string[] { "Assign", "Scripting" })]   
-    public class ScriptedAssignActorComponent : ScriptedComponentBase
+    public class ExecuteInlineScriptActorComponent : ScriptedComponentBase
     {       
-        public ScriptedAssignActorComponent() : base("Assign", "ScriptedAssign")
+        public ExecuteInlineScriptActorComponent() : base("Script", "ExecuteInlineScript")
         {           
         }
 

--- a/src/Pixel.Automation.Scripting.Components/ActorComponents/ExecuteScriptActorComponent.cs
+++ b/src/Pixel.Automation.Scripting.Components/ActorComponents/ExecuteScriptActorComponent.cs
@@ -7,13 +7,16 @@ using System.Threading.Tasks;
 
 namespace Pixel.Automation.Scripting.Components
 {
+    /// <summary>
+    /// Use <see cref="ExecuteScriptActorComponent"/> to execute actions using custom script.
+    /// </summary>
     [DataContract]
     [Serializable]
     [ToolBoxItem("Execute [Editor]", "Scripting", iconSource: null, description: "Execute any provided script", tags: new string[] { "Scripted Action", "Scripting" })]   
-    public class ScriptedActionActorComponent : ScriptedComponentBase
+    public class ExecuteScriptActorComponent : ScriptedComponentBase
     {
 
-        public ScriptedActionActorComponent() : base("Scripted Action", "ScriptedAction")
+        public ExecuteScriptActorComponent() : base("Script", "ExecuteScript")
         {
 
         }

--- a/src/Pixel.Scripting.Script.Editor/CodeTextEditor.cs
+++ b/src/Pixel.Scripting.Script.Editor/CodeTextEditor.cs
@@ -35,6 +35,9 @@ namespace Pixel.Scripting.Script.Editor
             private set;
         }
 
+        public bool EnableDiagnostics { get; set; } = true;
+
+        public bool EnableCodeActions { get; set; } = true;
 
         private IEditorService editorService;      
         private CodeActionsControl codeActionsControl;
@@ -82,12 +85,12 @@ namespace Pixel.Scripting.Script.Editor
             TextArea.TextView.BackgroundRenderers.Add(textMarkerService);
             TextArea.TextView.LineTransformers.Add(textMarkerService);
 
-            if(this.editorService.IsFeatureEnabled(EditorFeature.Diagnostics))
+            if(this.EnableDiagnostics && this.editorService.IsFeatureEnabled(EditorFeature.Diagnostics))
             {
                 this.diagnosticsManager = new DiagnosticsManager(this.editorService, this, this.Document, this.textMarkerService);
             }
 
-            if (this.editorService.IsFeatureEnabled(EditorFeature.CodeActions))
+            if (this.EnableCodeActions && this.editorService.IsFeatureEnabled(EditorFeature.CodeActions))
             {
                 this.codeActionsControl = new CodeActionsControl(this, this.editorService);
             }

--- a/src/Pixel.Scripting.Script.Editor/Editor/REPL/REPLEditorScreenViewModel.cs
+++ b/src/Pixel.Scripting.Script.Editor/Editor/REPL/REPLEditorScreenViewModel.cs
@@ -39,6 +39,8 @@ namespace Pixel.Scripting.Script.Editor.REPL
             this.DisplayName = "Script Editor";
             this.Editor = new CodeTextEditor(this.editorService)
             {
+                EnableCodeActions = false,
+                EnableDiagnostics = false,
                 ShowLineNumbers = true,
                 Margin = new Thickness(5),
                 FontSize = 23,

--- a/src/Pixel.Scripting.Script.Editor/Editor/Script/InlineScriptEditorViewModel.cs
+++ b/src/Pixel.Scripting.Script.Editor/Editor/Script/InlineScriptEditorViewModel.cs
@@ -22,6 +22,8 @@ namespace Pixel.Scripting.Script.Editor.Script
             this.editorService = editorService;
             this.Editor = new CodeTextEditor(editorService)
             {
+                EnableDiagnostics = false,
+                EnableCodeActions = false,
                 ShowLineNumbers = false,
                 Margin = new Thickness(2),
                 FontSize = 14,

--- a/src/Pixel.Scripting.Script.Editor/EditorFactory/ScriptEditorFactory.cs
+++ b/src/Pixel.Scripting.Script.Editor/EditorFactory/ScriptEditorFactory.cs
@@ -32,7 +32,7 @@ namespace Pixel.Scripting.Script.Editor
             this.editorService.Initialize(new WorkspaceOptions()
             { 
                 WorkingDirectory = workingDirectory,
-                EnableCodeActions = false,
+                EnableCodeActions = true,
                 AssemblyReferences = editorReferences,
                 WorkspaceType = WorkspaceType.Script
             });

--- a/src/Unit.Tests/Pixel.Automation.Scripting.Components.Tests/ActorComponents/ExecuteInlineScriptActorComponentFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Scripting.Components.Tests/ActorComponents/ExecuteInlineScriptActorComponentFixture.cs
@@ -2,12 +2,12 @@
 using NUnit.Framework;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Interfaces;
-using System;
+using Pixel.Automation.Core.Models;
 using System.Threading.Tasks;
 
 namespace Pixel.Automation.Scripting.Components.Tests.ActorComponents
 {
-    public class ScriptedActionActorComponentTests
+    public class ExecuteInlineScriptActorComponentFixture
     {
         [Test]
         public async Task CanAct()
@@ -15,20 +15,17 @@ namespace Pixel.Automation.Scripting.Components.Tests.ActorComponents
             var entityManager = Substitute.For<IEntityManager>();
 
             IScriptEngine scriptEngine = Substitute.For<IScriptEngine>();
-            scriptEngine.CreateDelegateAsync<Action<IApplication, IComponent>>(Arg.Any<string>()).Returns((a, b) =>
-            {
-               
-            });
+            scriptEngine.ExecuteFileAsync(Arg.Any<string>()).Returns(new ScriptResult());
             entityManager.GetScriptEngine().Returns(scriptEngine);
-            var scriptedActionActor = new ScriptedActionActorComponent()
+            var scriptedAssignActor = new ExecuteInlineScriptActorComponent()
             {
                 EntityManager = entityManager,
                 ScriptFile = "script.csx"
             };
 
-            await scriptedActionActor.ActAsync();
-        
-            await scriptEngine.Received(1).CreateDelegateAsync<Action<IApplication, IComponent>>("script.csx");
+            await scriptedAssignActor.ActAsync();
+
+            await scriptEngine.Received(1).ExecuteFileAsync("script.csx");
         }
     }
 }

--- a/src/Unit.Tests/Pixel.Automation.Scripting.Components.Tests/ActorComponents/ExecuteScriptActorComponentFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Scripting.Components.Tests/ActorComponents/ExecuteScriptActorComponentFixture.cs
@@ -2,12 +2,12 @@
 using NUnit.Framework;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Interfaces;
-using Pixel.Automation.Core.Models;
+using System;
 using System.Threading.Tasks;
 
 namespace Pixel.Automation.Scripting.Components.Tests.ActorComponents
 {
-    public class ScriptedAssignActorComponentTests
+    public class ExecuteScriptActorComponentFixture
     {
         [Test]
         public async Task CanAct()
@@ -15,17 +15,20 @@ namespace Pixel.Automation.Scripting.Components.Tests.ActorComponents
             var entityManager = Substitute.For<IEntityManager>();
 
             IScriptEngine scriptEngine = Substitute.For<IScriptEngine>();
-            scriptEngine.ExecuteFileAsync(Arg.Any<string>()).Returns(new ScriptResult());
+            scriptEngine.CreateDelegateAsync<Action<IApplication, IComponent>>(Arg.Any<string>()).Returns((a, b) =>
+            {
+               
+            });
             entityManager.GetScriptEngine().Returns(scriptEngine);
-            var scriptedAssignActor = new ScriptedAssignActorComponent()
+            var scriptedActionActor = new ExecuteScriptActorComponent()
             {
                 EntityManager = entityManager,
                 ScriptFile = "script.csx"
             };
 
-            await scriptedAssignActor.ActAsync();
-
-            await scriptEngine.Received(1).ExecuteFileAsync("script.csx");
+            await scriptedActionActor.ActAsync();
+        
+            await scriptEngine.Received(1).CreateDelegateAsync<Action<IApplication, IComponent>>("script.csx");
         }
     }
 }


### PR DESCRIPTION
**Description**
In Code editor, it is possible to get diagnostics suggestion like add a required namespace. However, this is not enabled for Script Editor. Enable it for Script Editor window except for Inline Script Editor for now.

Additionally, renamed script actor components to ExecuteScriptActorComponent and ExecuteInlineScriptActorComponent.