### PR TITLE
Can't Save Test Case when another fixture has Test Case with same name

### DIFF
--- a/src/Pixel.Automation.Editor.Core/SmartScreen.cs
+++ b/src/Pixel.Automation.Editor.Core/SmartScreen.cs
@@ -36,13 +36,15 @@ namespace Pixel.Automation.Editor.Core
         public IEnumerable GetErrors(string propertyName)
         {           
             if (propertyErrors.ContainsKey(propertyName ?? string.Empty))
+            {
                 return propertyErrors[propertyName ?? string.Empty];
+            }
             return default(IEnumerable);
         }
 
         public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged = delegate { };
       
-        protected virtual void AddOrAppendErrors(string propertyName,params string[] errors)
+        protected virtual void AddOrAppendErrors(string propertyName, params string[] errors)
         {
             if (!propertyErrors.ContainsKey(propertyName))
             {

--- a/src/Pixel.Automation.TestExplorer.ViewModels/EditTestCaseViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/EditTestCaseViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using Pixel.Automation.Core.Enums;
 using Pixel.Automation.Core.TestData;
 using Pixel.Automation.Editor.Core;
+using Serilog;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -8,6 +9,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
 {
     public class EditTestCaseViewModel : SmartScreen
     {
+        private readonly ILogger logger = Log.ForContext<EditTestCaseViewModel>();
         private readonly TestCaseViewModel testCase;
         private readonly IEnumerable<TestCaseViewModel> existingTestCases;
 
@@ -95,12 +97,14 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                 //this.testCase.Tags.Clear();
                 //this.testCase.Tags.AddRange(CopyOfTestCase.Tags);
                 await this.TryCloseAsync(true);
+                logger.Information("Edit Test Case changes applied.");
             }
         }
 
         public async void Cancel()
         {
             await this.TryCloseAsync(false);
+            logger.Information("Edit Test Case changes were cancelled.");
         }
 
         public bool Validate()

--- a/src/Pixel.Automation.TestExplorer.ViewModels/EditTestFixtureViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/EditTestFixtureViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Pixel.Automation.Core.TestData;
 using Pixel.Automation.Editor.Core;
+using Serilog;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,6 +8,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
 {
     public class EditTestFixtureViewModel : SmartScreen
     {
+        private readonly ILogger logger = Log.ForContext<EditTestFixtureViewModel>();
         private readonly TestFixtureViewModel testFixtureVM;
         private readonly IEnumerable<TestFixtureViewModel> existingFixtures;
 
@@ -100,12 +102,14 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                 //this.testFixtureVM.Tags.Clear();
                 //this.testFixtureVM.Tags.AddRange(CopyOfTestFixture.Tags);
                 await this.TryCloseAsync(true);
+                logger.Information("Edit Test Fixture changes applied.");
             }           
         }
 
         public async void Cancel()
         {
             await this.TryCloseAsync(false);
+            logger.Information("Edit Test Fixture changes were cancelled.");
         }
 
         public bool Validate()

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestRepositoryManager.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestRepositoryManager.cs
@@ -394,8 +394,8 @@ namespace Pixel.Automation.TestExplorer
         {
             try
             {
-                var existingTestCases = TestFixtures.SelectMany(c => c.Tests);
-                existingTestCases = existingTestCases.Except(new[] { testCaseVM });
+                var parentFixture = TestFixtures.First(t => t.Id.Equals(testCaseVM.FixtureId));               
+                var existingTestCases = parentFixture.Tests.Except(new[] { testCaseVM });
                 var testCaseEditor = new EditTestCaseViewModel(testCaseVM, existingTestCases);
                 bool? result = await this.windowManager.ShowDialogAsync(testCaseEditor);
                 if (result.HasValue && result.Value)


### PR DESCRIPTION
**Description**
It is possible to add a new test case with duplicate name in to another fixture i.e. Test case names are unique within fixture.
However, if we try to edit a test case with duplicate name across fixture, It doesn't allow to save.

**Fix**
While adding a test case , we only pass on existing test cases as test cases available within the fixture to which new test case is being added. However, when editing a test case, we are passing all test cases available as existing test cases. Due to this validation scope for unique name is all test cases and not just the test cases in current fixture. Modified the logic to consider only test cases within current fixture while editing a test case.