### PR TITLE
Argument Editor UI Improvements

### DIFF
--- a/src/Pixel.Automation.Designer.Views/Resources/Argument.Editors.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Argument.Editors.xaml
@@ -7,23 +7,44 @@
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro">
   
     <Style TargetType="Button" x:Key="ChangeArgumentTypeButtonStyle" BasedOn="{StaticResource MahApps.Styles.Button.Square}">
+        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"></Setter>
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent2}"/>
         <Setter Property="BorderBrush" Value="#FFCCCCCC"/>
         <Setter Property="BorderThickness" Value="0,1,1,1"/>
         <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Normal" />
+        <Setter Property="Width" Value="20"/>     
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border IsHitTestVisible="True" Background="{DynamicResource  MahApps.Brushes.Control.Background}" BorderThickness="{TemplateBinding BorderThickness}"
+                            BorderBrush="{DynamicResource MahApps.Brushes.Control.Border}">
+                        <iconPacks:PackIconFontAwesome x:Name="EllipsisVSolid" Width="{TemplateBinding Width}"
+                                        Height="{TemplateBinding Height}" IsHitTestVisible="False"
+                                        Margin="2" Padding="4" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        Foreground="{TemplateBinding Foreground}"
+                                        Kind="EllipsisVSolid" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{DynamicResource MahApps.Colors.Gray8}" />
-                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}"/>              
             </Trigger>
         </Style.Triggers>
     </Style>
 
     <Style x:Key="InArgumentToggleStateStyle" TargetType="ToggleButton" BasedOn="{StaticResource MahApps.Styles.Button.Square}">
+        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"></Setter>
         <Setter Property="BorderBrush" Value="#FFCCCCCC"/>
         <Setter Property="BorderThickness" Value="0,1,1,1" />
         <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Normal" />
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent2}" />
         <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}"/>
+                <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"/>
+            </Trigger>
             <Trigger Property="IsChecked" Value="False">
                 <Setter Property="Content">
                     <Setter.Value>
@@ -44,23 +65,21 @@
                         S
                     </Setter.Value>
                 </Setter>
-            </Trigger>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{DynamicResource MahApps.Colors.Gray8}" />
-                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-                <Setter Property="BorderThickness" Value="1"/>
-            </Trigger>
-            <!--<DataTrigger Binding="{Binding OwnerComponent.EntityManager, ElementName=InArgumentControl}" Value="{x:Null}">
-                <Setter Property="Visibility" Value="Collapsed"/>
-            </DataTrigger>-->
+            </Trigger>           
         </Style.Triggers>
     </Style>
 
     <Style x:Key="OutArgumentToggleStateStyle" TargetType="ToggleButton" BasedOn="{StaticResource MahApps.Styles.Button.Square}">
+        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"></Setter>
         <Setter Property="BorderBrush" Value="#FFCCCCCC"/>
         <Setter Property="BorderThickness" Value="0,1,1,1" />
         <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Normal" />
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent2}" />
         <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}"/>
+                <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"/>
+            </Trigger>
             <Trigger Property="IsChecked" Value="False">
                 <Setter Property="Content">
                     <Setter.Value>
@@ -74,26 +93,18 @@
                         S
                     </Setter.Value>
                 </Setter>
-            </Trigger>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{DynamicResource MahApps.Colors.Gray8}" />
-                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-                <Setter Property="BorderThickness" Value="1"/>
-            </Trigger>
-            <!--<DataTrigger Binding="{Binding OwnerComponent.EntityManager, ElementName=OutArgumentControl}" Value="{x:Null}">
-                <Setter Property="Visibility" Value="Collapsed"/>
-            </DataTrigger>-->
+            </Trigger>            
         </Style.Triggers>
     </Style>
 
-    <!-- InArgument Data Templates-->
-    <DataTemplate x:Key="InArgument_Default">
+    <!-- Argument Data Templates-->
+    <DataTemplate x:Key="Argument_Default">
         <TextBox x:Name="DefaultValueTextBox"  DataContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=ContentControl}}"
                  Text="{Binding Path=DefaultValue,UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" Metro:TextBoxHelper.UseFloatingWatermark="True"
                  Metro:TextBoxHelper.Watermark="{Binding ArgumentType}" Metro:TextBoxHelper.ClearTextButton="True" />
     </DataTemplate>
 
-    <DataTemplate x:Key="InArgument_ScreenCoordinate">
+    <DataTemplate x:Key="Argument_ScreenCoordinate">
         <StackPanel Orientation="Vertical">
             <TextBox x:Name="XCoordinate"  DataContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=ContentControl}}"
                  Text="{Binding Path=DefaultValue.XCoordinate,UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" Metro:TextBoxHelper.UseFloatingWatermark="True"
@@ -104,7 +115,7 @@
         </StackPanel>        
     </DataTemplate>
 
-    <DataTemplate x:Key="InArgument_Point">
+    <DataTemplate x:Key="Argument_Point">
         <StackPanel Orientation="Vertical">
             <TextBox x:Name="XCoordinate"  DataContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=ContentControl}}"
                  Text="{Binding Path=DefaultValue.X,UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" Metro:TextBoxHelper.UseFloatingWatermark="True"
@@ -114,5 +125,13 @@
                  Metro:TextBoxHelper.Watermark="y-coordinate" Metro:TextBoxHelper.ClearTextButton="True" />
         </StackPanel>
     </DataTemplate>
-    
+
+    <DataTemplate x:Key="Argument_Error">
+        <TextBox x:Name="ErrorTemplate" IsEnabled="False" BorderBrush="{DynamicResource MahApps.Brushes.Validation5}" 
+                 DataContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=ContentControl}}"
+                 Metro:TextBoxHelper.Watermark="{Binding ArgumentType}"
+                 ToolTip="Use data bound or script mode for complex types" 
+                 ToolTipService.ShowOnDisabled="true" />
+    </DataTemplate>
+
 </ResourceDictionary>

--- a/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
@@ -166,6 +166,57 @@
         </Setter>
     </Style>
 
+    <Style x:Key="EditScriptButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"></Setter>
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent2}"/>
+        <Setter Property="Width" Value="26"/>
+        <Setter Property="Height" Value="Auto"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border IsHitTestVisible="True" Background="{DynamicResource  MahApps.Brushes.Control.Background}" BorderThickness="{TemplateBinding BorderThickness}"
+                            BorderBrush="{TemplateBinding BorderBrush}">
+                        <iconPacks:PackIconModern x:Name="PageEdit" Width="{TemplateBinding Width}"
+                                        Height="{TemplateBinding Height}" IsHitTestVisible="False"
+                                        Margin="2" Padding="4" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        Foreground="{TemplateBinding Foreground}"
+                                        Kind="PageEdit" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">                
+                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}"/>
+            </Trigger>
+        </Style.Triggers>       
+    </Style>
+
+    <Style x:Key="VerticalDotsButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"></Setter>             
+        <Setter Property="Width" Value="20"/>
+        <Setter Property="Height" Value="Auto"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border IsHitTestVisible="True" Background="{DynamicResource  MahApps.Brushes.Control.Background}" BorderThickness="{TemplateBinding BorderThickness}"
+                        BorderBrush="{TemplateBinding BorderBrush}">                     
+                        <iconPacks:PackIconFontAwesome x:Name="EllipsisVSolid" Width="{TemplateBinding Width}"
+                                        Height="{TemplateBinding Height}" IsHitTestVisible="False"
+                                        Margin="2" Padding="4" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        Foreground="{DynamicResource MahApps.Brushes.Accent2}"
+                                        Kind="EllipsisVSolid" />
+                    </Border>               
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="TextBlockStyle" TargetType="TextBlock">
         <Setter Property="FontWeight" Value="Bold"></Setter>
         <Setter Property="FontStyle" Value="Normal"></Setter>

--- a/src/Pixel.Automation.Editor.Controls/Arguments/ArgumentTemplateSelector.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/ArgumentTemplateSelector.cs
@@ -3,19 +3,19 @@ using System.Windows.Controls;
 
 namespace Pixel.Automation.Editor.Controls.Arguments
 {
-    public class InArgumentTemplateSelector : DataTemplateSelector
+    public class ArgumentTemplateSelector : DataTemplateSelector
     {
         public override DataTemplate  SelectTemplate(object item, DependencyObject container)
         {
             FrameworkElement element = container as FrameworkElement;
-            if (item!=null && element != null)
+            if (item != null && element != null)
             {               
                 string typeName = item.GetType().Name;
-                DataTemplate dataTemplate = element.TryFindResource($"InArgument_{typeName}") as DataTemplate;
-                return dataTemplate ?? element.FindResource("InArgument_Default") as DataTemplate;
+                DataTemplate dataTemplate = element.TryFindResource($"Argument_{typeName}") as DataTemplate;
+                return dataTemplate ?? element.FindResource("Argument_Default") as DataTemplate;
              
             }
-            return base.SelectTemplate(item,container);
+            return element.FindResource("Argument_Error") as DataTemplate;
         }
 
     }

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/InArgumentEditor.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/InArgumentEditor.xaml
@@ -10,7 +10,7 @@
              d:DesignHeight="300" d:DesignWidth="300">
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
-        <local:InArgumentTemplateSelector x:Key="InArgumentTemplateSelector"/>
+        <local:ArgumentTemplateSelector x:Key="ArgumentTemplateSelector"/>
         <converters:ArgumentModeToVisibilityConverter x:Key="ArgsModeToVisConverter"/>
         <converters:ArgumentModeToBooleanConverter x:Key="ArgsModeToBoolConverter"/>
     </UserControl.Resources>
@@ -18,11 +18,11 @@
 
         <DockPanel x:Name="ArgumentEditorPanel" LastChildFill="True">
 
-            <Button x:Name="ChangeArgumentTypeButton" Visibility="{Binding Argument.CanChangeType,ElementName=InArgumentControl,Converter={StaticResource BoolToVis}}"
-                    Click="ChangeArgumentType" Style="{DynamicResource ChangeArgumentTypeButtonStyle}" 
-                    Content="..." ToolTip="Change Type" DockPanel.Dock="Right"/>
+            <Button x:Name="ChangeArgumentTypeButton" Visibility="{Binding Argument.CanChangeType,ElementName=InArgumentControl,Converter={StaticResource BoolToVis}}"                    
+                    Click="ChangeArgumentType" Style="{DynamicResource ChangeArgumentTypeButtonStyle}" Height="26" 
+                    ToolTip="Change Type" DockPanel.Dock="Right"/>
 
-            <ToggleButton x:Name="ArgumentModeToggle" IsThreeState="True" Style="{DynamicResource InArgumentToggleStateStyle}" Width="28"
+            <ToggleButton x:Name="ArgumentModeToggle" IsThreeState="True" Style="{DynamicResource InArgumentToggleStateStyle}" Width="28"                         
                       Click="ChangeArgumentMode" Visibility="{Binding Argument.CanChangeMode,ElementName=InArgumentControl,Converter={StaticResource BoolToVis}}"
                       IsChecked="{Binding Argument.Mode,Mode=OneWay, ElementName=InArgumentControl,Converter={StaticResource ArgsModeToBoolConverter}}"
                       DockPanel.Dock="Right" ToolTip="Toggle between Default/DataBound/Scripted mode"></ToggleButton>
@@ -31,29 +31,27 @@
 
                 <ContentControl x:Name="DefaultValueEditor" Content="{Binding Argument.DefaultValue,ElementName=InArgumentControl,Mode=TwoWay}"
                                 DataContext="{Binding Argument,ElementName=InArgumentControl,Mode=TwoWay}"
-                                ContentTemplateSelector="{StaticResource InArgumentTemplateSelector}"
+                                ContentTemplateSelector="{StaticResource ArgumentTemplateSelector}"
                                 Visibility="{Binding Argument.Mode,ElementName=InArgumentControl,Converter={StaticResource ArgsModeToVisConverter},
                                 ConverterParameter=VisibleOnDefault}"></ContentControl>
 
                 <ComboBox x:Name="ArgumentsComboBox" ItemsSource="{Binding AvailableProperties,ElementName=InArgumentControl}" 
-                          IsEditable="True"
-                          Metro:TextBoxHelper.UseFloatingWatermark="True"
+                          IsEditable="True" Metro:TextBoxHelper.UseFloatingWatermark="True"
                           Metro:TextBoxHelper.Watermark="{Binding Argument.ArgumentType,ElementName=InArgumentControl}"
                           SelectedValue="{Binding Argument.PropertyPath,ElementName=InArgumentControl}"
-                  Style="{DynamicResource MahApps.Styles.ComboBox.Virtualized}"
-                  Visibility="{Binding Argument.Mode,ElementName=InArgumentControl, Converter={StaticResource ArgsModeToVisConverter},ConverterParameter=VisibleOnDataBound}" />
+                          Style="{DynamicResource MahApps.Styles.ComboBox.Virtualized}"
+                          Visibility="{Binding Argument.Mode,ElementName=InArgumentControl, Converter={StaticResource ArgsModeToVisConverter},ConverterParameter=VisibleOnDataBound}" />
 
-                <Button x:Name="ScriptEditorButton" Content="C# Script Editor..."  Click="ShowScriptEditor" Style="{DynamicResource MahApps.Styles.Button.Square}"
-                        ToolTip="Open Script editor" Padding="5"  BorderThickness="1"  BorderBrush="#FFCCCCCC"
-                        Visibility="{Binding Argument.Mode,ElementName=InArgumentControl,Converter={StaticResource ArgsModeToVisConverter},
-                        ConverterParameter=VisibleOnScripted}"></Button>
+                <DockPanel Visibility="{Binding Argument.Mode,ElementName=InArgumentControl,Converter={StaticResource ArgsModeToVisConverter}, 
+                    ConverterParameter=VisibleOnScripted}" LastChildFill="True">
+                    <Button x:Name="ScriptEditorButton" Content="E"  Click="ShowScriptEditor" Style="{DynamicResource EditScriptButtonStyle}" Height="26"
+                            ToolTip="Open Script editor" Padding="5"  BorderThickness="0,1,1,1"  BorderBrush="#FFCCCCCC" DockPanel.Dock="Right"></Button>
+                    <TextBox x:Name="ScriptPath" Text="{Binding Argument.ScriptFile, ElementName=InArgumentControl}" BorderBrush="#FFCCCCCC" DockPanel.Dock="Left"/>
+                </DockPanel>
 
             </Grid>
 
-
-
         </DockPanel>
-
 
     </Grid>
 </local:ArgumentEditorBase>

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/InArgumentEditor.xaml.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/InArgumentEditor.xaml.cs
@@ -9,7 +9,7 @@ namespace Pixel.Automation.Editor.Controls.Arguments
     /// <summary>
     /// Interaction logic for InArgumentEditor.xaml
     /// </summary>
-    public partial class InArgumentEditor : ArgumentEditorBase , ITypeEditor
+    public partial class InArgumentEditor : ArgumentEditorBase, ITypeEditor
     {
         public InArgumentEditor() : base()
         {
@@ -21,14 +21,16 @@ namespace Pixel.Automation.Editor.Controls.Arguments
         {
             this.propertyItem = propertyItem;
             this.OwnerComponent = propertyItem.Instance as Component;
-            this.Argument = propertyItem.Instance.GetType().GetProperty(propertyItem.PropertyName).GetValue(propertyItem.Instance) as Argument;         
+            this.Argument = propertyItem.Instance.GetType().GetProperty(propertyItem.PropertyName).GetValue(propertyItem.Instance) as Argument;
             return this;
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             if (this.OwnerComponent?.EntityManager == null)
+            {
                 return;
+            }
             LoadAvailableProperties();
         }
 
@@ -36,7 +38,10 @@ namespace Pixel.Automation.Editor.Controls.Arguments
         public void ChangeArgumentMode(object sender, RoutedEventArgs e)
         {
             if (this.OwnerComponent?.EntityManager == null)
+            {
                 return;
+            }
+            //Set argument mode to next mode based on current mode i.e. rotate from Default -> DataBound -> Scripted -> Default....
             switch (this.Argument.Mode)
             {
                 case ArgumentMode.Default:
@@ -45,13 +50,12 @@ namespace Pixel.Automation.Editor.Controls.Arguments
                     break;
                 case ArgumentMode.DataBound:
                     this.Argument.Mode = ArgumentMode.Scripted;
+                    InitializeScriptName();
                     break;
                 case ArgumentMode.Scripted:
-                    DeleteScriptFile();
                     this.Argument.Mode = ArgumentMode.Default;
                     break;
             }
-
         }
 
     }

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/OutArgumentEditor.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/OutArgumentEditor.xaml
@@ -10,19 +10,17 @@
              d:DesignHeight="300" d:DesignWidth="300">
 
     <UserControl.Resources>
-        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
-        <local:InArgumentTemplateSelector x:Key="InArgumentTemplateSelector"/>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>       
         <converters:ArgumentModeToVisibilityConverter x:Key="ArgsModeToVisConverter"/>
         <converters:ArgumentModeToBooleanConverter x:Key="ArgsModeToBoolConverter"/>
     </UserControl.Resources>
     <Grid>
         <Grid>
-
             <DockPanel x:Name="ArgumentEditorPanel" LastChildFill="True">
 
-                <Button x:Name="ChangeArgumentTypeButton" Visibility="{Binding Argument.CanChangeType,ElementName=OutArgumentControl,Converter={StaticResource BoolToVis}}"
-                    Click="ChangeArgumentType"  Style="{DynamicResource ChangeArgumentTypeButtonStyle}"
-                    Content="..." ToolTip="Change Type" DockPanel.Dock="Right"/>
+                <Button x:Name="ChangeArgumentTypeButton" Visibility="{Binding Argument.CanChangeType,ElementName=OutArgumentControl,Converter={StaticResource BoolToVis}}"                                        
+                    Click="ChangeArgumentType"  Style="{DynamicResource ChangeArgumentTypeButtonStyle}" Height="26"
+                    ToolTip="Change Type" DockPanel.Dock="Right"/>
 
                 <ToggleButton x:Name="ArgumentModeToggle" Style="{DynamicResource OutArgumentToggleStateStyle}" Width="28"
                       Click="ChangeArgumentMode" Visibility="{Binding Argument.CanChangeMode,ElementName=OutArgumentControl,Converter={StaticResource BoolToVis}}"
@@ -33,21 +31,22 @@
                 <Grid  MinWidth="100" HorizontalAlignment="Stretch" DockPanel.Dock="Right">
 
                     <ComboBox x:Name="ArgumentsComboBox" ItemsSource="{Binding AvailableProperties,ElementName=OutArgumentControl}" 
-                          IsEditable="True"
-                          Metro:TextBoxHelper.UseFloatingWatermark="True"
+                          IsEditable="True" Metro:TextBoxHelper.UseFloatingWatermark="True"
                           Metro:TextBoxHelper.Watermark="{Binding Argument.ArgumentType,ElementName=OutArgumentControl}"
                           SelectedValue="{Binding Argument.PropertyPath,Mode=TwoWay,ElementName=OutArgumentControl}"
-                  Style="{DynamicResource MahApps.Styles.ComboBox.Virtualized}"
-                  Visibility="{Binding Argument.Mode,ElementName=OutArgumentControl, Converter={StaticResource ArgsModeToVisConverter},ConverterParameter=VisibleOnDataBound}" />
+                          Style="{DynamicResource MahApps.Styles.ComboBox.Virtualized}"
+                          Visibility="{Binding Argument.Mode,ElementName=OutArgumentControl, Converter={StaticResource ArgsModeToVisConverter},ConverterParameter=VisibleOnDataBound}" />
 
-                    <Button x:Name="ScriptEditorButton" Content="C# Script Editor..."  Click="ShowScriptEditor" BorderThickness="1,1,1,1"  BorderBrush="#FFCCCCCC"
-                        ToolTip="Open Script editor" Padding="5"  Style="{DynamicResource MahApps.Styles.Button.Square}"
-                        Visibility="{Binding Argument.Mode,ElementName=OutArgumentControl,Converter={StaticResource ArgsModeToVisConverter},
-                        ConverterParameter=VisibleOnScripted}"></Button>
+                    <DockPanel Visibility="{Binding Argument.Mode,ElementName=OutArgumentControl,Converter={StaticResource ArgsModeToVisConverter}, 
+                        ConverterParameter=VisibleOnScripted}" LastChildFill="True">
+                        <Button x:Name="ScriptEditorButton" Click="ShowScriptEditor" Style="{DynamicResource EditScriptButtonStyle}" Height="26"                                                            
+                                ToolTip="Open Script editor" Padding="5"  BorderThickness="0,1,1,1"  BorderBrush="#FFCCCCCC" DockPanel.Dock="Right"></Button>
+                        <TextBox x:Name="ScriptPath" Text="{Binding Argument.ScriptFile, ElementName=OutArgumentControl}"
+                                 BorderBrush="#FFCCCCCC" DockPanel.Dock="Left"/>
+                    </DockPanel>
 
                 </Grid>
-
-            </DockPanel>
-        </Grid>
+            </DockPanel>            
+        </Grid>        
     </Grid>
 </local:ArgumentEditorBase>

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/OutArgumentEditor.xaml.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/OutArgumentEditor.xaml.cs
@@ -21,7 +21,9 @@ namespace Pixel.Automation.Editor.Controls.Arguments
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             if (this.OwnerComponent?.EntityManager == null)
+            {
                 return;
+            }
             LoadAvailableProperties();
         }
 
@@ -35,18 +37,19 @@ namespace Pixel.Automation.Editor.Controls.Arguments
         public void ChangeArgumentMode(object sender, RoutedEventArgs e)
         {
             if (this.OwnerComponent?.EntityManager == null)
+            {
                 return;
+            }
             if (this.Argument.Mode == ArgumentMode.DataBound)
             {
                 this.Argument.Mode = ArgumentMode.Scripted;
+                InitializeScriptName();
             }
             else if (this.Argument.Mode == ArgumentMode.Scripted)
-            {
-                DeleteScriptFile();
-                LoadAvailableProperties();
+            {                
                 this.Argument.Mode = ArgumentMode.DataBound;
+                LoadAvailableProperties();
             }
-
         }
     }
 }

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/InArgumentUserControl.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/InArgumentUserControl.xaml
@@ -11,7 +11,7 @@
     <Grid>
         <Grid.Resources>
             <BooleanToVisibilityConverter x:Key="BoolToVis"/>
-            <local:InArgumentTemplateSelector x:Key="InArgumentTemplateSelector"/>
+            <local:ArgumentTemplateSelector x:Key="ArgumentTemplateSelector"/>
             <converters:ArgumentModeToVisibilityConverter x:Key="ArgsModeToVisConverter"/>
             <converters:ArgumentModeToBooleanConverter x:Key="ArgsModeToBoolConverter"/>
         </Grid.Resources>
@@ -20,7 +20,7 @@
 
             <Button x:Name="ChangeArgumentTypeButton" Visibility="{Binding Argument.CanChangeType,ElementName=InArgumentControl,Converter={StaticResource BoolToVis}}"
                     Click="ChangeArgumentType" Style="{DynamicResource ChangeArgumentTypeButtonStyle}" 
-                    Content="..." ToolTip="Change Type" DockPanel.Dock="Right"/>
+                    ToolTip="Change Type" DockPanel.Dock="Right"/>
 
             <ToggleButton x:Name="ArgumentModeToggle" IsThreeState="True" Style="{DynamicResource InArgumentToggleStateStyle}" Width="28" 
                       Click="ChangeArgumentMode" Visibility="{Binding Argument.CanChangeMode,ElementName=InArgumentControl,Converter={StaticResource BoolToVis}}"
@@ -30,23 +30,26 @@
             <Grid  MinWidth="100" HorizontalAlignment="Stretch" DockPanel.Dock="Right">
 
                 <ContentControl x:Name="DefaultValueEditor" Content="{Binding Argument.DefaultValue,ElementName=InArgumentControl,Mode=TwoWay}"
-                                DataContext="{Binding Argument,ElementName=InArgumentControl,Mode=TwoWay}"
-                                ContentTemplateSelector="{StaticResource InArgumentTemplateSelector}"
+                                DataContext="{Binding Argument,ElementName=InArgumentControl,Mode=TwoWay}" Width="158" MaxWidth="158"
+                                ContentTemplateSelector="{StaticResource ArgumentTemplateSelector}"
                                 Visibility="{Binding Argument.Mode,ElementName=InArgumentControl,Converter={StaticResource ArgsModeToVisConverter},
                                 ConverterParameter=VisibleOnDefault}"></ContentControl>
 
                 <ComboBox x:Name="ArgumentsComboBox" ItemsSource="{Binding AvailableProperties,ElementName=InArgumentControl}" 
-                          IsEditable="True"
+                          IsEditable="True" Width="158" MaxWidth="158"
                           Metro:TextBoxHelper.UseFloatingWatermark="True"
                           Metro:TextBoxHelper.Watermark="{Binding Argument.ArgumentType,ElementName=InArgumentControl}"
                           SelectedValue="{Binding Argument.PropertyPath,ElementName=InArgumentControl}"
                   Style="{DynamicResource MahApps.Styles.ComboBox.Virtualized}"
                   Visibility="{Binding Argument.Mode,ElementName=InArgumentControl, Converter={StaticResource ArgsModeToVisConverter},ConverterParameter=VisibleOnDataBound}" />
 
-                <Button x:Name="ScriptEditorButton" Content="C# Script Editor..."  Click="ShowScriptEditor" Style="{DynamicResource MahApps.Styles.Button.Square}"
-                        ToolTip="Open Script editor" Padding="5"  BorderThickness="1"  BorderBrush="#FFCCCCCC"
-                        Visibility="{Binding Argument.Mode,ElementName=InArgumentControl,Converter={StaticResource ArgsModeToVisConverter},
-                        ConverterParameter=VisibleOnScripted}"></Button>
+                <DockPanel Visibility="{Binding Argument.Mode,ElementName=InArgumentControl,Converter={StaticResource ArgsModeToVisConverter}, 
+                    ConverterParameter=VisibleOnScripted}" LastChildFill="True" Width="158" MaxWidth="158">
+                    <Button x:Name="ScriptEditorButton"  Click="ShowScriptEditor" Style="{DynamicResource EditScriptButtonStyle}"
+                            ToolTip="Open Script editor" Padding="5"  BorderThickness="0,1,1,1"  BorderBrush="#FFCCCCCC" DockPanel.Dock="Right"></Button>
+                    <TextBox x:Name="ScriptPath" Text="{Binding Argument.ScriptFile, ElementName=InArgumentControl}" VerticalContentAlignment="Center"
+                             MaxWidth="158" BorderBrush="#FFCCCCCC" DockPanel.Dock="Left"/>
+                </DockPanel>
 
             </Grid>
         </DockPanel>

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/InArgumentUserControl.xaml.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/InArgumentUserControl.xaml.cs
@@ -20,7 +20,9 @@ namespace Pixel.Automation.Editor.Controls.Arguments
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             if (this.OwnerComponent?.EntityManager == null)
+            {
                 return;
+            }
             LoadAvailableProperties();
         }     
 
@@ -38,9 +40,9 @@ namespace Pixel.Automation.Editor.Controls.Arguments
                     break;
                 case ArgumentMode.DataBound:
                     this.Argument.Mode = ArgumentMode.Scripted;
+                    InitializeScriptName();
                     break;
-                case ArgumentMode.Scripted:
-                    DeleteScriptFile();
+                case ArgumentMode.Scripted:                   
                     this.Argument.Mode = ArgumentMode.Default;
                     break;
             }            

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/OutArgumentUserControl.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/OutArgumentUserControl.xaml
@@ -9,8 +9,7 @@
              mc:Ignorable="d" x:Name="OutArgumentControl"
              d:DesignHeight="300" d:DesignWidth="300">
     <local:ArgumentUserControl.Resources>
-        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
-        <local:InArgumentTemplateSelector x:Key="InArgumentTemplateSelector"/>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>      
         <converters:ArgumentModeToVisibilityConverter x:Key="ArgsModeToVisConverter"/>
         <converters:ArgumentModeToBooleanConverter x:Key="ArgsModeToBoolConverter"/>
     </local:ArgumentUserControl.Resources>
@@ -20,7 +19,7 @@
 
             <Button x:Name="ChangeArgumentTypeButton" Visibility="{Binding Argument.CanChangeType,ElementName=OutArgumentControl,Converter={StaticResource BoolToVis}}"
                     Click="ChangeArgumentType"  Style="{DynamicResource ChangeArgumentTypeButtonStyle}"
-                    Content="..." ToolTip="Change Type" DockPanel.Dock="Right"/>
+                    ToolTip="Change Type" DockPanel.Dock="Right"/>
 
             <ToggleButton x:Name="ArgumentModeToggle" Style="{DynamicResource OutArgumentToggleStateStyle}" Width="28" 
                       Click="ChangeArgumentMode" Visibility="{Binding Argument.CanChangeMode,ElementName=OutArgumentControl,Converter={StaticResource BoolToVis}}"
@@ -31,17 +30,20 @@
             <Grid  MinWidth="100" HorizontalAlignment="Stretch" DockPanel.Dock="Right">
 
                 <ComboBox x:Name="ArgumentsComboBox" ItemsSource="{Binding AvailableProperties,ElementName=OutArgumentControl}" 
-                          IsEditable="True"
+                          IsEditable="True" Width="158" MaxWidth="158"
                           Metro:TextBoxHelper.UseFloatingWatermark="True"
                           Metro:TextBoxHelper.Watermark="{Binding Argument.ArgumentType,ElementName=OutArgumentControl}"
                           SelectedValue="{Binding Argument.PropertyPath,Mode=TwoWay,ElementName=OutArgumentControl}"
                   Style="{DynamicResource MahApps.Styles.ComboBox.Virtualized}"
                   Visibility="{Binding Argument.Mode,ElementName=OutArgumentControl, Converter={StaticResource ArgsModeToVisConverter},ConverterParameter=VisibleOnDataBound}" />
 
-                <Button x:Name="ScriptEditorButton" Content="C# Script Editor..."  Click="ShowScriptEditor" BorderThickness="1,1,1,1"  BorderBrush="#FFCCCCCC"
-                        ToolTip="Open Script editor" Padding="5"  Style="{DynamicResource MahApps.Styles.Button.Square}"
-                        Visibility="{Binding Argument.Mode,ElementName=OutArgumentControl,Converter={StaticResource ArgsModeToVisConverter},
-                        ConverterParameter=VisibleOnScripted}"></Button>
+                <DockPanel Visibility="{Binding Argument.Mode,ElementName=OutArgumentControl,Converter={StaticResource ArgsModeToVisConverter}, 
+                    ConverterParameter=VisibleOnScripted}" LastChildFill="True" Width="158" MaxWidth="158">
+                    <Button x:Name="ScriptEditorButton" Content="E"  Click="ShowScriptEditor" Style="{DynamicResource EditScriptButtonStyle}"
+                            ToolTip="Open Script editor" Padding="5"  BorderThickness="0,1,1,1"  BorderBrush="#FFCCCCCC" DockPanel.Dock="Right"></Button>
+                    <TextBox x:Name="ScriptPath" Text="{Binding Argument.ScriptFile, ElementName=OutArgumentControl}" VerticalContentAlignment="Center"
+                             BorderBrush="#FFCCCCCC" DockPanel.Dock="Left"/>
+                </DockPanel>
 
             </Grid>
 

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/OutArgumentUserControl.xaml.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/OutArgumentUserControl.xaml.cs
@@ -26,16 +26,18 @@ namespace Pixel.Automation.Editor.Controls.Arguments
         public void ChangeArgumentMode(object sender, RoutedEventArgs e)
         {
             if (this.OwnerComponent?.EntityManager == null)
+            {
                 return;
+            }
             if (this.Argument.Mode == ArgumentMode.DataBound)
             {
                 this.Argument.Mode = ArgumentMode.Scripted;
+                InitializeScriptName();
             }
             else if (this.Argument.Mode == ArgumentMode.Scripted)
-            {
-                LoadAvailableProperties();
-                DeleteScriptFile();
+            {                        
                 this.Argument.Mode = ArgumentMode.DataBound;
+                LoadAvailableProperties();
             }
 
         }        


### PR DESCRIPTION
**Description**
1. Added an error template for argument editors when a editor mode for default mode is not enabled. This is usually the case for co mplex types.
2. Script names are visible and editable now when in scripted mode. This allows user to have control over script file. Eventually, in future, Idea is to add a script repository and it should be possible to create and edit script outside and reuse them by drag drop on argument editors.
3. Don't delete script files when argument mode is changed so that if user changes their mind later, script should still be available.However, if argument type is changed , script file will be deleted. This might need to be changed later when we add reusable scripts. 