### PR TITLE
Load compile time refs assemblies defined in include list

### DIFF
--- a/src/Pixel.Scripting.Common.CSharp/.Refs.Include
+++ b/src/Pixel.Scripting.Common.CSharp/.Refs.Include
@@ -1,0 +1,16 @@
+﻿Microsoft.CSharp.dll
+mscorlib.dll
+netstandard.dll
+System.dll
+System.Collections.dll
+System.Console.dll
+System.Core.dll
+System.Drawing.dll
+System.IO.dll
+System.IO.FileSystem.dll
+System.Linq.dll
+System.Net.dll
+System.Runtime.dll
+System.Text.RegularExpressions.dll
+System.Threading.dll
+System.Threading.Tasks.dll

--- a/src/Pixel.Scripting.Common.CSharp/Pixel.Scripting.Common.CSharp.csproj
+++ b/src/Pixel.Scripting.Common.CSharp/Pixel.Scripting.Common.CSharp.csproj
@@ -23,4 +23,10 @@
     </ProjectReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update=".Refs.Include">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
**Description**
For Code and Script editors we need to reference compile time assemblies. These are available in Refs folder of the application.
Currently, all the assemblies from refs folder is loaded in Workspace. This is not desired as it can add to memory footprint.

**Change**
Added a .Refs.Include file which contains a list of assemblies which should be loaded by default in to Editor Workspace.
We are not removing any files from Refs folder however. If it is required that some additional assemblies are needed, one can edit  .Refs.Include file to include any additional assembly. This is not required at runtime (for test runner) as they don't use compile time ref assemblies.