### PR TITLE
Allow adding and editing tags for Test Fixtures and Test Cases 

### DIFF
--- a/src/Pixel.Automation.Core/TestData/Tag.cs
+++ b/src/Pixel.Automation.Core/TestData/Tag.cs
@@ -1,5 +1,6 @@
 ﻿using Dawn;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -10,16 +11,23 @@ namespace Pixel.Automation.Core.TestData
     [Serializable]
     public class Tag
     {
+        [DataMember]
         public string Key { get; set; }
 
+        [DataMember]
         public string Value { get; set; }
     }
 
     [DataContract]
     [Serializable]
-    public class TagCollection
+    public class TagCollection : ICollection<Tag>
     {
-        public List<Tag> Tags { get; } = new List<Tag>();
+        [DataMember]
+        public List<Tag> Tags { get; set; } = new List<Tag>();
+
+        public int Count => this.Tags.Count;
+
+        public bool IsReadOnly => false;
 
         public string this[string key]
         {
@@ -30,7 +38,7 @@ namespace Pixel.Automation.Core.TestData
             }
             set
             {
-                AddTag(key, value);
+                Add(key, value);
             }
         }
 
@@ -45,7 +53,7 @@ namespace Pixel.Automation.Core.TestData
             this.Tags.AddRange(tags);
         }
 
-        public void AddTag(string key, string value)
+        public void Add(string key, string value)
         {
             var tag = this.Tags.FirstOrDefault(t => t.Key.Equals(key));
             if (tag != null)
@@ -56,7 +64,7 @@ namespace Pixel.Automation.Core.TestData
             this.Tags.Add(new Tag() { Key = key, Value = value });
         }
 
-        public void DeleteTag(string key)
+        public void Delete(string key)
         {
             var tag = this.Tags.FirstOrDefault(t => t.Key.Equals(key));
             if (tag != null)
@@ -65,9 +73,49 @@ namespace Pixel.Automation.Core.TestData
             }
         }
 
-        public bool HasTag(string key)
+        public bool Contains(string key)
         {
             return this.Tags.Any(t => t.Key.Equals(key));
+        }
+
+        public void Clear()
+        {
+            this.Tags.Clear();
+        }
+
+        public IEnumerator<Tag> GetEnumerator()
+        {
+            return this.Tags.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.Tags.GetEnumerator();
+        }
+
+        public void Add(Tag item)
+        {
+            Guard.Argument(item).NotNull();
+            this.Tags.Add(item);
+        }
+
+        public bool Contains(Tag item)
+        {
+            return this.Tags.Contains(item);
+        }
+
+        public void CopyTo(Tag[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Remove(Tag item)
+        {
+            if(Contains(item))
+            {
+                return this.Tags.Remove(item);                
+            }
+            return false;
         }
     }
 }

--- a/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
@@ -303,6 +303,18 @@
         </Setter>
     </Style>
 
+    <Style x:Key="StackPanelWithoutErrorTemplateStyle" TargetType="{x:Type StackPanel}">
+        <Style.Setters>
+            <Setter Property="Validation.ErrorTemplate">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <AdornedElementPlaceholder></AdornedElementPlaceholder>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style.Setters>
+    </Style>
+    
     <Style x:Key="ModelErrorStyle" TargetType="{x:Type ItemsControl}">
         <Setter Property="ItemTemplate">
             <Setter.Value>

--- a/src/Pixel.Automation.Editor.Core/SmartScreen.cs
+++ b/src/Pixel.Automation.Editor.Core/SmartScreen.cs
@@ -14,22 +14,13 @@ namespace Pixel.Automation.Editor.Core
 
         protected Dictionary<string, List<string>> propertyErrors = new Dictionary<string, List<string>>();
         
-        public bool HasErrors
-        {
-            get
-            {
-                return propertyErrors.Count() > 0;
-            }
-        }
-    
-        public bool ShowModelErrors
-        {
-            get => HasErrors && propertyErrors.ContainsKey("") && propertyErrors[""].Count() > 0;           
-        }
+        public bool HasErrors => propertyErrors.Count() > 0;
 
-        public void DismissModelErrors()
+        public virtual bool ShowModelErrors => HasErrors && propertyErrors.ContainsKey("") && propertyErrors[""].Count() > 0;
+
+        public virtual void DismissModelErrors()
         {
-            propertyErrors.Remove("");
+            ClearErrors("");
             NotifyOfPropertyChange(() => ShowModelErrors);
         }
 
@@ -59,6 +50,18 @@ namespace Pixel.Automation.Editor.Core
             NotifyOfPropertyChange(() => ShowModelErrors);
         }
 
+
+        protected virtual void AddOrAppendErrors(string propertyName, IEnumerable<string> errors)
+        {
+            if (!propertyErrors.ContainsKey(propertyName))
+            {
+                propertyErrors.Add(propertyName, new List<string>());
+            }
+            var existingErrors = propertyErrors[propertyName];         
+            existingErrors.AddRange(errors);
+            OnErrorsChanged(propertyName);
+            NotifyOfPropertyChange(() => ShowModelErrors);
+        }
 
         protected virtual void ClearErrors(string propertyName)
         {

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TagCollectionViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TagCollectionViewModel.cs
@@ -1,0 +1,102 @@
+﻿using Caliburn.Micro;
+using Dawn;
+using Pixel.Automation.Core.TestData;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Pixel.Automation.TestExplorer.ViewModels
+{
+    public class TagCollectionViewModel : PropertyChangedBase
+    {
+        public ObservableCollection<TagViewModel> Tags { get; private set; } = new ObservableCollection<TagViewModel>();
+
+        private TagViewModel selectedTag;
+        public TagViewModel SelectedTag
+        {
+            get => selectedTag;
+            set
+            {
+                selectedTag = value;
+                NotifyOfPropertyChange(() => SelectedTag);
+                NotifyOfPropertyChange(() => CanEdit);
+                NotifyOfPropertyChange(() => CanDelete);
+            }
+        }
+
+        private bool hasErrors;
+        public bool HasErrors
+        {
+            get => hasErrors;
+            set
+            {
+                hasErrors = value;
+                NotifyOfPropertyChange(() => HasErrors);
+            }
+        }
+
+        public TagCollectionViewModel()
+        {
+
+        }
+
+        public void AddNew()
+        {
+            var newTag = new TagViewModel(new Tag()) { IsEditing = true };
+            Add(newTag);
+            SelectedTag = newTag;
+        }
+
+        public bool CanEdit
+        {
+            get => this.SelectedTag != null && !this.Tags.Any(t => t.IsEditing);
+        }
+
+        public void EditSelected()
+        {
+            this.SelectedTag?.Edit();
+        }
+
+        public bool CanDelete
+        {
+            get => this.SelectedTag != null;
+        }
+
+        public void DeleteSelected()
+        {
+            if (this.SelectedTag != null)
+            {
+                this.SelectedTag.Delete();           
+                this.Tags.Remove(this.SelectedTag);
+                this.SelectedTag = null;
+            }
+        }
+
+        public void Add(TagViewModel item)
+        {
+            Guard.Argument(item).NotNull();
+            this.Tags.Add(item);
+        }
+
+        public bool Validate(out List<string> validationErrors)
+        {
+            validationErrors = new List<string>();
+            if (this.Tags.Any(t => !t.IsValid()))
+            {
+                validationErrors.Add("All tags must have a key and value.");
+            }
+            if (this.Tags.Any(t => t.IsEditing))
+            {
+                validationErrors.Add("All tags open for edit must be saved.");
+            }
+            if (this.Tags.Select(t => t.Key).Distinct().Count() < this.Tags.Count)
+            {
+                validationErrors.Add("Tag keys must be unique");
+            }
+            HasErrors = !validationErrors.Any();
+            return HasErrors;
+        }
+
+    }
+
+}

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TagViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TagViewModel.cs
@@ -1,0 +1,85 @@
+﻿using Caliburn.Micro;
+using Pixel.Automation.Core.TestData;
+using Pixel.Automation.Editor.Core;
+using System;
+using System.Windows.Input;
+
+namespace Pixel.Automation.TestExplorer.ViewModels
+{
+    public class TagViewModel : PropertyChangedBase
+    {
+        private readonly Tag tag;
+
+        public string Key { get; set; }
+
+        public string Value { get; set; }
+
+        private bool isDeleted;
+        public bool IsDeleted
+        {
+            get => isDeleted;
+            set
+            {
+                isDeleted = value;
+                NotifyOfPropertyChange(() => IsDeleted);
+            }
+        }
+
+        private bool isEditing;
+        public bool IsEditing
+        {
+            get => isEditing;
+            set
+            {
+                isEditing = value;
+                NotifyOfPropertyChange(() => IsEditing);
+            }
+        }
+
+        private ICommand saveCommand;
+        public ICommand SaveCommand
+        {
+            get { return saveCommand ?? (saveCommand = new RelayCommand<bool>(p => Save(), p => true)); }
+        }
+
+
+        public TagViewModel(Tag tag)
+        {
+            this.tag = tag;
+            this.Key = tag.Key;
+            this.Value = tag.Value;
+        }
+
+        public void Edit()
+        {
+            IsEditing = true;
+        }
+
+        public void Delete()
+        {
+            IsDeleted = true;
+            IsEditing = false;
+            NotifyOfPropertyChange(() => IsDeleted);
+        }
+
+        public void Save()
+        {
+            if (!string.IsNullOrEmpty(this.Key) && !string.IsNullOrEmpty(this.Value))
+            {
+                this.tag.Key = this.Key;
+                this.tag.Value = this.Value;
+                IsEditing = false;
+            }
+        }
+
+        public bool IsValid()
+        {
+            return !string.IsNullOrEmpty(this.Key) && !string.IsNullOrEmpty(this.Value);
+        }
+
+        public override string ToString()
+        {
+            return $"{Key ?? String.Empty} : {Value ?? String.Empty}";
+        }
+    }
+}

--- a/src/Pixel.Automation.TestExplorer.Views/EditTestCaseView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/EditTestCaseView.xaml
@@ -15,11 +15,17 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <controls:MetroWindow.Resources>
-        <Thickness x:Key="ControlMargin">5 5 5 5</Thickness>
-        <BooleanToVisibilityConverter x:Key="boolToVisibilityConverter"/>
-    </controls:MetroWindow.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary  Source="pack://application:,,,/Pixel.Automation.TestExplorer.Views;component/resources/Resources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <Thickness x:Key="ControlMargin">5 5 5 5</Thickness>
+            <BooleanToVisibilityConverter x:Key="boolToVisibilityConverter"/>
+        </ResourceDictionary>
+    </controls:MetroWindow.Resources>   
     <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="{StaticResource ControlMargin}">
         <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch">
+         
             <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
                 <Label Content="Name" VerticalAlignment="Center"/>
                 <TextBox x:Name="DisplayName" Text="{Binding TestCaseDisplayName, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
@@ -27,6 +33,7 @@
                      controls:TextBoxHelper.Watermark="Name"  HorizontalAlignment="Stretch"
                      VerticalAlignment="Top" Margin="5,5,5,0"></TextBox>
             </StackPanel>
+            
             <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
                 <Label Content="Description"/>
                 <TextBox x:Name="Description" Text="{Binding TestCaseDescription, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
@@ -34,22 +41,8 @@
                      controls:TextBoxHelper.Watermark="Description"  HorizontalAlignment="Stretch"
                      VerticalAlignment="Top" Margin="5,5,5,0"></TextBox>
             </StackPanel>
-            <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
-                <Label Content="Execution Speed"/>
-                <Slider x:Name="DelayFactor" Value="{Binding DelayFactor}" SmallChange="1" TickPlacement="None" LargeChange="10"
-                        Margin="5,5,5,0"  Style="{DynamicResource MahApps.Styles.Slider.Flat}"                      
-                        AutoToolTipPlacement="TopLeft"
-                        Minimum="0"  Maximum="100" ToolTip="Controls the pre-delay and post-delay for actors"/>
-            </StackPanel>
-            <!--<StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
-                <Label Content="Tags"/>
-                <TextBox x:Name="Tags" Text="{Binding Tags, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
-                     controls:TextBoxHelper.ClearTextButton="True" controls:TextBoxHelper.UseFloatingWatermark="True"                     
-                     controls:TextBoxHelper.Watermark="Tags (comma seperate e.g. tag1,tag2)"  HorizontalAlignment="Stretch"
-                     VerticalAlignment="Top" Margin="5,5,5,0"></TextBox>
-            </StackPanel>-->
-          
-            <StackPanel Orientation="Horizontal" Margin="{StaticResource ControlMargin}">                
+            
+            <StackPanel Orientation="Horizontal" Margin="5,10,5,5">
                 <Label Content="Muted" ></Label>
                 <CheckBox x:Name="IsMuted" IsChecked="{Binding IsMuted}" ToolTip="Muted test cases are not executed"/>
                 <Label Content="Order" Margin="4,0,0,0" ></Label>
@@ -57,11 +50,59 @@
                 <Label Content="Priority" DockPanel.Dock="Left" Margin="4,0,0,0"></Label>
                 <ComboBox ItemsSource="{Binding Source={editorCore:EnumBindingSource {x:Type models:Priority}}}" DockPanel.Dock="Right"
                         SelectedItem="{Binding Path=Priority}" ToolTip="Priority" MinWidth="80"/>
-            </StackPanel>           
+            </StackPanel>
+
+            <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
+                <Label Content="Execution Speed"/>
+                <Slider x:Name="DelayFactor" Value="{Binding DelayFactor}" SmallChange="1" TickPlacement="None" LargeChange="10"
+                        Margin="5,5,5,0"  AutoToolTipPlacement="TopLeft"
+                        Minimum="0"  Maximum="100" ToolTip="Controls the pre-delay and post-delay for actors"/>
+            </StackPanel>
+         
+
+            <StackPanel x:Name="TagPanel" Orientation="Vertical" Margin="{StaticResource ControlMargin}" Style="{StaticResource StackPanelWithoutErrorTemplateStyle}"
+                        DataContext="{Binding TagCollection, ValidatesOnNotifyDataErrors=True}">
+                <StackPanel Orientation="Horizontal" >
+                    <Label Name="Tags" Content="Tags"></Label>
+                    <Button Name="AddNewTag" Content="{iconPacks:Modern Add}"     
+                            ToolTip="Add new tag"
+                            cal:Message.Attach="[Event Click] = [Action AddNew()]" Style="{StaticResource EditControlButtonStyle}"/>
+                    <Button Name="EditSelectedTag" Content="{iconPacks:FontAwesome PencilAltSolid}"
+                            ToolTip="Edit selected tag" ToolTipService.ShowOnDisabled="true"
+                            IsEnabled="{Binding CanEdit, FallbackValue=false}"
+                            cal:Message.Attach="[Event Click] = [Action EditSelected()]" Style="{StaticResource EditControlButtonStyle}"/>
+                    <Button Name="DeleteSelectedTag" Content="{iconPacks:FontAwesome TrashAltSolid}"
+                            ToolTip="Delete selected tag" ToolTipService.ShowOnDisabled="true"
+                            IsEnabled="{Binding CanDelete, FallbackValue=false}"
+                            cal:Message.Attach="[Event Click] = [Action DeleteSelected()]" 
+                            Style="{StaticResource EditControlButtonStyle}"/>
+                </StackPanel>
+                <ListBox x:Name="TagCollection" ItemsSource="{Binding Tags}" SelectedItem="{Binding SelectedTag}" Style="{StaticResource TagEditorStyle}"
+                        BorderThickness="0" Margin="-6,0,0,0" ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.CanContentScroll="False"/>
+
+            </StackPanel>
+            
+            <DockPanel x:Name="ErrorPanel" Margin="5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" LastChildFill="False" Grid.Row="1"
+                   Background="{DynamicResource MahApps.Brushes.ValidationSummary3}"
+                   Visibility="{Binding ShowModelErrors, FallbackValue=false, Converter={StaticResource boolToVisConverter}}">
+                <ItemsControl x:Name="ErrorList" Style="{DynamicResource ModelErrorStyle}"                       
+                      ItemsSource="{Binding Path=(Validation.Errors), ElementName=TagPanel}"
+                      DockPanel.Dock="Left" Margin="5"/>
+                <Button x:Name="HideErrorsPanel" Width="20"  Height="20" DockPanel.Dock="Right" VerticalAlignment="Top" Margin="0,5,5,0"
+                      cal:Message.Attach="[Event Click] = [Action DismissModelErrors()]" Background="Transparent"
+                      Style="{DynamicResource EditControlButtonStyle}" ToolTip="Dismiss"
+                            Content="{iconPacks:Material CloseCircleOutline}"/>
+            </DockPanel>
+            
         </StackPanel>
-        <DockPanel LastChildFill="False" Margin="{StaticResource ControlMargin}">
+
+        <DockPanel LastChildFill="False" Margin="0,5,0,8">
+            <Border DockPanel.Dock="Top" BorderThickness="1" Height="1" HorizontalAlignment="Stretch" Margin="0,0,0,10"
+                    Width="{Binding Path=Width,RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type DockPanel}}}" 
+                    BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
             <Button x:Name="Cancel" Content="CANCEL" Width="100" DockPanel.Dock="Right"  Margin="10,0,4,0" Style="{DynamicResource MahApps.Styles.Button.Square}"/>
             <Button x:Name="Save" Content="Save" DockPanel.Dock="Right" Width="100"  Style="{DynamicResource MahApps.Styles.Button.Square.Accent}"/>
         </DockPanel>
+        
     </StackPanel>
 </controls:MetroWindow>

--- a/src/Pixel.Automation.TestExplorer.Views/EditTestFixtureView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/EditTestFixtureView.xaml
@@ -4,18 +4,25 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Pixel.Automation.TestExplorer.Views"
-             xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"           
              xmlns:cal="http://www.caliburnproject.org"
-             WindowStartupLocation="CenterOwner"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             WindowStartupLocation="CenterOwner" ResizeMode="NoResize"
              Height="Auto" MinWidth="550" SizeToContent="WidthAndHeight"
              IsMinButtonEnabled="False" Title="Test Fixture" GlowBrush="{DynamicResource AccentColorBrush}"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <controls:MetroWindow.Resources>
-        <Thickness x:Key="ControlMargin">5 5 5 5</Thickness>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary  Source="pack://application:,,,/Pixel.Automation.TestExplorer.Views;component/resources/Resources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <Thickness x:Key="ControlMargin">5 5 5 5</Thickness>
+        </ResourceDictionary>      
     </controls:MetroWindow.Resources>
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="{StaticResource ControlMargin}">
+    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"  Margin="{StaticResource ControlMargin}">
         <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch">
+          
             <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
                 <Label Content="Name" VerticalAlignment="Center"/>
                 <TextBox x:Name="DisplayName" Text="{Binding TestFixtureDisplayName, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}"
@@ -23,6 +30,7 @@
                      controls:TextBoxHelper.Watermark="Name"  HorizontalAlignment="Stretch"
                      VerticalAlignment="Top" Margin="5,5,5,0"></TextBox>
             </StackPanel>
+            
             <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
                 <Label Content="Category" VerticalAlignment="Center"/>
                 <TextBox x:Name="Category" Text="{Binding TestFixtureCategory, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}"
@@ -30,6 +38,7 @@
                      controls:TextBoxHelper.Watermark="Category"  HorizontalAlignment="Stretch"
                      VerticalAlignment="Top" Margin="5,5,5,0"></TextBox>
             </StackPanel>
+            
             <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
                 <Label Content="Description"/>
                 <TextBox x:Name="Description" Text="{Binding TestFixtureDescription, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}"
@@ -37,30 +46,64 @@
                      controls:TextBoxHelper.Watermark="Description"  HorizontalAlignment="Stretch"
                      VerticalAlignment="Top" Margin="5,5,5,0"></TextBox>
             </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Margin="5,10,5,5">
+                <Label Content="Muted"></Label>
+                <CheckBox x:Name="IsMuted" IsChecked="{Binding IsMuted}" ToolTip="Tests belonging to a muted fixture are not executed"/>
+                <Label Content="Order" Margin="5,0,0,0" ></Label>
+                <controls:NumericUpDown Minimum="0" Value="{Binding Order}" ToolTip="Order of execution of fixture"/>
+            </StackPanel>
+            
             <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
                 <Label Content="Execution Speed"/>
                 <Slider x:Name="DelayFactor" Value="{Binding DelayFactor}" SmallChange="1" TickPlacement="None" LargeChange="10"
-                        Margin="5,5,5,0"  Style="{DynamicResource MahApps.Styles.Slider.Flat}"
-                        AutoToolTipPlacement="TopLeft"
+                        Margin="5,5,5,0" AutoToolTipPlacement="TopLeft"
                         Minimum="0"  Maximum="100" ToolTip="Controls the pre-delay and post-delay for actors"/>
             </StackPanel>
-            <!--<StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
-                <Label Content="Tags"/>
-                <TextBox x:Name="Tags" Text="{Binding Tags, ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
-                     controls:TextBoxHelper.ClearTextButton="True" controls:TextBoxHelper.UseFloatingWatermark="True"                     
-                     controls:TextBoxHelper.Watermark="Tags (comma seperate e.g. tag1,tag2)"  HorizontalAlignment="Stretch"
-                     VerticalAlignment="Top" Margin="5,5,5,0"></TextBox>
-            </StackPanel>-->
-            <StackPanel Orientation="Horizontal" Margin="{StaticResource ControlMargin}">
-                <Label Content="Muted" ></Label>
-                <CheckBox x:Name="IsMuted" IsChecked="{Binding IsMuted}" ToolTip="Tests belonging to a muted fixture are not executed"/>
-                <Label Content="Order" Margin="4,0,0,0" ></Label>
-                <controls:NumericUpDown Minimum="0" Value="{Binding Order}" ToolTip="Order of execution of fixture"/>               
-            </StackPanel>           
+                        
+            <StackPanel x:Name="TagPanel" Orientation="Vertical" Margin="{StaticResource ControlMargin}" Style="{StaticResource StackPanelWithoutErrorTemplateStyle}"
+                        DataContext="{Binding TagCollection, ValidatesOnNotifyDataErrors=True}">
+                <StackPanel Orientation="Horizontal" >
+                    <Label Name="Tags" Content="Tags"></Label>
+                    <Button Name="AddNewTag" Content="{iconPacks:Modern Add}"     
+                            ToolTip="Add new tag"
+                            cal:Message.Attach="[Event Click] = [Action AddNew()]" Style="{StaticResource EditControlButtonStyle}"/>
+                    <Button Name="EditSelectedTag" Content="{iconPacks:FontAwesome PencilAltSolid}"
+                            ToolTip="Edit selected tag" ToolTipService.ShowOnDisabled="true"
+                            IsEnabled="{Binding CanEdit, FallbackValue=false}"
+                            cal:Message.Attach="[Event Click] = [Action EditSelected()]" Style="{StaticResource EditControlButtonStyle}"/>
+                    <Button Name="DeleteSelectedTag" Content="{iconPacks:FontAwesome TrashAltSolid}"
+                            ToolTip="Delete selected tag" ToolTipService.ShowOnDisabled="true"
+                            IsEnabled="{Binding CanDelete, FallbackValue=false}"
+                            cal:Message.Attach="[Event Click] = [Action DeleteSelected()]" 
+                            Style="{StaticResource EditControlButtonStyle}"/>
+                </StackPanel>
+                <ListBox x:Name="TagCollection" ItemsSource="{Binding Tags}" SelectedItem="{Binding SelectedTag}" Style="{StaticResource TagEditorStyle}"
+                        BorderThickness="0" Margin="-6,0,0,0" ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.CanContentScroll="False"/>             
+              
+            </StackPanel>          
+
+            <DockPanel x:Name="ErrorPanel" Margin="5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" LastChildFill="False" Grid.Row="1"
+                   Background="{DynamicResource MahApps.Brushes.ValidationSummary3}"
+                   Visibility="{Binding ShowModelErrors, FallbackValue=false, Converter={StaticResource boolToVisConverter}}">
+                <ItemsControl x:Name="ErrorList" Style="{DynamicResource ModelErrorStyle}"                       
+                      ItemsSource="{Binding Path=(Validation.Errors), ElementName=TagPanel}"
+                      DockPanel.Dock="Left" Margin="5"/>
+                <Button x:Name="HideErrorsPanel" Width="20"  Height="20" DockPanel.Dock="Right" VerticalAlignment="Top" Margin="0,5,5,0"
+                      cal:Message.Attach="[Event Click] = [Action DismissModelErrors()]" Background="Transparent"
+                      Style="{DynamicResource EditControlButtonStyle}" ToolTip="Dismiss"
+                            Content="{iconPacks:Material CloseCircleOutline}"/>
+            </DockPanel>
+            
         </StackPanel>
-        <DockPanel LastChildFill="False" Margin="{StaticResource ControlMargin}">
+               
+        <DockPanel LastChildFill="False" Margin="0,5,0,8">
+            <Border DockPanel.Dock="Top" BorderThickness="1" Height="1" HorizontalAlignment="Stretch" Margin="0,0,0,10"
+                    Width="{Binding Path=Width,RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type DockPanel}}}" 
+                    BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
             <Button x:Name="Cancel" Content="CANCEL" Width="100" DockPanel.Dock="Right"  Margin="10,0,4,0" Style="{DynamicResource MahApps.Styles.Button.Square}"/>
             <Button x:Name="Save" Content="Save" DockPanel.Dock="Right" Width="100"  Style="{DynamicResource MahApps.Styles.Button.Square.Accent}"/>
         </DockPanel>
+        
     </StackPanel>
 </controls:MetroWindow>

--- a/src/Pixel.Automation.TestExplorer.Views/Resources/Resources.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/Resources/Resources.xaml
@@ -1,0 +1,77 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"        
+                    xmlns:vm="clr-namespace:Pixel.Automation.TestExplorer.ViewModels;assembly=Pixel.Automation.TestExplorer.ViewModels"
+                    xmlns:s="clr-namespace:System;assembly=mscorlib"
+                    xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks">
+   
+    <BooleanToVisibilityConverter x:Key="boolToVisConverter"></BooleanToVisibilityConverter>
+    <s:Boolean x:Key="True">True</s:Boolean>
+   
+    <DataTemplate x:Key="EditTagTemplate" DataType="{x:Type vm:TagViewModel}">
+        <StackPanel Orientation="Horizontal" Margin="5,5,0,5" Background="{DynamicResource MahApps.Brushes.Button.Flat.Background}">
+            <TextBox x:Name="TagKey" Text="{Binding Key}" MinWidth="60"  controls:TextBoxHelper.ClearTextButton="True" 
+                      controls:TextBoxHelper.Watermark="Key" Margin="4,4,0,4"/>
+            <TextBox x:Name="TagValue" Text="{Binding Value}" MinWidth="60"  controls:TextBoxHelper.ClearTextButton="True"
+                     controls:TextBoxHelper.Watermark="Value" Margin="4,4,0,4"/>
+            <Button x:Name="Save" Command="{Binding SaveCommand}" CommandParameter="{StaticResource True}" Margin="4,4,4,4" Background="Transparent"
+                    Style="{StaticResource EditControlButtonStyle}" Content="{iconPacks:FontAwesome SaveSolid}" Width="24" Height="24" />
+        </StackPanel>
+        <DataTemplate.Triggers>
+            <DataTrigger Binding="{Binding IsDeleted}" Value="true">
+                <Setter Property="Visibility" Value="Collapsed"/>
+            </DataTrigger>
+        </DataTemplate.Triggers>
+    </DataTemplate>
+
+    <DataTemplate x:Key="ViewTagTemplate" DataType="{x:Type vm:TagViewModel}">
+        <Border BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent3}" Margin="5,5,0,5" IsHitTestVisible="True">
+            <StackPanel Orientation="Horizontal" Background="{DynamicResource MahApps.Brushes.Button.Flat.Background}">
+                <Label x:Name="TagView" Content="{Binding}" HorizontalAlignment="Center" HorizontalContentAlignment="Center"/>
+            </StackPanel>
+        </Border>
+        <DataTemplate.Triggers>
+            <DataTrigger Binding="{Binding IsDeleted}" Value="true">
+                <Setter Property="Visibility" Value="Collapsed"/>
+            </DataTrigger>
+        </DataTemplate.Triggers>
+    </DataTemplate>
+
+    <Style x:Key="TagItemStyle" TargetType="{x:Type ListBoxItem}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <ContentControl x:Name="TagContent" Content="{Binding}" FontSize="{TemplateBinding FontSize}"
+                                    FontWeight="{TemplateBinding FontWeight}" Background="{TemplateBinding Background}" ContentTemplate="{StaticResource ViewTagTemplate}"/>
+                    <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding IsEditing}" Value="True">
+                            <Setter Property="ContentTemplate" TargetName="TagContent" Value="{StaticResource EditTagTemplate}"/>
+                        </DataTrigger>                        
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsSelected" Value="true">
+                <Setter Property="FontSize" Value="14"></Setter>
+                <Setter Property="FontWeight" Value="Bold"></Setter>
+                <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Accent}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="TagEditorStyle" TargetType="{x:Type ListBox}">
+        <Setter Property="ItemContainerStyle" Value="{StaticResource TagItemStyle}"/>
+        <Setter Property="MaxWidth" Value="520"/>
+        <Setter Property="Width" Value="520"/>
+        <Setter Property="Margin" Value="0,5,0,0"/>
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <WrapPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/TestData/TestCaseFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/TestData/TestCaseFixture.cs
@@ -29,7 +29,7 @@ namespace Pixel.Automation.Core.Tests.TestData
             testCase.IsMuted = true;
             testCase.ScriptFile = "TestCase.csx";
             testCase.TestDataId = Guid.NewGuid().ToString();
-            testCase.Tags.AddTag("color", "red");
+            testCase.Tags.Add("color", "red");
             testCase.Description = "Description";
             testCase.TestCaseEntity = new Entity();
 
@@ -48,7 +48,7 @@ namespace Pixel.Automation.Core.Tests.TestData
         public void ValidateThatTestCaseCanBeCloned()
         {
             var testCase = new TestCase() { DisplayName = "TestCase", FixtureId = "FixtureId", Order = 10, IsMuted = true, ScriptFile = "ScriptFile.csx", TestDataId = "TestDataId", Description = "Description", TestCaseEntity = new Entity() };
-            testCase.Tags.AddTag("color", "red");
+            testCase.Tags.Add("color", "red");
             var copyOfTestCase = testCase.Clone() as TestCase;
 
             Assert.AreEqual(testCase.DisplayName, copyOfTestCase.DisplayName);

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/TestData/TestFixtureFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/TestData/TestFixtureFixture.cs
@@ -29,7 +29,7 @@ namespace Pixel.Automation.Core.Tests.TestData
             testFixture.IsMuted = true;
             testFixture.ScriptFile = "TestFixture.csx";
             testFixture.Description = "Description";
-            testFixture.Tags.AddTag("color", "red");
+            testFixture.Tags.Add("color", "red");
             testFixture.Tests.Add(new TestCase());
             testFixture.TestFixtureEntity = new Entity();
 
@@ -49,7 +49,7 @@ namespace Pixel.Automation.Core.Tests.TestData
         {
             var testFixture = new TestFixture() { DisplayName = "TestCase", Order = 10, IsMuted = true, ScriptFile = "ScriptFile.csx", 
                 Description = "Description", Category = "GroupOne", TestFixtureEntity = new Entity() };
-            testFixture.Tags.AddTag("color", "red");
+            testFixture.Tags.Add("color", "red");
             testFixture.Tests.Add(new TestCase());
             var copyOftestFixture = testFixture.Clone() as TestFixture;
 

--- a/src/Unit.Tests/Pixel.Automation.TestExplorer.ViewModels.Tests/TestCaseViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.TestExplorer.ViewModels.Tests/TestCaseViewModelFixture.cs
@@ -42,8 +42,8 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
                 FixtureId = "Fixture#1",
                 ScriptFile = "Script.csx"
             };
-            testCase.Tags.AddTag("color", "red");
-            testCase.Tags.AddTag("priority", "high");
+            testCase.Tags.Add("color", "red");
+            testCase.Tags.Add("priority", "high");
             TestCaseViewModel testCaseViewModel = new TestCaseViewModel(testCase, eventAggregator);
 
             Assert.IsTrue(!string.IsNullOrEmpty(testCaseViewModel.Id));
@@ -52,8 +52,8 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
             Assert.AreEqual("Test case description", testCaseViewModel.Description);
             Assert.AreEqual("Fixture#1", testCaseViewModel.FixtureId);
             Assert.AreEqual(testCaseEntity, testCaseViewModel.TestCaseEntity);
-            Assert.IsTrue(testCaseViewModel.Tags.HasTag("color"));
-            Assert.IsTrue(testCaseViewModel.Tags.HasTag("priority"));
+            Assert.IsTrue(testCaseViewModel.Tags.Contains("color"));
+            Assert.IsTrue(testCaseViewModel.Tags.Contains("priority"));
             Assert.AreEqual("Script.csx", testCaseViewModel.ScriptFile);
             Assert.IsNull(testCaseViewModel.TestDataId);
             Assert.IsFalse(testCaseViewModel.IsMuted);
@@ -83,7 +83,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
                 ScriptFile = "Script.csx",
                 IsMuted = true
             };
-            testCase.Tags.AddTag("color", "red");       
+            testCase.Tags.Add("color", "red");       
             Assert.AreEqual("TestCase#1", testCase.DisplayName);
             Assert.AreEqual(1, testCase.Order);
             Assert.AreEqual("Test case description", testCase.Description);         

--- a/src/Unit.Tests/Pixel.Automation.TestExplorer.ViewModels.Tests/TestFixtureViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.TestExplorer.ViewModels.Tests/TestFixtureViewModelFixture.cs
@@ -21,16 +21,16 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
                 ScriptFile = "Script.csx",
                 TestFixtureEntity = fixtureEntity
             };
-            testFixture.Tags.AddTag("color", "red");
-            testFixture.Tags.AddTag("priority", "low");
+            testFixture.Tags.Add("color", "red");
+            testFixture.Tags.Add("priority", "low");
             TestFixtureViewModel testFixtureviewModel = new TestFixtureViewModel(testFixture);
 
             Assert.IsTrue(!string.IsNullOrEmpty(testFixtureviewModel.Id));
             Assert.AreEqual("TestFixture#1", testFixtureviewModel.DisplayName);
             Assert.AreEqual(1, testFixtureviewModel.Order);
             Assert.AreEqual("Test fixture description", testFixtureviewModel.Description);          
-            Assert.IsTrue(testFixtureviewModel.Tags.HasTag("color"));
-            Assert.IsTrue(testFixtureviewModel.Tags.HasTag("priority"));
+            Assert.IsTrue(testFixtureviewModel.Tags.Contains("color"));
+            Assert.IsTrue(testFixtureviewModel.Tags.Contains("priority"));
             Assert.AreEqual("Script.csx", testFixtureviewModel.ScriptFile);
             Assert.AreEqual(fixtureEntity, testFixtureviewModel.TestFixtureEntity);
             Assert.IsFalse(testFixtureviewModel.IsMuted);
@@ -58,15 +58,15 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
                 ScriptFile = "Script.csx",
                 IsMuted = true
             };
-            testCaseViewModel.Tags.AddTag("color", "red");
-            testCaseViewModel.Tags.AddTag("priority", "high");
+            testCaseViewModel.Tags.Add("color", "red");
+            testCaseViewModel.Tags.Add("priority", "high");
 
             Assert.AreEqual("TestFixture#1", testFixture.DisplayName);
             Assert.AreEqual(1, testFixture.Order);
             Assert.AreEqual("Test fixture description", testFixture.Description);
             Assert.AreEqual(fixtureEntity, testFixture.TestFixtureEntity);
-            Assert.IsTrue(testCaseViewModel.Tags.HasTag("color"));
-            Assert.IsTrue(testCaseViewModel.Tags.HasTag("priority"));
+            Assert.IsTrue(testCaseViewModel.Tags.Contains("color"));
+            Assert.IsTrue(testCaseViewModel.Tags.Contains("priority"));
             Assert.AreEqual("Script.csx", testFixture.ScriptFile);
             Assert.IsTrue(testFixture.IsMuted);
         }


### PR DESCRIPTION
**Description**
Test Fixtures and Test Cases have a collection of tags which are key value pairs to add annotation to them.
These tags can be used to filter tests to be executed. Currently, there was no way to add or edit these tags from UI.
This change enables tags to be added , edited and deleted from add/edit screen for Test fixtures and Test cases.