### PR TITLE
Don't allow certain entities to be deleted.

### DIFF
--- a/src/Pixel.Automation.Core.Components/Entities/ApplicationPoolEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Entities/ApplicationPoolEntity.cs
@@ -1,12 +1,10 @@
-﻿using Pixel.Automation.Core.Attributes;
-using System;
+﻿using System;
 using System.Runtime.Serialization;
 
 namespace Pixel.Automation.Core.Components
 {
     [DataContract]
-    [Serializable]
-    [ToolBoxItem("Application Pool", "Core Entities", iconSource: null, description: "Represents an application pool", tags: new string[] { "Application Pool" })]
+    [Serializable]   
     public class ApplicationPoolEntity : Entity
     {
         public ApplicationPoolEntity() : base("Application Pool", "ApplicationPoolEntity")

--- a/src/Pixel.Automation.Core.Components/Entities/ProcessRootEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Entities/ProcessRootEntity.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Core.Components.Entities
+{
+    [DataContract]
+    [Serializable]
+    public class  ProcessRootEntity : Entity
+    {
+        public ProcessRootEntity() : base("Automation Process", "RootEntity")
+        {
+
+        }
+    }
+}

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -1,6 +1,7 @@
 ﻿using Dawn;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Components;
+using Pixel.Automation.Core.Components.Entities;
 using Pixel.Automation.Core.Components.TestCase;
 using Pixel.Automation.Core.Enums;
 using Pixel.Automation.Core.Interfaces;
@@ -99,7 +100,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             logger.Information($"Loading project file for {this.GetProjectName()} now");
             if (!File.Exists(this.projectFileSystem.ProcessFile))
             {
-                this.RootEntity = new Entity("Automation Process", "Root");
+                this.RootEntity = new ProcessRootEntity();
             }
             else
             {

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -1,6 +1,7 @@
 ﻿using Dawn;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Components;
+using Pixel.Automation.Core.Components.Entities;
 using Pixel.Automation.Core.Components.Processors;
 using Pixel.Automation.Core.Components.Sequences;
 using Pixel.Automation.Core.Interfaces;
@@ -76,7 +77,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             }
             else
             {
-                templateRoot = new Entity("Automation Process", "Root");
+                templateRoot = new ProcessRootEntity();
                 templateRoot.EntityManager = entityManager;
 
                 ApplicationPoolEntity appPoolEntity = new ApplicationPoolEntity();

--- a/src/Pixel.Automation.Designer.Views/Resources/Component.Templates.Common.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Component.Templates.Common.xaml
@@ -10,77 +10,7 @@
     <HierarchicalDataTemplate x:Key="EmptyTemplate" ItemsSource="{Binding ComponentCollection}">
 
     </HierarchicalDataTemplate>
-
-    <DataTemplate x:Key="HttpRequest">
-        <Border x:Name="brdContainer"  BorderThickness="2" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"
-                HorizontalAlignment="Stretch" Margin="0,4,0,4"
-                Width="200" Height="60" Background="{DynamicResource MahApps.Brushes.Control.Background}">
-            <Grid IsHitTestVisible="True">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="6*"></RowDefinition>
-                    <RowDefinition Height="4*"></RowDefinition>
-                </Grid.RowDefinitions>
-                <Label  BorderThickness="1" Content="{Binding Name}" Padding="10,10,0,0" MinWidth="180" Height="60" HorizontalAlignment="Stretch"
-                       VerticalAlignment="Top" Grid.Row="0" FontFamily="Segoe UI" FontSize="12"/>
-                <StackPanel x:Name="pnlActions" Orientation="Horizontal" Grid.Row="1"  IsHitTestVisible="True"  HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                    <Button Style="{StaticResource LinkButton}" x:Name="btnDeleteComponent"  HorizontalAlignment="Left" VerticalAlignment="Center" Content="Delete" FontSize="10"
-                    FontWeight="Normal"  cal:Message.Attach="[Event Click] = [Action DeleteComponent($dataContext)]" Visibility="Hidden"  />
-                    <Button Style="{StaticResource LinkButton}" x:Name="btnRunComponent" HorizontalAlignment="Left" VerticalAlignment="Center"  FontWeight="Normal" 
-                           cal:Message.Attach="[Event Click] = [Action RunComponent($dataContext)]" Content="Run" FontSize="10" Visibility="Hidden"/>
-                    <Button Style="{StaticResource LinkButton}" x:Name="btnConfigure" HorizontalAlignment="Left" VerticalAlignment="Center"  FontWeight="Normal" 
-                           cal:Message.Attach="[Event Click] = [Action ConfigureRequest()]" Content="Configure" FontSize="10" Visibility="Hidden"/>
-                </StackPanel>
-            </Grid>
-        </Border>
-        <DataTemplate.Triggers>
-            <Trigger Property="IsMouseOver"  Value="true">
-                <Setter TargetName="btnDeleteComponent"  Property="Visibility" Value="Visible"/>
-                <Setter TargetName="btnRunComponent"  Property="Visibility" Value="Visible"/>
-                <Setter TargetName="btnConfigure"  Property="Visibility" Value="Visible"/>
-            </Trigger>
-            <DataTrigger Binding="{Binding IsExecuting}" Value="true">
-                <Setter TargetName="brdContainer" Property="BorderBrush" Value="Green"></Setter>
-            </DataTrigger>
-            <DataTrigger Binding="{Binding IsFaulted}" Value="true">
-                <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
-            </DataTrigger>
-            <DataTrigger Binding="{Binding IsValid}" Value="false">
-                <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
-            </DataTrigger>
-            <DataTrigger Binding="{Binding IsEnabled}" Value="false">
-                <Setter TargetName="brdContainer" Property="BorderBrush" Value="Gray"></Setter>
-            </DataTrigger>
-            <DataTrigger Binding="{Binding
-                            RelativeSource={RelativeSource
-                                Mode=FindAncestor,
-                                AncestorType={x:Type TreeViewItem}},
-                                Path=IsSelected}" Value="True">
-                <Setter TargetName="brdContainer" Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.AccentBase}"/>
-            </DataTrigger>
-        </DataTemplate.Triggers>
-    </DataTemplate>
-
-    <DataTemplate x:Key="TextInput">
-        <GroupBox BorderBrush="{DynamicResource MahApps.Brushes.Accent}"  Style="{StaticResource GroupBoxHeaderWithDelete}" Padding="10"
-                                  BorderThickness="2" Grid.Column="1" MinWidth="200" Width="Auto" MinHeight="60">
-            <TextBox Text="{Binding InputValue,Mode=TwoWay , UpdateSourceTrigger=PropertyChanged}"  HorizontalAlignment="Stretch" VerticalAlignment="Stretch"></TextBox>
-        </GroupBox>
-    </DataTemplate>
-
-    <DataTemplate x:Key="MultiInput">
-        <GroupBox BorderBrush="{DynamicResource MahApps.Brushes.Accent}"  Style="{StaticResource GroupBoxHeaderWithDelete}" Padding="10"
-                                  BorderThickness="2" Grid.Column="1" MinWidth="200" Width="Auto" MinHeight="60">
-            <ComboBox ItemsSource="{Binding InputValues,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsEditable="True"></ComboBox>
-        </GroupBox>
-    </DataTemplate>
-
-    <DataTemplate x:Key="MultiOutput">
-        <GroupBox BorderBrush="{DynamicResource MahApps.Brushes.Accent}"  Style="{StaticResource GroupBoxHeaderWithDelete}" Padding="10"
-                                  BorderThickness="2" Grid.Column="1" MinWidth="200" Width="Auto" MinHeight="60">
-            <ComboBox ItemsSource="{Binding ExtractedValues}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsEditable="True"></ComboBox>
-        </GroupBox>
-    </DataTemplate>
-
+   
     <Style x:Key="ExpandCollapseToggleStyle" TargetType="ToggleButton">
         <Setter Property="Focusable" Value="False"/>
         <Setter Property="Template">

--- a/src/Pixel.Automation.Designer.Views/Resources/Component.Templates.Slim.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Component.Templates.Slim.xaml
@@ -17,8 +17,8 @@
     <iconPacks:PackIconFontAwesome x:Key="ChromeIcon"  Kind="ChromeBrands" Foreground="{DynamicResource MahApps.Brushes.Accent}" 
                                            Background="{DynamicResource MahApps.Brushes.Control.Background}"/>
     <iconPacks:PackIconFontAwesome x:Key="EdgeIcon"  Kind="EdgeBrands" Foreground="{DynamicResource MahApps.Brushes.Accent}" 
-                                           Background="{DynamicResource MahApps.Brushes.Control.Background}"/>
-
+                                           Background="{DynamicResource MahApps.Brushes.Control.Background}"/>  
+    
     <HierarchicalDataTemplate x:Key="Entity" ItemsSource="{Binding ComponentCollection}">
         <Border x:Name="brdContainer"  BorderThickness="2" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"
                 HorizontalAlignment="Stretch" Margin="0,4,0,4" MinWidth="220" dd:DragDrop.IsDragSource="True"
@@ -39,6 +39,44 @@
                       Style="{DynamicResource EditControlButtonStyle}" ToolTip="Delete"  Content="{iconPacks:Material CloseCircleOutline}"/>
                 </StackPanel>
 
+            </DockPanel>
+        </Border>
+        <HierarchicalDataTemplate.Triggers>
+            <Trigger Property="IsMouseOver"  Value="true">
+                <Setter TargetName="pnlActions"  Property="Visibility" Value="Visible"/>
+            </Trigger>
+            <DataTrigger Binding="{Binding IsValid}" Value="false">
+                <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+                <Setter TargetName="brdContainer" Property="BorderBrush" Value="Gray"></Setter>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding
+                            RelativeSource={RelativeSource
+                                Mode=FindAncestor,
+                                AncestorType={x:Type TreeViewItem}},
+                                Path=IsSelected}" Value="True">
+                <Setter TargetName="brdContainer" Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.AccentBase}"/>
+            </DataTrigger>
+        </HierarchicalDataTemplate.Triggers>
+    </HierarchicalDataTemplate>
+
+    <HierarchicalDataTemplate x:Key="EntityNoDelete" ItemsSource="{Binding ComponentCollection}">
+        <Border x:Name="brdContainer"  BorderThickness="2" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"
+                HorizontalAlignment="Stretch" Margin="0,4,0,4" MinWidth="220" dd:DragDrop.IsDragSource="True"
+                Background="{DynamicResource MahApps.Brushes.Control.Background}">
+            <DockPanel Grid.Row="0" LastChildFill="True" Margin="4" Width="Auto" HorizontalAlignment="Stretch"
+                      IsHitTestVisible="True">
+                <Label DockPanel.Dock="Left"  Content="{Binding Name}" MaxWidth="160" 
+                       HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
+                            HorizontalAlignment="Right" Orientation="Horizontal">
+                    <Button x:Name="btnDrillIn" Margin="0,0,2,0" HorizontalAlignment="Right" 
+                                            Height="20" Width="20" ToolTip="Drill In"
+                                            cal:Message.Attach="[Event Click] = [Action ZoomInToEntity($dataContext)]"                   
+                                            Style="{DynamicResource EditControlButtonStyle}"
+                                            Content="{iconPacks:MaterialLight ArrangeBringForward}"/>                   
+                </StackPanel>
             </DockPanel>
         </Border>
         <HierarchicalDataTemplate.Triggers>
@@ -312,7 +350,6 @@
         </DataTemplate.Triggers>
     </HierarchicalDataTemplate>
 
-
     <HierarchicalDataTemplate x:Key="SequenceTemplate"  ItemsSource="{Binding ComponentCollection}">
         <DockPanel LastChildFill="True" Width="Auto" HorizontalAlignment="Stretch" MinWidth="220" Margin="0,4,0,4" 
                    Background="{DynamicResource MahApps.Brushes.Control.Background}" IsHitTestVisible="True">
@@ -382,42 +419,7 @@
             </DataTrigger>
         </DataTemplate.Triggers>       
     </HierarchicalDataTemplate>
-    
-    <!--<HierarchicalDataTemplate x:Key="GroupedTemplate" ItemsSource="{Binding ComponentCollection}">
-        <Border x:Name="brdContainer"  BorderThickness="2" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"
-                HorizontalAlignment="Stretch" Margin="4" MinWidth="200" dd:DragDrop.IsDragSource="True"
-                Background="{DynamicResource MahApps.Brushes.Control.Background}">
-            <DockPanel Grid.Row="0" LastChildFill="True" Margin="4" Width="Auto" HorizontalAlignment="Stretch"
-                      IsHitTestVisible="True">
-
-                <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
-
-                <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
-                            HorizontalAlignment="Right" Orientation="Horizontal">
-                    <Button x:Name="Run" Margin="0,0,2,0" HorizontalAlignment="Right" 
-                            Height="20" Width="20" ToolTip="Run"
-                            cal:Message.Attach="[Action RunComponent($dataContext)]"                   
-                            Style="{DynamicResource EditControlButtonStyle}"
-                            Content="{iconPacks:MaterialLight Play}"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-        <HierarchicalDataTemplate.Triggers>
-            <Trigger Property="IsMouseOver"  Value="true">
-                <Setter TargetName="pnlActions"  Property="Visibility" Value="Visible"/>
-            </Trigger>        
-            <DataTrigger Binding="{Binding IsFaulted}" Value="true">
-                <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
-            </DataTrigger>
-            <DataTrigger Binding="{Binding IsValid}" Value="false">
-                <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
-            </DataTrigger>
-            <DataTrigger Binding="{Binding IsEnabled}" Value="false">
-                <Setter TargetName="brdContainer" Property="BorderBrush" Value="Gray"></Setter>
-            </DataTrigger>         
-        </HierarchicalDataTemplate.Triggers>
-    </HierarchicalDataTemplate>-->
-
+  
     <Style TargetType="TreeViewItem" x:Key="GroupedStyle">
         <Setter Property="IsExpanded" Value="True"/>
         <Setter Property="Template">

--- a/src/Pixel.Automation.Designer.Views/Resources/TemplateMapping.xml
+++ b/src/Pixel.Automation.Designer.Views/Resources/TemplateMapping.xml
@@ -1,12 +1,47 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ArrayOfComponentTemplate xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.datacontract.org/2004/07/Pixel.Automation.Designer.Views">
-  <!--<ComponentTemplate>
+ 
+  <ComponentTemplate>
+    <Name>ProcessRootEntity</Name>
+    <DataTemplateKey>EntityNoDelete</DataTemplateKey>
+    <StyleKey>DefaultStyle</StyleKey>
+  </ComponentTemplate>
+  <ComponentTemplate>
     <Name>ApplicationPoolEntity</Name>
-    <DataTemplateKey>EmptyTemplate</DataTemplateKey>
-    <StyleKey>ContainerStyleHorizontal</StyleKey>
-  </ComponentTemplate>-->
+    <DataTemplateKey>EntityNoDelete</DataTemplateKey>
+    <StyleKey>DefaultStyle</StyleKey>
+  </ComponentTemplate>
+  <ComponentTemplate>
+    <Name>OneTimeSetUpEntity</Name>
+    <DataTemplateKey>EntityNoDelete</DataTemplateKey>
+    <StyleKey>DefaultStyle</StyleKey>
+  </ComponentTemplate>
+  <ComponentTemplate>
+    <Name>OneTimeTearDownEntity</Name>
+    <DataTemplateKey>EntityNoDelete</DataTemplateKey>
+    <StyleKey>DefaultStyle</StyleKey>
+  </ComponentTemplate>
+  <ComponentTemplate>
+    <Name>SetUpEntity</Name>
+    <DataTemplateKey>EntityNoDelete</DataTemplateKey>
+    <StyleKey>DefaultStyle</StyleKey>
+  </ComponentTemplate>
+  <ComponentTemplate>
+    <Name>TearDownEntity</Name>
+    <DataTemplateKey>EntityNoDelete</DataTemplateKey>
+    <StyleKey>DefaultStyle</StyleKey>
+  </ComponentTemplate>
+  <ComponentTemplate>
+    <Name>TestFixtureEntity</Name>
+    <DataTemplateKey>EntityNoDelete</DataTemplateKey>
+    <StyleKey>DefaultStyle</StyleKey>
+  </ComponentTemplate>
+  <ComponentTemplate>
+    <Name>TestCaseEntity</Name>
+    <DataTemplateKey>EntityNoDelete</DataTemplateKey>
+    <StyleKey>DefaultStyle</StyleKey>
+  </ComponentTemplate>
   
-  <!--Sequences-->
   <ComponentTemplate>
     <Name>SequenceEntity</Name>
     <DataTemplateKey>SequenceTemplate</DataTemplateKey>

--- a/src/Pixel.Automation.RunTime/TestRunner.cs
+++ b/src/Pixel.Automation.RunTime/TestRunner.cs
@@ -128,10 +128,13 @@ namespace Pixel.Automation.RunTime
                 scriptEngine.ClearState();
                 await scriptEngine.ExecuteFileAsync(fixture.ScriptFile);
 
-                var oneTimeSetupEntity = fixture.TestFixtureEntity.GetFirstComponentOfType<OneTimeSetUpEntity>(Core.Enums.SearchScope.Children);
-                oneTimeSetupEntity.ResetHierarchy();
-                await ProcessEntity(oneTimeSetupEntity);
-              
+                var oneTimeSetupEntity = fixture.TestFixtureEntity.GetFirstComponentOfType<OneTimeSetUpEntity>(Core.Enums.SearchScope.Children, false);
+                if (oneTimeSetupEntity != null)
+                {
+                    oneTimeSetupEntity.ResetHierarchy();
+                    await ProcessEntity(oneTimeSetupEntity);                   
+                }
+
                 logger.Information("One time setup completed for fixture : {0}", fixture);
 
             }
@@ -148,9 +151,12 @@ namespace Pixel.Automation.RunTime
             {
                 logger.Information("Performing one time teardown for fixture : {0}", fixture);
 
-                var oneTimeTearDownEntity = fixture.TestFixtureEntity.GetFirstComponentOfType<OneTimeTearDownEntity>(Core.Enums.SearchScope.Children);
-                oneTimeTearDownEntity.ResetHierarchy();
-                await ProcessEntity(oneTimeTearDownEntity);
+                var oneTimeTearDownEntity = fixture.TestFixtureEntity.GetFirstComponentOfType<OneTimeTearDownEntity>(Core.Enums.SearchScope.Children, false);
+                if(oneTimeTearDownEntity != null)
+                {
+                    oneTimeTearDownEntity.ResetHierarchy();
+                    await ProcessEntity(oneTimeTearDownEntity);
+                }              
              
                 IScriptEngine scriptEngine = fixture.TestFixtureEntity.EntityManager.GetScriptEngine();
                 scriptEngine.ClearState();
@@ -212,9 +218,12 @@ namespace Pixel.Automation.RunTime
 
                                 await testScriptEngine.ExecuteFileAsync(testCase.ScriptFile);
 
-                                var setupEntity = fixtureEntity.GetFirstComponentOfType<SetUpEntity>(Core.Enums.SearchScope.Children);
-                                setupEntity.ResetHierarchy();
-                                await ProcessEntity(setupEntity);
+                                var setupEntity = fixtureEntity.GetFirstComponentOfType<SetUpEntity>(Core.Enums.SearchScope.Children, false);
+                                if(setupEntity != null)
+                                {
+                                    setupEntity.ResetHierarchy();
+                                    await ProcessEntity(setupEntity);
+                                }                             
                             }
                             catch
                             {
@@ -237,9 +246,12 @@ namespace Pixel.Automation.RunTime
                         {
                             try
                             {
-                                var teartDownEntity = fixtureEntity.GetFirstComponentOfType<TearDownEntity>(Core.Enums.SearchScope.Children);
-                                teartDownEntity.ResetHierarchy();
-                                await ProcessEntity(teartDownEntity);
+                                var teartDownEntity = fixtureEntity.GetFirstComponentOfType<TearDownEntity>(Core.Enums.SearchScope.Children, false);
+                                if(teartDownEntity != null)
+                                {
+                                    teartDownEntity.ResetHierarchy();
+                                    await ProcessEntity(teartDownEntity);
+                                }                              
 
                                 //copy the fixture variable values back to fixture script engine so that following tests see modified values of these variable
                                 foreach (var variable in fixtureScriptEngine.GetScriptVariables())


### PR DESCRIPTION
**Description**
It is currently possible to delete all the entities from the automation process including the root itself.
It should not be possible to delete certain entities which can't be added back from component toolbox.

**Change**
Defined a new template without delete button for entities. Mapped certain entities like ProcessRootEntity, SetupEntity, TearDownEntity, OneTimeSetupEntity, OneTimeTearDownEntity, TestFixtureEntity and TestCaseEntity to use this template without delete button.

