### PR TITLE
ScriptEditorScreen runs in to exception while disposing

### DIFF
--- a/src/Pixel.Scripting.Script.Editor/Editor/Script/ScriptEditorScreenViewModel.cs
+++ b/src/Pixel.Scripting.Script.Editor/Editor/Script/ScriptEditorScreenViewModel.cs
@@ -24,12 +24,5 @@ namespace Pixel.Scripting.Script.Editor.Script
         {
             base.OpenDocument(documentName, ownerProject, initialContent ?? string.Empty);           
         }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            //Clear any custom directory that was set for script editor.
-            this.editorService.SwitchToDirectory(null);
-            base.Dispose(isDisposing);
-        }
     }
 }


### PR DESCRIPTION
**Description**
ScriptEditorScreenViewModel Dispose() throws exception when closing the script editor screen.

**Analysis**
ScriptEditorScreenViewModel tries to set working directory to null during dispose.
This is not required any more since we use relative paths for all the script files with project working directory as the root directory.

**Fix**
Remove the dispose override which tries to set working directory to null.