### PR TITLE
Hot keys with control modifier not working

### DIFF
--- a/src/Pixel.Automation.Native.Windows/Device/SyntheticKeyboard.cs
+++ b/src/Pixel.Automation.Native.Windows/Device/SyntheticKeyboard.cs
@@ -309,6 +309,7 @@ namespace Pixel.Automation.Native.Windows.Device
             {
                 case SyntheticKeyCode.LCONTROL:
                 case SyntheticKeyCode.RCONTROL:
+                case SyntheticKeyCode.CONTROL:
                 case SyntheticKeyCode.LSHIFT:
                 case SyntheticKeyCode.RSHIFT:
                 case SyntheticKeyCode.SHIFT:


### PR DESCRIPTION
**Description**
Hot key actor doesn't work as expected with Ctrl as the modifier key e.g. Ctrl + A doesn't select all text.

**Fix**
Ctrl was not getting identified as one of the hot keys . Only LCtrl and RCtrl were identified as modifier keys.
Added Ctrl to list of known modifiers.
