### PR TITLE
Don't allow duplicate application names

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Application/ApplicationExplorerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Application/ApplicationExplorerViewModel.cs
@@ -228,6 +228,11 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Application
                 if (keyArgs != null && keyArgs.Key == Key.Enter)
                 {
                     string newName = (context.Source as System.Windows.Controls.TextBox).Text;
+                    if(this.Applications.Any(a => a.ApplicationName.Equals(newName)))
+                    {
+                        logger.Warning($"An application already exists with name {newName}.");
+                        return;
+                    }
                     if (newName != application.ApplicationName)
                     {
                         var previousName = application.ApplicationName;

--- a/src/Pixel.Automation.Core/Application.cs
+++ b/src/Pixel.Automation.Core/Application.cs
@@ -28,6 +28,7 @@ namespace Pixel.Automation.Core
         /// Name of the application
         /// </summary>
         [DataMember(IsRequired = true, Order = 20)]
+        [Browsable(false)]
         public string ApplicationName
         {
             get


### PR DESCRIPTION
**Description**
It is possible to rename multiple application to same name. Application names should not be duplicate.

**Change**
1. Hide Application Name from property grid view to prevent changing it
2. While Renaming application from application explorer, added a check for duplicate name.
    No feedback is provided at the moment if trying to rename to duplicate. 