### PR TITLE
Don't serialize assembly version

### DIFF
--- a/src/Pixel.Automation.Core.Components/Controls/FindAllControlActorComponent.cs
+++ b/src/Pixel.Automation.Core.Components/Controls/FindAllControlActorComponent.cs
@@ -58,7 +58,7 @@ namespace Pixel.Automation.Core.Components.Controls
                 Tag = "FindAllControlsGroup",
                 GroupActor = new FindAllControlsActorComponent()
             };         
-            groupEntity.GroupPlaceHolder.AllowedComponentsType = typeof(IControlEntity);
+            groupEntity.GroupPlaceHolder.AllowedComponentsType = typeof(IControlEntity).Name;
             groupEntity.GroupPlaceHolder.Name = "Controls";
             return groupEntity;
         }

--- a/src/Pixel.Automation.Core.Components/Controls/FindControlActorComponent.cs
+++ b/src/Pixel.Automation.Core.Components/Controls/FindControlActorComponent.cs
@@ -54,7 +54,7 @@ namespace Pixel.Automation.Core.Components.Controls
                 GroupActor = new FindControlActorComponent()
             };
             groupEntity.GroupPlaceHolder.MaxComponentsCount = 1;
-            groupEntity.GroupPlaceHolder.AllowedComponentsType = typeof(IControlEntity);
+            groupEntity.GroupPlaceHolder.AllowedComponentsType = typeof(IControlEntity).Name;
             groupEntity.GroupPlaceHolder.Name = "Control";
             return groupEntity;
         }

--- a/src/Pixel.Automation.Core.Components/Controls/FindFirstControlActorComponent.cs
+++ b/src/Pixel.Automation.Core.Components/Controls/FindFirstControlActorComponent.cs
@@ -126,7 +126,7 @@ namespace Pixel.Automation.Core.Components.Controls
                 Tag = "FindFirstControlsGroup",
                 GroupActor = new FindFirstControlActorComponent()
             };          
-            groupEntity.GroupPlaceHolder.AllowedComponentsType = typeof(IControlEntity);
+            groupEntity.GroupPlaceHolder.AllowedComponentsType = typeof(IControlEntity).Name;
             groupEntity.GroupPlaceHolder.Name = "Control";
             return groupEntity;
         }

--- a/src/Pixel.Automation.Core.Components/Controls/HighlightControlActorComponent.cs
+++ b/src/Pixel.Automation.Core.Components/Controls/HighlightControlActorComponent.cs
@@ -86,7 +86,7 @@ namespace Pixel.Automation.Core.Components.Controls
                 GroupActor = new HighlightControlActorComponent()
             };
             groupEntity.GroupPlaceHolder.MaxComponentsCount = 1;
-            groupEntity.GroupPlaceHolder.AllowedComponentsType = typeof(IControlEntity);
+            groupEntity.GroupPlaceHolder.AllowedComponentsType = typeof(IControlEntity).Name;
             groupEntity.GroupPlaceHolder.Name = "Control";
             return groupEntity;
         }

--- a/src/Pixel.Automation.Core.Components/Entities/PlaceHolderEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Entities/PlaceHolderEntity.cs
@@ -12,23 +12,27 @@ namespace Pixel.Automation.Core.Components
         [System.ComponentModel.Browsable(false)]
         public int? MaxComponentsCount { get; set; } = 50;
 
+        /// <summary>
+        /// Store an interface name to AllowedComponentsType property.
+        /// Only components that implement this interface are allowed to be added to this PlaceHolderEntity
+        /// </summary>
         [DataMember]
         [System.ComponentModel.Browsable(false)]
-        public Type AllowedComponentsType { get; set; } = typeof(IComponent);
+        public string AllowedComponentsType { get; set; } = typeof(IComponent).Name;
 
-        public PlaceHolderEntity() : base("Place Holder","PlaceHolder")
+        public PlaceHolderEntity() : base("Place Holder", "PlaceHolder")
         {
            
         }
 
-        public PlaceHolderEntity(string name,string tag= "PlaceHolder"):base(name, tag)
+        public PlaceHolderEntity(string name, string tag= "PlaceHolder"):base(name, tag)
         {
 
         }
 
         public override Entity AddComponent(IComponent component)
         {
-            if(!AllowedComponentsType.IsAssignableFrom(component.GetType()))
+            if(component.GetType().GetInterface(AllowedComponentsType) == null)
             {
                 throw new ArgumentException($"Only components of type {AllowedComponentsType} can be added");
             }

--- a/src/Pixel.Automation.RunTime/Serialization/JsonSerializer.cs
+++ b/src/Pixel.Automation.RunTime/Serialization/JsonSerializer.cs
@@ -13,7 +13,7 @@ namespace Pixel.Automation.RunTime.Serialization
         private readonly JsonSerializerSettings settings = new JsonSerializerSettings()
         {
             TypeNameHandling = TypeNameHandling.Auto,
-            TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Full
+            TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple
         };
 
         public T Deserialize<T>(string path, List<Type> knownTypes = null) where T : new()

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Entities/PlaceHolderEntityTest.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Entities/PlaceHolderEntityTest.cs
@@ -18,12 +18,12 @@ namespace Pixel.Automation.Core.Components.Tests
 
             var placeHolderEntity = new PlaceHolderEntity()
             {
-                AllowedComponentsType = typeof(Entity),
+                AllowedComponentsType = typeof(IControlEntity).Name,
                 MaxComponentsCount = 5,
                 EntityManager = entityManager
             };
 
-            var entity = Substitute.For<Entity>();
+            var entity = Substitute.For<IControlEntity>();
             var actorComponent = Substitute.For<ActorComponent>();
 
             placeHolderEntity.AddComponent(entity);
@@ -43,7 +43,7 @@ namespace Pixel.Automation.Core.Components.Tests
 
             var placeHolderEntity = new PlaceHolderEntity()
             {
-                AllowedComponentsType = typeof(IComponent),
+                AllowedComponentsType = typeof(IComponent).Name,
                 MaxComponentsCount = 3,
                 EntityManager = entityManager
             };


### PR DESCRIPTION
**Description**
Project files are persisted as json files by serialization . Newtonsoft.json is used for serializing to json.
The assembly version is serialized as well  along with type names which is not desirable given as the project evolves and there are newer versions. 

**Additional Info**
If there is a property of type Type on a model, this property is still serialized with type name and assembly version even if Newtonsoft.json is configured to use Simple type handling. We need to avoid using serializable properties of type Type 
