### PR TITLE
Allow control over speed of execution of test cases

### DIFF
--- a/src/Pixel.Automation.Core/ApplicationSettings.cs
+++ b/src/Pixel.Automation.Core/ApplicationSettings.cs
@@ -1,26 +1,75 @@
-﻿namespace Pixel.Automation.Core
+﻿using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Core
 {
-    public class ApplicationSettings
+    [DataContract]
+    public class ApplicationSettings : NotifyPropertyChanged
     {
         /// <summary>
         /// Path relative to working directory where application configuration (including controls and prefabs) are stored locally
         /// </summary>
+        [DataMember]
         public string ApplicationDirectory { get; set; }
 
         /// <summary>
         /// Path relative to working directory where automation projects are stored locally
         /// </summary>
+        [DataMember]
         public string AutomationDirectory { get; set; }
 
+        private string persistenceServiceUri;
         /// <summary>
         /// Service end point for storing and retrieving application , process and test result data
         /// </summary>
-        public string PersistenceServiceUri { get; set; }
+        [DataMember]
+        public string PersistenceServiceUri
+        {
+            get => this.persistenceServiceUri;
+            set
+            {
+                this.persistenceServiceUri = value;
+                if (string.IsNullOrEmpty(value))
+                {
+                    this.IsOfflineMode = true;
+                }
+                OnPropertyChanged();
+            }
+        }
 
+      
+        private bool isOfflineMode;
         /// <summary>
         /// If true, data won't be stored using persistence service . Local file syste will be used.
         /// </summary>
-        public bool IsOfflineMode { get; set; }
+        [DataMember]
+        public bool IsOfflineMode
+        {
+            get => this.isOfflineMode;
+            set
+            {
+                this.isOfflineMode = value;
+                OnPropertyChanged();
+            }
+        }      
+                
+        /// <summary>
+        /// Default amound of delay in ms before actor is executed
+        /// </summary>
+        [DataMember]
+        public int PreDelay { get; set; }
 
+        /// <summary>
+        /// Default amount of delay in ms after actor is executed
+        /// </summary>
+        [DataMember]
+        public int PostDelay { get; set; }
+
+        /// <summary>
+        /// Default scaling factor that can be used to control Pre and Post Delay amount
+        /// e.g. if delay factor is 3 and pre delay is 100, actual delay applied will be 300 ms before actor is executed.
+        /// This can be changed per fixture or per test using execution speed setting.
+        /// </summary>
+        [DataMember]
+        public int DelayFactor { get; set; }
     }
 }

--- a/src/Pixel.Automation.Core/Enums/Priority.cs
+++ b/src/Pixel.Automation.Core/Enums/Priority.cs
@@ -9,7 +9,7 @@ namespace Pixel.Automation.Core.Enums
         Default,
         [Description("Low")]
         Low,
-        [Description("Low")]
+        [Description("Medium")]
         Medium,
         [Description("High")]
         High       

--- a/src/Pixel.Automation.Core/TestData/TestCase.cs
+++ b/src/Pixel.Automation.Core/TestData/TestCase.cs
@@ -26,6 +26,13 @@ namespace Pixel.Automation.Core.TestData
         [DataMember]
         public bool IsMuted { get; set; }
 
+        /// <summary>
+        /// Controls the delay for pre and post run of actors.
+        /// </summary>
+        [DataMember]
+        public int DelayFactor { get; set; } = 3;
+
+
         [DataMember]
         public Priority Priority { get; set; }
 
@@ -49,12 +56,13 @@ namespace Pixel.Automation.Core.TestData
         public object Clone()
         {
             TestCase copy = new TestCase()
-            {              
+            {
                 DisplayName = this.DisplayName,
-                Description = this.Description,   
+                Description = this.Description,
                 Tags = new TagCollection(this.Tags.Tags),
-                IsMuted = this.IsMuted,               
-                Order = this.Order            
+                IsMuted = this.IsMuted,
+                Order = this.Order,
+                DelayFactor = this.DelayFactor
             };
             return copy;
         }

--- a/src/Pixel.Automation.Core/TestData/TestFixture.cs
+++ b/src/Pixel.Automation.Core/TestData/TestFixture.cs
@@ -31,6 +31,12 @@ namespace Pixel.Automation.Core.TestData
         [DataMember]
         public string Category { get; set; } = "Default";
 
+        /// <summary>
+        /// Controls the delay for pre and post run of actors.
+        /// </summary>
+        [DataMember]
+        public int DelayFactor { get; set; } = 3; 
+
         [DataMember]
         public TagCollection Tags { get; private set; } = new TagCollection();
 
@@ -47,6 +53,7 @@ namespace Pixel.Automation.Core.TestData
                 IsMuted = this.IsMuted,             
                 Description = this.Description,
                 Category = this.Category,
+                DelayFactor = this.DelayFactor,
                 Tags = this.Tags               
             };
             return copy;

--- a/src/Pixel.Automation.Designer.ViewModels/Flyouts/SettingsViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Flyouts/SettingsViewModel.cs
@@ -1,15 +1,9 @@
-﻿using ControlzEx.Theming;
-using Dawn;
-using MahApps.Metro;
+﻿using Dawn;
 using Microsoft.Extensions.Configuration;
 using Pixel.Automation.Core;
 using Pixel.Automation.Editor.Core;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Windows;
-using System.Windows.Media;
 
 namespace Pixel.Automation.Designer.ViewModels.Flyouts
 {
@@ -17,67 +11,11 @@ namespace Pixel.Automation.Designer.ViewModels.Flyouts
     {
         private readonly IConfiguration configurationManager;
 
-        public List<AccentColorMenuData> AccentColors { get; set; }
-        public List<AppThemeMenuData> AppThemes { get; set; }
+        public ThemeSettings ThemeSettings { get; private set; }
 
-        AccentColorMenuData selectedAccentColor;
-        public AccentColorMenuData SelectedAccentColor
-        {
-            get
-            {
-                return selectedAccentColor;
-            }
-            set
-            {
-                this.selectedAccentColor = value;
-                this.selectedAccentColor.DoChangeTheme();
-                NotifyOfPropertyChange();
-            }
-        }
-
-        AppThemeMenuData selectedAppTheme;
-        public AppThemeMenuData SelectedAppTheme
-        {
-            get
-            {
-                return selectedAppTheme;
-            }
-            set
-            {
-                this.selectedAppTheme = value;
-                this.selectedAppTheme.DoChangeTheme();
-                NotifyOfPropertyChange();
-            }
-        }
-
-        private string persistenceServiceUri;
-        public string PersistenceServiceUri
-        {
-            get => this.persistenceServiceUri;
-            set
-            {
-                this.persistenceServiceUri = value;
-                if(string.IsNullOrEmpty(value))
-                {
-                    this.IsOfflineMode = true;
-                }
-                NotifyOfPropertyChange();
-            }
-        }
-
-        private bool isOfflineMode;
-        public bool IsOfflineMode
-        {
-            get => this.isOfflineMode;
-            set
-            {
-                this.isOfflineMode = value;
-                NotifyOfPropertyChange();
-            }
-        }
+        public ApplicationSettings ApplicationSettings { get; private set; }
        
-
-        public SettingsViewModel(IConfiguration configurationManager)
+        public SettingsViewModel(IConfiguration configurationManager, ApplicationSettings applicationSettings, UserSettings userSettings)
         {
             this.configurationManager = Guard.Argument(configurationManager, nameof(configurationManager)).NotNull().Value;
 
@@ -85,40 +23,21 @@ namespace Pixel.Automation.Designer.ViewModels.Flyouts
             this.Position = MahApps.Metro.Controls.Position.Right;
             this.Theme = MahApps.Metro.Controls.FlyoutTheme.Inverse;
 
-
-            // create accent color menu items for the demo
-            this.AccentColors = ThemeManager.Current.ColorSchemes.Select(a => new AccentColorMenuData { Name = a })
-                                            .ToList();
-
-            // create metro theme color menu items for the demo
-            this.AppThemes = ThemeManager.Current.Themes
-                                         .GroupBy(x => x.BaseColorScheme)
-                                         .Select(x => x.First())
-                                         .Select(a => new AppThemeMenuData() { Name = a.BaseColorScheme })
-                                         .ToList();
-
-            var userSettings = configurationManager.GetSection("userSettings").Get<UserSettings>();
-            this.SelectedAccentColor = this.AccentColors.FirstOrDefault(a => a.Name.Equals(userSettings.Accent));
-            this.SelectedAppTheme = this.AppThemes.FirstOrDefault(a => a.Name.Equals(userSettings.Theme));
-
-            var applicationSettings = configurationManager.GetSection("applicationSettings").Get<ApplicationSettings>();
-            this.PersistenceServiceUri = applicationSettings.PersistenceServiceUri;
-            this.IsOfflineMode = applicationSettings.IsOfflineMode;
+            this.ApplicationSettings = applicationSettings;
+            this.ThemeSettings = new ThemeSettings(userSettings);
         }
 
 
         public void Save()
         {
-            var userSettings = configurationManager.GetSection("userSettings").Get<UserSettings>();
-            userSettings.Theme = this.selectedAppTheme?.Name ?? "Light";
-            userSettings.Accent = this.selectedAccentColor?.Name ?? "Blue";
-        
-            var applicationSettings = configurationManager.GetSection("applicationSettings").Get<ApplicationSettings>();
-            applicationSettings.PersistenceServiceUri = this.persistenceServiceUri;
-            applicationSettings.IsOfflineMode = this.isOfflineMode;
-
+            var userSettings = new UserSettings()
+            {
+                Theme = this.ThemeSettings.SelectedAppTheme?.Name ?? "Light",
+                Accent = this.ThemeSettings.SelectedAccentColor?.Name ?? "Crimson"
+            };  
+          
             AddOrUpdateSection("userSettings", userSettings);
-            AddOrUpdateSection("applicationSettings", applicationSettings);
+            AddOrUpdateSection("applicationSettings", this.ApplicationSettings);
         }
 
         private void AddOrUpdateSection<T>(string sectionKey, T sectionData)
@@ -130,34 +49,5 @@ namespace Pixel.Automation.Designer.ViewModels.Flyouts
             string updatedContent = Newtonsoft.Json.JsonConvert.SerializeObject(jsonObj, Newtonsoft.Json.Formatting.Indented);
             File.WriteAllText(filePath, updatedContent);
         }
-
-
-    }
-
-    public class AccentColorMenuData
-    {
-        public string Name { get; set; }
-
-        //public Brush BorderColorBrush { get; set; }
-
-        //public Brush ColorBrush { get; set; }
-
-        public AccentColorMenuData()
-        {
-
-        }
-
-        public virtual void DoChangeTheme()
-        {
-            ThemeManager.Current.ChangeThemeColorScheme(System.Windows.Application.Current, this.Name);
-        }
-    }
-
-    public class AppThemeMenuData : AccentColorMenuData
-    {
-        public override void DoChangeTheme()
-        {
-            ThemeManager.Current.ChangeThemeBaseColor(System.Windows.Application.Current, this.Name);
-        }
-    }
+    }   
 }

--- a/src/Pixel.Automation.Designer.ViewModels/Flyouts/ThemeSettings.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Flyouts/ThemeSettings.cs
@@ -1,0 +1,85 @@
+﻿using Caliburn.Micro;
+using ControlzEx.Theming;
+using Pixel.Automation.Editor.Core;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Pixel.Automation.Designer.ViewModels.Flyouts
+{
+    public class AccentColorMenuData
+    {
+        public string Name { get; set; }
+    
+        public AccentColorMenuData()
+        {
+
+        }
+
+        public virtual void DoChangeTheme()
+        {
+            ThemeManager.Current.ChangeThemeColorScheme(System.Windows.Application.Current, this.Name);
+        }
+    }
+
+    public class AppThemeMenuData : AccentColorMenuData
+    {
+        public override void DoChangeTheme()
+        {
+            ThemeManager.Current.ChangeThemeBaseColor(System.Windows.Application.Current, this.Name);
+        }
+    }
+
+    public class ThemeSettings : PropertyChangedBase
+    {
+
+        public List<AccentColorMenuData> AccentColors { get; set; }
+        public List<AppThemeMenuData> AppThemes { get; set; }
+
+        AccentColorMenuData selectedAccentColor;
+        public AccentColorMenuData SelectedAccentColor
+        {
+            get
+            {
+                return selectedAccentColor;
+            }
+            set
+            {
+                this.selectedAccentColor = value;
+                this.selectedAccentColor.DoChangeTheme();
+                NotifyOfPropertyChange();
+            }
+        }
+
+        AppThemeMenuData selectedAppTheme;
+        public AppThemeMenuData SelectedAppTheme
+        {
+            get
+            {
+                return selectedAppTheme;
+            }
+            set
+            {
+                this.selectedAppTheme = value;
+                this.selectedAppTheme.DoChangeTheme();
+                NotifyOfPropertyChange();
+            }
+        }
+
+        public ThemeSettings(UserSettings userSettings)
+        {
+
+            this.AccentColors = ThemeManager.Current.ColorSchemes.Select(a => new AccentColorMenuData { Name = a })
+                                         .ToList();
+
+            // create metro theme color menu items for the demo
+            this.AppThemes = ThemeManager.Current.Themes
+                                         .GroupBy(x => x.BaseColorScheme)
+                                         .Select(x => x.First())
+                                         .Select(a => new AppThemeMenuData() { Name = a.BaseColorScheme })
+                                         .ToList();
+            this.SelectedAccentColor = this.AccentColors.FirstOrDefault(a => a.Name.Equals(userSettings.Accent));
+            this.SelectedAppTheme = this.AppThemes.FirstOrDefault(a => a.Name.Equals(userSettings.Theme));
+        }
+
+    }
+}

--- a/src/Pixel.Automation.Designer.Views/Flyouts/SettingsView.xaml
+++ b/src/Pixel.Automation.Designer.Views/Flyouts/SettingsView.xaml
@@ -9,7 +9,7 @@
              mc:Ignorable="d" Width="600"
              d:DesignHeight="300" d:DesignWidth="300">
     <UserControl.Resources>
-        
+        <Thickness x:Key="MarginTop" Left="0" Top="4" Right="0" Bottom="0"/>
     </UserControl.Resources>
     
     
@@ -20,27 +20,83 @@
             <Controls:MetroTabItem Controls:HeaderedControlHelper.HeaderFontSize="18" Header="General">
                 <StackPanel Margin="10,5,5,5">
                     <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch">
-                        <Label Content="Persistence Service" Padding="0,0,0,5"></Label>
-                        <TextBox x:Name="PersistenceServiceUri" Controls:TextBoxHelper.Watermark="Service endpoint" Controls:TextBoxHelper.ClearTextButton="True"></TextBox>
+                        <StackPanel Orientation="Horizontal">
+                            <Label Content="Presistence Service" Padding="0,0,0,5" VerticalContentAlignment="Center"></Label>
+                            <Button x:Name="InfoPersistenceService" Style="{StaticResource InfoButtonStyle}" Margin="5,0,0,5"
+                                    ToolTip="Service endpoint for data persistence"/>
+                        </StackPanel>
+                        <TextBox x:Name="PersistenceServiceUri" Controls:TextBoxHelper.Watermark="Service endpoint" 
+                                 Text="{Binding ApplicationSettings.PersistenceServiceUri}" Width="250" HorizontalAlignment="Left"
+                                 Controls:TextBoxHelper.ClearTextButton="True"></TextBox>
                     </StackPanel>
-                    <StackPanel  HorizontalAlignment="Stretch" Margin="0,5,0,0">                     
-                        <CheckBox x:Name="IsOfflineMode" Content="Work Offline"></CheckBox>
-                    </StackPanel>
+                    <StackPanel Orientation="Horizontal"  Margin="{StaticResource MarginTop}">
+                        <CheckBox x:Name="IsOfflineMode" IsChecked="{Binding ApplicationSettings.IsOfflineMode}" Content="Work Offline"></CheckBox>
+                        <Button x:Name="InfoIsOfflineMode" Style="{StaticResource InfoButtonStyle}" Margin="5,0,0,0"
+                                    ToolTip="Indicates whether to work in offline mode. Data is stored locally in offline mode."/>
+                    </StackPanel>                   
                 </StackPanel>
             </Controls:MetroTabItem>
             
+            <Controls:MetroTabItem Controls:HeaderedControlHelper.HeaderFontSize="18" Header="Fixture" ToolTip="Application settings for Test Fixture">
+                <StackPanel Margin="10,5,5,5">
+                    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch">
+                        <StackPanel Orientation="Horizontal">
+                            <Label Content="Delay Before" Padding="0,0,0,5" VerticalContentAlignment="Center"></Label>
+                            <Button x:Name="InfoPreDelay" Style="{StaticResource InfoButtonStyle}" Margin="5,0,0,5"
+                                    ToolTip="Amount of delay in ms before executing an actor inside a test case."/>
+                        </StackPanel>
+                        <TextBox x:Name="PreDelay" Controls:TextBoxHelper.Watermark="Delay Before" 
+                                 Text="{Binding ApplicationSettings.PreDelay}" Width="250" HorizontalAlignment="Left"
+                                 Controls:TextBoxHelper.ClearTextButton="True"></TextBox>
+                    </StackPanel>
+                    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Margin="{StaticResource MarginTop}">
+                        <StackPanel Orientation="Horizontal">
+                            <Label Content="Delay After" Padding="0,0,0,5" VerticalContentAlignment="Center"></Label>
+                            <Button x:Name="InfoPostDelay" Style="{StaticResource InfoButtonStyle}" Margin="5,0,0,5"                                   
+                                    ToolTip="Amount of delay in ms after executing an actor inside a test case."/>
+                        </StackPanel>
+                        <TextBox x:Name="PostDelay" Controls:TextBoxHelper.Watermark="Delay After" 
+                                 Text="{Binding ApplicationSettings.PostDelay}" Width="250" HorizontalAlignment="Left"
+                                 Controls:TextBoxHelper.ClearTextButton="True"></TextBox>
+                    </StackPanel>
+                    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Margin="{StaticResource MarginTop}">
+                        <StackPanel Orientation="Horizontal">
+                            <Label Content="Delay Factor" Padding="0,0,0,5" VerticalContentAlignment="Center"></Label>
+                            <Button x:Name="InfoDelayFactor" Style="{StaticResource InfoButtonStyle}" Margin="5,0,0,5"
+                                    ToolTip="Default scaling factor for pre and post delay that can be used to control the actual applied delay"/>
+                        </StackPanel>
+                        <TextBox x:Name="DelayFactor" Controls:TextBoxHelper.Watermark="Delay Factor" 
+                                 Text="{Binding ApplicationSettings.DelayFactor}" Width="250" HorizontalAlignment="Left"
+                                 Controls:TextBoxHelper.ClearTextButton="True"></TextBox>
+                    </StackPanel>
+                </StackPanel>
+            </Controls:MetroTabItem>
+
             <Controls:MetroTabItem Controls:HeaderedControlHelper.HeaderFontSize="18" Header="Theme">
                 <StackPanel Margin="10,5,5,5">
                     <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch">
-                        <Label Content="Theme" Padding="0,0,0,5"></Label>
-                        <ComboBox x:Name="AppThemes" DisplayMemberPath="Name" Width="200" HorizontalAlignment="Left"/>
+                        <StackPanel Orientation="Horizontal">
+                            <Label Content="Theme" Padding="0,0,0,5" VerticalContentAlignment="Center"></Label>
+                            <Button x:Name="InfoTheme" Style="{StaticResource InfoButtonStyle}" Margin="5,0,0,5"
+                                    ToolTip="Theme for the application"/>
+                        </StackPanel>
+                        <ComboBox x:Name="AppThemes" DisplayMemberPath="Name"
+                                  ItemsSource="{Binding ThemeSettings.AppThemes}" SelectedItem="{Binding ThemeSettings.SelectedAppTheme}"
+                                  Width="200" HorizontalAlignment="Left"/>
                     </StackPanel>
-                    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch">
-                        <Label Content="Accent" Padding="0,5,0,5"></Label>
-                        <ComboBox x:Name="AccentColors" DisplayMemberPath="Name" Width="200" HorizontalAlignment="Left"/>
+                    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Margin="{StaticResource MarginTop}">
+                        <StackPanel Orientation="Horizontal">
+                            <Label Content="Accent" Padding="0,0,0,5" VerticalContentAlignment="Center"></Label>
+                            <Button x:Name="InfoAccent" Style="{StaticResource InfoButtonStyle}" Margin="5,0,0,5"
+                                    ToolTip="Accent used with the theme"/>
+                        </StackPanel>
+                        <ComboBox x:Name="AccentColors" DisplayMemberPath="Name"
+                                  ItemsSource="{Binding ThemeSettings.AccentColors}" SelectedItem="{Binding ThemeSettings.SelectedAccentColor}"
+                                  Width="200" HorizontalAlignment="Left"/>
                     </StackPanel>
                 </StackPanel>
-            </Controls:MetroTabItem>          
+            </Controls:MetroTabItem>           
+            
         </Controls:MetroTabControl>
         <DockPanel LastChildFill="False" DockPanel.Dock="Top" Margin="10,10,0,0">
             <Button x:Name="Save" Content="Save" DockPanel.Dock="Left" Margin="0" Width="100"

--- a/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
@@ -217,6 +217,27 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="InfoButtonStyle" TargetType="Button" BasedOn="{StaticResource MahApps.Styles.Button.Circle}">
+        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"></Setter>
+        <Setter Property="Width" Value="24"></Setter>
+        <Setter Property="Height" Value="24"></Setter>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border IsHitTestVisible="True" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}"
+                        BorderBrush="{TemplateBinding BorderBrush}">
+                        <iconPacks:PackIconOcticons x:Name="Info" Width="{TemplateBinding Width}"
+                                        Height="{TemplateBinding Height}" IsHitTestVisible="False"
+                                        Margin="2" Padding="4" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        Foreground="{DynamicResource MahApps.Brushes.Flyout.Foreground}"
+                                        Kind="Info" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+ 
     <Style x:Key="TextBlockStyle" TargetType="TextBlock">
         <Setter Property="FontWeight" Value="Bold"></Setter>
         <Setter Property="FontStyle" Value="Normal"></Setter>

--- a/src/Pixel.Automation.Designer.Views/appsettings.json
+++ b/src/Pixel.Automation.Designer.Views/appsettings.json
@@ -7,6 +7,9 @@
     "applicationDirectory": "Applications",
     "automationDirectory": "Automations",
     "persistenceServiceUri": "https://localhost:5001/api",
-    "isOfflineMode": "true"
+    "isOfflineMode": "true",
+    "preDelay": 100,
+    "postDelay": 100,
+    "delayFactor" : 3 
   }
 }

--- a/src/Pixel.Automation.Test.Runner/appsettings.json
+++ b/src/Pixel.Automation.Test.Runner/appsettings.json
@@ -3,6 +3,9 @@
     "applicationDirectory": "Applications",
     "automationDirectory": "Automations",
     "persistenceServiceUri": "https://localhost:5001/api",
-    "isOfflineMode": "false"
+    "isOfflineMode": "false",
+    "preDelay": 100,
+    "postDelay": 100,
+    "delayFactor":  3
   }
 }

--- a/src/Pixel.Automation.TestExplorer.ViewModels/EditTestCaseViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/EditTestCaseViewModel.cs
@@ -40,6 +40,13 @@ namespace Pixel.Automation.TestExplorer.ViewModels
             set => CopyOfTestCase.IsMuted = value;
         }
 
+        public int DelayFactor
+        {
+            get => (100 - CopyOfTestCase.DelayFactor);
+            set => CopyOfTestCase.DelayFactor = (100 - value);
+        }
+
+
         public int Order
         {
             get => CopyOfTestCase.Order;
@@ -84,6 +91,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                 this.testCase.Description = CopyOfTestCase.Description;
                 this.testCase.IsMuted = CopyOfTestCase.IsMuted;
                 this.testCase.Order = CopyOfTestCase.Order;
+                this.testCase.DelayFactor = CopyOfTestCase.DelayFactor;
                 //this.testCase.Tags.Clear();
                 //this.testCase.Tags.AddRange(CopyOfTestCase.Tags);
                 await this.TryCloseAsync(true);

--- a/src/Pixel.Automation.TestExplorer.ViewModels/EditTestFixtureViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/EditTestFixtureViewModel.cs
@@ -51,6 +51,12 @@ namespace Pixel.Automation.TestExplorer.ViewModels
             set => CopyOfTestFixture.IsMuted = value;
         }
 
+        public int DelayFactor
+        {
+            get => (100 - CopyOfTestFixture.DelayFactor);
+            set => CopyOfTestFixture.DelayFactor = (100 - value);
+        }
+
         public int Order
         {
             get => CopyOfTestFixture.Order;
@@ -90,6 +96,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                 this.testFixtureVM.Category = CopyOfTestFixture.Category;
                 this.testFixtureVM.IsMuted = CopyOfTestFixture.IsMuted;
                 this.testFixtureVM.Order = CopyOfTestFixture.Order;
+                this.testFixtureVM.DelayFactor = CopyOfTestFixture.DelayFactor;
                 //this.testFixtureVM.Tags.Clear();
                 //this.testFixtureVM.Tags.AddRange(CopyOfTestFixture.Tags);
                 await this.TryCloseAsync(true);

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestCaseViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestCaseViewModel.cs
@@ -71,7 +71,13 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                 OnPropertyChanged();
             }
         }
-     
+
+        public int DelayFactor
+        {
+            get => TestCase.DelayFactor;
+            set => TestCase.DelayFactor = value;
+        }
+
         public Priority Priority
         {
             get => TestCase.Priority;

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestFixtureViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestFixtureViewModel.cs
@@ -68,6 +68,12 @@ namespace Pixel.Automation.TestExplorer.ViewModels
             get => TestFixture.Category;
             set => TestFixture.Category = value;
         }
+
+        public int DelayFactor
+        {
+            get => TestFixture.DelayFactor;
+            set => TestFixture.DelayFactor = value;
+        }
         
         public Entity TestFixtureEntity
         {

--- a/src/Pixel.Automation.TestExplorer.Views/EditTestCaseView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/EditTestCaseView.xaml
@@ -34,6 +34,13 @@
                      controls:TextBoxHelper.Watermark="Description"  HorizontalAlignment="Stretch"
                      VerticalAlignment="Top" Margin="5,5,5,0"></TextBox>
             </StackPanel>
+            <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
+                <Label Content="Execution Speed"/>
+                <Slider x:Name="DelayFactor" Value="{Binding DelayFactor}" SmallChange="1" TickPlacement="None" LargeChange="10"
+                        Margin="5,5,5,0"  Style="{DynamicResource MahApps.Styles.Slider.Flat}"                      
+                        AutoToolTipPlacement="TopLeft"
+                        Minimum="0"  Maximum="100" ToolTip="Controls the pre-delay and post-delay for actors"/>
+            </StackPanel>
             <!--<StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
                 <Label Content="Tags"/>
                 <TextBox x:Name="Tags" Text="{Binding Tags, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
@@ -41,19 +48,16 @@
                      controls:TextBoxHelper.Watermark="Tags (comma seperate e.g. tag1,tag2)"  HorizontalAlignment="Stretch"
                      VerticalAlignment="Top" Margin="5,5,5,0"></TextBox>
             </StackPanel>-->
-            <StackPanel Orientation="Horizontal" Margin="{StaticResource ControlMargin}">
-                <StackPanel Orientation="Horizontal" Margin="4 0 0 0">
-                    <CheckBox x:Name="IsMuted" IsChecked="{Binding IsMuted}" ToolTip="Muted test cases are not executed"/>
-                    <Label Content="Muted" ></Label>                   
-                    <controls:NumericUpDown Minimum="0" Value="{Binding Order}" Margin="10,0,0,0" ToolTip="Order of execution of test case within a fixture"/>
-                    <Label Content="Order" ></Label>
-                    <DockPanel LastChildFill="True" MinWidth="320" Grid.Row="2">
-                        <Label Content="Type" DockPanel.Dock="Left" MinWidth="80"></Label>
-                        <ComboBox ItemsSource="{Binding Source={editorCore:EnumBindingSource {x:Type models:Priority}}}" DockPanel.Dock="Right"
-                        SelectedItem="{Binding Path=Priority}" ToolTip="Priority"/>
-                    </DockPanel>
-                </StackPanel>
-            </StackPanel>          
+          
+            <StackPanel Orientation="Horizontal" Margin="{StaticResource ControlMargin}">                
+                <Label Content="Muted" ></Label>
+                <CheckBox x:Name="IsMuted" IsChecked="{Binding IsMuted}" ToolTip="Muted test cases are not executed"/>
+                <Label Content="Order" Margin="4,0,0,0" ></Label>
+                <controls:NumericUpDown Minimum="0" Value="{Binding Order}" ToolTip="Order of execution of test case within a fixture"/>
+                <Label Content="Priority" DockPanel.Dock="Left" Margin="4,0,0,0"></Label>
+                <ComboBox ItemsSource="{Binding Source={editorCore:EnumBindingSource {x:Type models:Priority}}}" DockPanel.Dock="Right"
+                        SelectedItem="{Binding Path=Priority}" ToolTip="Priority" MinWidth="80"/>
+            </StackPanel>           
         </StackPanel>
         <DockPanel LastChildFill="False" Margin="{StaticResource ControlMargin}">
             <Button x:Name="Cancel" Content="CANCEL" Width="100" DockPanel.Dock="Right"  Margin="10,0,4,0" Style="{DynamicResource MahApps.Styles.Button.Square}"/>

--- a/src/Pixel.Automation.TestExplorer.Views/EditTestFixtureView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/EditTestFixtureView.xaml
@@ -37,6 +37,13 @@
                      controls:TextBoxHelper.Watermark="Description"  HorizontalAlignment="Stretch"
                      VerticalAlignment="Top" Margin="5,5,5,0"></TextBox>
             </StackPanel>
+            <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
+                <Label Content="Execution Speed"/>
+                <Slider x:Name="DelayFactor" Value="{Binding DelayFactor}" SmallChange="1" TickPlacement="None" LargeChange="10"
+                        Margin="5,5,5,0"  Style="{DynamicResource MahApps.Styles.Slider.Flat}"
+                        AutoToolTipPlacement="TopLeft"
+                        Minimum="0"  Maximum="100" ToolTip="Controls the pre-delay and post-delay for actors"/>
+            </StackPanel>
             <!--<StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
                 <Label Content="Tags"/>
                 <TextBox x:Name="Tags" Text="{Binding Tags, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
@@ -45,12 +52,10 @@
                      VerticalAlignment="Top" Margin="5,5,5,0"></TextBox>
             </StackPanel>-->
             <StackPanel Orientation="Horizontal" Margin="{StaticResource ControlMargin}">
-                <StackPanel Orientation="Horizontal" Margin="4 0 0 0">
-                    <CheckBox x:Name="IsMuted" IsChecked="{Binding IsMuted}" ToolTip="Tests belonging to a muted fixture are not executed"/>
-                    <Label Content="Muted" ></Label>
-                    <controls:NumericUpDown Minimum="0" Value="{Binding Order}" Margin="10,0,0,0" ToolTip="Order of execution of fixture"/>
-                    <Label Content="Order" ></Label>
-                </StackPanel>
+                <Label Content="Muted" ></Label>
+                <CheckBox x:Name="IsMuted" IsChecked="{Binding IsMuted}" ToolTip="Tests belonging to a muted fixture are not executed"/>
+                <Label Content="Order" Margin="4,0,0,0" ></Label>
+                <controls:NumericUpDown Minimum="0" Value="{Binding Order}" ToolTip="Order of execution of fixture"/>               
             </StackPanel>           
         </StackPanel>
         <DockPanel LastChildFill="False" Margin="{StaticResource ControlMargin}">


### PR DESCRIPTION
**Description**
There should be a way to control the speed of execution of test cases.
Added three application level settings :
1. PreDelay :  Delay in millisecond before executing an actor (default value of 100)
2. PostDelay : Delay in millisecond after executing an actor (default value of 100)
3. DelayFactor : A scaling factor for PreDelay and PostDelay. This control is available at TestFixture and TestCase level to allow controlling speed of execution for each test case.

Additionally, refactored  some settings view model code while making this change.