### PR TITLE
Test data can be loaded from dynamic source now based on a variable 

### DIFF
--- a/src/Pixel.Automation.Core/Interfaces/IDataSourceReader.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IDataSourceReader.cs
@@ -5,6 +5,15 @@ namespace Pixel.Automation.Core.Interfaces
     public interface IDataSourceReader
     {
         /// <summary>
+        /// Append a suffix to data source file name to dynamically load data from different data source.
+        /// Ex: DataSource is configured to use script dataSource.csx . However, suffix is set to a non-empty value say secondary.
+        /// In this case , DataSourceReader should check if file dataSource.secondary.csx exists. If it exists, use that file.
+        /// If suffix file doesn't exist, use the default file dataSource.csx instead.
+        /// </summary>
+        /// <param name="environment"></param>
+        void SetDataSourceSuffix(string environment);
+
+        /// <summary>
         /// Load data from Test data source given it's id
         /// </summary>
         /// <param name="dataSourceId">Test Case</param>

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -79,6 +79,8 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                     using (var sw = File.CreateText(scriptFile))
                     {
                         sw.WriteLine("//Default Initialization script for automation process");
+                        sw.WriteLine();
+                        sw.Write("string dataSourceSuffix = string.Empty;");
                     };
                     logger.Information("Created initialization script file : {scriptFile}", scriptFile);
                 }

--- a/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
@@ -193,7 +193,8 @@
     </Style>
 
     <Style x:Key="VerticalDotsButtonStyle" TargetType="Button">
-        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"></Setter>             
+        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"></Setter>
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent2}"></Setter>
         <Setter Property="Width" Value="20"/>
         <Setter Property="Height" Value="Auto"/>
         <Setter Property="Template">
@@ -204,7 +205,7 @@
                         <iconPacks:PackIconFontAwesome x:Name="EllipsisVSolid" Width="{TemplateBinding Width}"
                                         Height="{TemplateBinding Height}" IsHitTestVisible="False"
                                         Margin="2" Padding="4" HorizontalAlignment="Center" VerticalAlignment="Center"
-                                        Foreground="{DynamicResource MahApps.Brushes.Accent2}"
+                                        Foreground="{TemplateBinding Foreground}"
                                         Kind="EllipsisVSolid" />
                     </Border>               
                 </ControlTemplate>
@@ -213,6 +214,9 @@
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Badged.Background.Disabled}"/>
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/src/Pixel.Automation.RunTime/DataSourceReader.cs
+++ b/src/Pixel.Automation.RunTime/DataSourceReader.cs
@@ -3,6 +3,7 @@ using Pixel.Automation.Core;
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.Models;
 using Pixel.Automation.Core.TestData;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -14,12 +15,15 @@ namespace Pixel.Automation.RunTime
     /// <inheritdoc/>
     public class DataSourceReader : IDataSourceReader
     {
+        private readonly ILogger logger = Log.ForContext<DataSourceReader>();
         private readonly IProjectFileSystem fileSystem;
         private readonly ISerializer serializer;
         private readonly IDataReader[] dataReaders;
         private readonly IScriptEngineFactory scriptEngineFactory;
         private Lazy<IScriptEngine> codeScriptEngine;
         private Lazy<IScriptEngine> csvScriptEngine;
+
+        private string dataSourceSuffix = string.Empty;
 
         public DataSourceReader(ISerializer serializer, IProjectFileSystem fileSystem, IScriptEngineFactory scriptEngineFactory, IDataReader[] dataReaders)
         {
@@ -36,6 +40,12 @@ namespace Pixel.Automation.RunTime
             this.codeScriptEngine = new Lazy<IScriptEngine>(() => { return this.scriptEngineFactory.CreateScriptEngine(fileSystem.WorkingDirectory); });
             this.csvScriptEngine = new Lazy<IScriptEngine>(() => { return this.scriptEngineFactory.CreateScriptEngine(fileSystem.WorkingDirectory); });
 
+        }
+
+        public void SetDataSourceSuffix(string dataSourceSuffix)
+        {
+            this.dataSourceSuffix = dataSourceSuffix;
+            logger.Information($"Data source suffix set to : {dataSourceSuffix}");
         }
 
         public IEnumerable<object> LoadData(string dataSourceId)
@@ -63,7 +73,12 @@ namespace Pixel.Automation.RunTime
 
         private async Task<IEnumerable<object>> GetCodedTestData(TestDataSource testDataSource)
         {
-            ScriptResult result = await codeScriptEngine.Value.ExecuteFileAsync(testDataSource.ScriptFile);          
+            string scriptFile = testDataSource.ScriptFile;        
+            if(!string.IsNullOrEmpty(this.dataSourceSuffix))
+            {
+                scriptFile = $"{Path.GetFileNameWithoutExtension(scriptFile)}.{this.dataSourceSuffix}{Path.GetExtension(scriptFile)}";
+            }
+            ScriptResult result = await codeScriptEngine.Value.ExecuteFileAsync(scriptFile);          
             result = await codeScriptEngine.Value.ExecuteScriptAsync("GetDataRows()");
             return (result.ReturnValue as IEnumerable<object>) ?? throw new InvalidCastException("Data source should return IEnumerable data");
         }
@@ -75,10 +90,19 @@ namespace Pixel.Automation.RunTime
             if (csvDataReader == null)
             {
                 throw new Exception("No DataReader for csv file is available");
-            }          
+            }
 
-            object globals = new DataReaderScriptGlobal() { DataReaderArgument = csvDataReader, DataSourceArgument = testDataSource };
-            this.codeScriptEngine.Value.SetGlobals(globals);
+            //Resolve the target file path to an absolute path
+            var csvDataSourceConfiguration = testDataSource.MetaData as CsvDataSourceConfiguration;
+            string csvFile = csvDataSourceConfiguration.TargetFile;
+            if (!string.IsNullOrEmpty(this.dataSourceSuffix))
+            {
+                csvFile = $"{Path.GetFileNameWithoutExtension(csvFile)}.{this.dataSourceSuffix}{Path.GetExtension(csvFile)}";
+            }
+            csvDataSourceConfiguration.TargetFile = Path.Combine(this.fileSystem.TestDataRepository, csvFile);
+
+            object globals = new DataReaderScriptGlobal() { DataSourceArgument = testDataSource, DataReaderArgument = csvDataReader };
+            this.csvScriptEngine.Value.SetGlobals(globals);
             ScriptResult result = await this.csvScriptEngine.Value.ExecuteFileAsync(testDataSource.ScriptFile);
             result = await this.csvScriptEngine.Value.ExecuteScriptAsync("GetDataRows(DataSourceArgument, DataReaderArgument)");
             return (result.ReturnValue as IEnumerable<object>) ?? throw new InvalidCastException("Data source should return IEnumerable data");

--- a/src/Pixel.Automation.RunTime/TestRunner.cs
+++ b/src/Pixel.Automation.RunTime/TestRunner.cs
@@ -62,10 +62,19 @@ namespace Pixel.Automation.RunTime
             try
             {
                 logger.Information("Performing environment setup");               
+       
                 var oneTimeSetUpEntity = this.entityManager.RootEntity.GetFirstComponentOfType<OneTimeSetUpEntity>(Core.Enums.SearchScope.Descendants);
                 oneTimeSetUpEntity.ResetHierarchy();
                 await ProcessEntity(oneTimeSetUpEntity);
                 IsSetupComplete = true;
+
+                //set the data source suffix if any 
+                var scriptEngine = this.entityManager.GetScriptEngine();
+                if(scriptEngine.HasScriptVariable("dataSourceSuffix"))
+                {
+                    string dataSourceSuffix = scriptEngine.GetVariableValue<string>("dataSourceSuffix");
+                    this.testDataLoader.SetDataSourceSuffix(dataSourceSuffix);
+                }
 
                 logger.Information("Environment setup completed");
 
@@ -91,6 +100,9 @@ namespace Pixel.Automation.RunTime
                 var oneTimeTearDownEntity = this.entityManager.RootEntity.GetFirstComponentOfType<OneTimeTearDownEntity>(Core.Enums.SearchScope.Descendants);
                 oneTimeTearDownEntity.ResetHierarchy();
                 await ProcessEntity(oneTimeTearDownEntity);
+
+                //clear the data source suffix
+                this.testDataLoader.SetDataSourceSuffix(string.Empty);
 
                 logger.Information("Environment teardown completed");
 

--- a/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataModelEditorViewModel.cs
+++ b/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataModelEditorViewModel.cs
@@ -79,7 +79,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
         {
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.Append(dataSourceType.GetRequiredImportsForType(Enumerable.Empty<Assembly>(), new string[] { typeof(object).Namespace, typeof(IEnumerable<>).Namespace, 
-            typeof(IDataReader).Namespace, typeof(TestDataSource).Name }));           
+            typeof(IDataReader).Namespace, typeof(TestDataSource).Namespace }));           
             stringBuilder.Append(Environment.NewLine);
             stringBuilder.Append($"IEnumerable<{dataSourceType.GetDisplayName()}> GetDataRows(TestDataSource dataSource, IDataReader dataReader)");
             stringBuilder.Append(Environment.NewLine);
@@ -88,6 +88,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
             stringBuilder.Append("\t dataReader.Initialize(dataSource.MetaData);");
             stringBuilder.Append(Environment.NewLine);
             stringBuilder.Append($"\t return dataReader.GetAllRowsAs<{dataSourceType.GetDisplayName()}>();");
+            stringBuilder.Append(Environment.NewLine);
             stringBuilder.Append("}");
             return stringBuilder.ToString();
         }       

--- a/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataRepository.cs
+++ b/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataRepository.cs
@@ -7,6 +7,7 @@ using Pixel.Automation.Editor.Core.Interfaces;
 using Pixel.Scripting.Editor.Core.Contracts;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
@@ -183,9 +184,8 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
         }
 
         private async void EditCsvDataSource(TestDataSource testDataSource)
-        {
-            var argumentTypeBrowser = typeBrowserFactory.CreateArgumentTypeBrowser();
-            TestDataSourceViewModel dataSourceViewModel = new TestDataSourceViewModel(this.windowManager, this.projectFileSystem, testDataSource, argumentTypeBrowser);
+        {            
+            TestDataSourceViewModel dataSourceViewModel = new TestDataSourceViewModel(this.windowManager, this.projectFileSystem, testDataSource);
             TestDataSourceBuilderViewModel testDataSourceBuilder = new TestDataSourceBuilderViewModel(new IStagedScreen[] { dataSourceViewModel });
             var result = await windowManager.ShowDialogAsync(testDataSourceBuilder);
             if (result.HasValue && result.Value)

--- a/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataSourceBuilderViewModel.cs
+++ b/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataSourceBuilderViewModel.cs
@@ -1,5 +1,4 @@
-﻿using Caliburn.Micro;
-using Pixel.Automation.Editor.Core;
+﻿using Pixel.Automation.Editor.Core;
 using System.Collections.Generic;
 
 namespace Pixel.Automation.TestData.Repository.ViewModels
@@ -8,7 +7,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
     {     
         public TestDataSourceBuilderViewModel(IEnumerable<IStagedScreen> stagedScreens)
         {
-            this.DisplayName = "Create new data source";
+            this.DisplayName = "Data Source Editor";
             this.stagedScreens.AddRange(stagedScreens);
         }     
     }

--- a/src/Pixel.Automation.TestData.Repository.Views/TestDataSourceBuilderView.xaml
+++ b/src/Pixel.Automation.TestData.Repository.Views/TestDataSourceBuilderView.xaml
@@ -8,7 +8,7 @@
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks" cal:Bind.AtDesignTime="True"
              xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro" 
              mc:Ignorable="d" ResizeMode="CanResizeWithGrip"  GlowBrush="{DynamicResource MahApps.Brushes.Accent}"
-             MinHeight="400" MaxWidth="800"
+             MinHeight="400" MaxWidth="800" WindowStartupLocation="CenterScreen"
              d:DesignHeight="450" d:DesignWidth="800">
     
     <controls:MetroWindow.Resources>

--- a/src/Pixel.Automation.TestData.Repository.Views/TestDataSourceView.xaml
+++ b/src/Pixel.Automation.TestData.Repository.Views/TestDataSourceView.xaml
@@ -9,38 +9,31 @@
              xmlns:cal="http://www.caliburnproject.org"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks" cal:Bind.AtDesignTime="True"
              xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
-             mc:Ignorable="d" 
+             xmlns:converters="clr-namespace:Pixel.Automation.Editor.Core.Converters;assembly=Pixel.Automation.Editor.Core"
+             mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
        
         <ResourceDictionary>
-           
+            <converters:InverseBooleanConverter x:Key="invBooleanConverter"/>
             <Thickness x:Key="ControlMargin">0 5 0 0</Thickness>           
             <Thickness x:Key="RowMargin">0 5 0 5</Thickness>
-            <Thickness x:Key="ButtonMargin">10 0 0 0</Thickness>
-
-            <Style x:Key="SelectDataTypeButtonStyle" TargetType="Button">
-                <Style.Triggers>
-                    <DataTrigger Binding="{Binding IsInEditMode}" Value="true">
-                        <Setter Property="IsEnabled" Value="False"/>
-                    </DataTrigger>
-                </Style.Triggers>
-            </Style>
-
+            <Thickness x:Key="ButtonMargin">0 0 0 0</Thickness>
             
             <DataTemplate DataType="{x:Type core:DataSourceConfiguration}">
                 <StackPanel Orientation="Horizontal"   DataContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ContentControl}}"
                             HorizontalAlignment="Stretch" VerticalAlignment="Center" MinWidth="320" Margin="{StaticResource RowMargin}">
-                    <Label Content="Data Type" DockPanel.Dock="Left" MinWidth="80"></Label>
-                    <TextBox DockPanel.Dock="Left" VerticalAlignment="Center"
-                         Text="{Binding TestDataType, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
-                         controls:TextBoxHelper.Watermark="Data Type" HorizontalAlignment="Stretch"
-                         controls:TextBoxHelper.UseFloatingWatermark="True"  MinWidth="660"                                                       
-                         ToolTip="Type of data model returned from this data source" />
-                    <Button x:Name="SelectTestDataType" Margin="{StaticResource ButtonMargin}" Height="26"                          
-                            cal:Message.Attach="[Event Click] = [Action SelectTestDataType()]"
-                            Style="{StaticResource SelectDataTypeButtonStyle}"
-                            Content="..." DockPanel.Dock="Right"/>
+                    <DockPanel LastChildFill="True" MinWidth="320" Margin="{StaticResource RowMargin}"  MaxHeight="38">
+                        <Label Content="Data Type" DockPanel.Dock="Left" MinWidth="80" VerticalAlignment="Center"></Label>                      
+                        <Button x:Name="SelectTestDataType" Margin="{StaticResource ButtonMargin}" Style="{DynamicResource VerticalDotsButtonStyle}"                          
+                            cal:Message.Attach="[Event Click] = [Action SelectTestDataType()]"                         
+                            DockPanel.Dock="Right" Width="16" />
+                        <TextBox DockPanel.Dock="Left" VerticalAlignment="Center" BorderThickness="1,1,0,1"
+                            Text="{Binding TestDataType, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
+                            controls:TextBoxHelper.Watermark="Data Type" HorizontalAlignment="Stretch"
+                            controls:TextBoxHelper.UseFloatingWatermark="True"  MinWidth="660"                                                       
+                            ToolTip="Type of data model returned from this data source" />
+                    </DockPanel>
                 </StackPanel>
 
             </DataTemplate>
@@ -48,39 +41,40 @@
             <DataTemplate DataType="{x:Type core:CsvDataSourceConfiguration}">
                 <StackPanel Orientation="Vertical"  DataContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ContentControl}}">
 
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Center" MinWidth="320" Margin="{StaticResource RowMargin}" >
-                        <Label Content="File" DockPanel.Dock="Left" MinWidth="80"></Label>
-                        <TextBox DockPanel.Dock="Left" VerticalAlignment="Center"
-                         Text="{Binding DataFileName, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
-                         controls:TextBoxHelper.Watermark="csv data file" HorizontalAlignment="Stretch"
-                         controls:TextBoxHelper.UseFloatingWatermark="True"  MinWidth="660"                                                     
-                         ToolTip="csv file containing data for" />
-                        <Button x:Name="BrowseForFile" Margin="{StaticResource ButtonMargin}" Height="26"                               
-                                cal:Message.Attach="[Event Click] = [Action BrowseForFile()]"
-                                Content="..."  DockPanel.Dock="Right"/>
-                    </StackPanel>
+                    <DockPanel LastChildFill="True" MinWidth="320" Margin="{StaticResource RowMargin}" MaxHeight="38">
+                        <Label Content="File" DockPanel.Dock="Left" MinWidth="80" VerticalAlignment="Center" ></Label>
+                        <Button x:Name="BrowseForFile" Margin="{StaticResource ButtonMargin}" Style="{DynamicResource VerticalDotsButtonStyle}"                               
+                                cal:Message.Attach="[Event Click] = [Action BrowseForFile()]" VerticalAlignment="Center"
+                                DockPanel.Dock="Right" Width="16" />
+                        <TextBox DockPanel.Dock="Left" VerticalAlignment="Center" BorderThickness="1,1,0,1"
+                            Text="{Binding DataFileName, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
+                            controls:TextBoxHelper.Watermark="csv data file" HorizontalAlignment="Stretch"
+                            controls:TextBoxHelper.UseFloatingWatermark="True"  MinWidth="660"                                                     
+                            ToolTip="csv file containing data for" />
+                    </DockPanel>
 
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Center" MinWidth="320" Margin="{StaticResource RowMargin}" >
-                        <Label Content="Delimiter" DockPanel.Dock="Left" MinWidth="80"></Label>
+                    <DockPanel LastChildFill="True" MinWidth="320" Margin="{StaticResource RowMargin}"  MaxHeight="38">
+                        <Label Content="Delimiter" DockPanel.Dock="Left" MinWidth="80" VerticalAlignment="Center"></Label>
                         <TextBox DockPanel.Dock="Left" VerticalAlignment="Center"
-                         Text="{Binding Delimiter, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
-                         controls:TextBoxHelper.Watermark="Delimiter" HorizontalAlignment="Stretch"
-                         controls:TextBoxHelper.UseFloatingWatermark="True"  MinWidth="660"                                                     
-                         ToolTip="Delimiter used in csv file" />                     
-                    </StackPanel>
+                            Text="{Binding Delimiter, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
+                            controls:TextBoxHelper.Watermark="Delimiter" HorizontalAlignment="Stretch"
+                            controls:TextBoxHelper.UseFloatingWatermark="True"  MinWidth="660"                                                     
+                            ToolTip="Delimiter used in csv file" />                     
+                    </DockPanel>
 
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Center" MinWidth="320" Margin="{StaticResource RowMargin}" >
-                        <Label Content="Data Type" DockPanel.Dock="Left" MinWidth="80"></Label>
-                        <TextBox DockPanel.Dock="Left" VerticalAlignment="Center" IsReadOnly="True"
-                         Text="{Binding TestDataType, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
-                         controls:TextBoxHelper.Watermark="Data Type" HorizontalAlignment="Stretch"
-                         controls:TextBoxHelper.UseFloatingWatermark="True"  MinWidth="660"                                                            
-                         ToolTip="Type of data model returned from this data source" />
-                        <Button x:Name="SelectTestDataType" Margin="{StaticResource ButtonMargin}" Height="26"                            
+                    <DockPanel LastChildFill="True" MinWidth="320" Margin="{StaticResource RowMargin}"  MaxHeight="38">
+                        <Label Content="Data Type" DockPanel.Dock="Left" MinWidth="80" VerticalAlignment="Center"></Label>                        
+                        <Button x:Name="SelectTestDataType" Margin="{StaticResource ButtonMargin}" VerticalAlignment="Center"                            
                                 cal:Message.Attach="[Event Click] = [Action SelectTestDataType()]" 
-                                Style="{StaticResource SelectDataTypeButtonStyle}"
-                                Content="..." DockPanel.Dock="Right"/>
-                    </StackPanel>
+                                Style="{DynamicResource VerticalDotsButtonStyle}"
+                                DockPanel.Dock="Right" Width="16"/>
+                        <TextBox DockPanel.Dock="Left" VerticalAlignment="Center" IsReadOnly="True" BorderThickness="1,1,0,1"
+                            Text="{Binding TestDataType, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
+                            controls:TextBoxHelper.Watermark="Data Type" HorizontalAlignment="Stretch"
+                            controls:TextBoxHelper.UseFloatingWatermark="True"  MinWidth="660"        
+                            IsEnabled="{Binding IsInEditMode, Converter={StaticResource invBooleanConverter}}"     
+                            ToolTip="Type of data model returned from this data source" />
+                    </DockPanel>
 
                 </StackPanel>
             </DataTemplate>
@@ -94,10 +88,10 @@
         <StackPanel Orientation="Vertical" Margin="10" VerticalAlignment="Top">
 
             <DockPanel LastChildFill="True" MinWidth="320" Margin="{StaticResource RowMargin}">
-                <Label Content="Name" MinWidth="80" DockPanel.Dock="Left" ></Label>
+                <Label Content="Name" MinWidth="80" DockPanel.Dock="Left" VerticalAlignment="Center"></Label>
                 <TextBox DockPanel.Dock="Right" Margin="{StaticResource ControlMargin}" VerticalAlignment="Center"
                          Text="{Binding Name, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
-                         IsReadOnly="{Binding IsInEditMode}"
+                         IsEnabled="{Binding IsInEditMode, Converter={StaticResource invBooleanConverter}}"
                          controls:TextBoxHelper.Watermark="Data Source Name"
                          controls:TextBoxHelper.UseFloatingWatermark="True"                                                         
                          ToolTip="Data source name. It should be a valid C# class name." />

--- a/src/Unit.Tests/Pixel.Automation.RunTime.Tests/DataSourceReaderTests.cs
+++ b/src/Unit.Tests/Pixel.Automation.RunTime.Tests/DataSourceReaderTests.cs
@@ -52,10 +52,18 @@ namespace Pixel.Automation.RunTime.Tests
         [Test]
         public void ValidateThatCsvDataSourceCanBeLoaded()
         {
-            var testDataSource = new TestDataSource() { DataSource = DataSource.CsvFile };
+            var testDataSource = new TestDataSource() 
+            { 
+                DataSource = DataSource.CsvFile,
+                MetaData = new CsvDataSourceConfiguration()
+                {
+                    TargetFile = "CsvFile.csv"
+                }
+            };
 
             var fileSystem = Substitute.For<IProjectFileSystem>();
             fileSystem.TestCaseRepository.Returns(Environment.CurrentDirectory);
+            fileSystem.TestDataRepository.Returns(Environment.CurrentDirectory);
             fileSystem.Exists(Arg.Any<string>()).Returns(true);
 
             var serializer = Substitute.For<ISerializer>();


### PR DESCRIPTION
**Description**
Test cases require test data source. Currently, test data source can be coded i.e. data is defined in a script file or it can come from a csv file. Test data source is linked to a test case at design time. However, we want to have a way such that same data source can point to different script files or csv files dynamically. This will enable running test cases with different data dynamically without modifying the data source. For ex: We can have a rigorous testing with lots of data or want to do a quick run with few important cases only. 

**How**
Take an example of a coded data source that points to TestData.csx as configured at design time. Add another script file called TestData.small.csx in to TestDataRepository folder for the project besides TestData.csx. There is a variable **dataSourceSuffix** available in initialization script which can be used to control which of these files is picked by the test data source. If the dataSourceSuffix is empty, it picks TestData.csx , however, if dataSourceSuffix is set to small , test data source will use TestData.small.csx. Same goes for a csv file data source. If suffixed source is not available , default source is used. 

**RunTime**
Test runner can receive a custom initialization script as one of the parameters. We can have multiple initialization scripts with different values of dataSourceSuffix. Pass the desired intialization script to control the data source.