### PR TITLE
Remove ObservableCollection from Entity

### DIFF
--- a/src/Pixel.Automation.Core.Components/Decisions/IfEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Decisions/IfEntity.cs
@@ -14,6 +14,7 @@ namespace Pixel.Automation.Core.Components.Decisions
     [ToolBoxItem("If", "Decisions", iconSource: null, description: "Wraps a group of automation entity that are processed only if the if criteria is satisfied ", tags: new string[] { "Deicsion", "DecisionGroup", "Entity" })]
     [Scriptable("ScriptFile")]
     [Initializer(typeof(ScriptFileInitializer))]
+    [NoDropTarget]
     public class IfEntity : Entity
     {
         protected string scriptFile;
@@ -72,10 +73,14 @@ namespace Pixel.Automation.Core.Components.Decisions
             PlaceHolderEntity thenBlock = new PlaceHolderEntity("Then");
             PlaceHolderEntity elseBlock = new PlaceHolderEntity("Else");  
                     
-            this.AddComponent(thenBlock);
-            this.AddComponent(elseBlock);          
+            base.AddComponent(thenBlock);
+            base.AddComponent(elseBlock);          
         }
 
+        public override Entity AddComponent(Interfaces.IComponent component)
+        {
+            return this;
+        }
 
     }
 }

--- a/src/Pixel.Automation.Core.Components/Entities/GroupEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Entities/GroupEntity.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Pixel.Automation.Core.Attributes;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -8,6 +9,7 @@ namespace Pixel.Automation.Core.Components
 {
     [DataContract]
     [Serializable]
+    [NoDropTarget]
     public class GroupEntity : Entity
     {
         private ActorComponent groupActorComponent;
@@ -79,9 +81,8 @@ namespace Pixel.Automation.Core.Components
         }
 
           
-        public override Entity AddComponent(Core.Interfaces.IComponent component)
+        public override Entity AddComponent(Interfaces.IComponent component)
         {
-            this.GroupPlaceHolder?.AddComponent(component);
             return this;
         }
     }

--- a/src/Pixel.Automation.Core.Components/Entities/PlaceHolderEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Entities/PlaceHolderEntity.cs
@@ -32,23 +32,22 @@ namespace Pixel.Automation.Core.Components
 
         public override Entity AddComponent(IComponent component)
         {
-            if(component.GetType().GetInterface(AllowedComponentsType) == null)
+            if(!this.Components.Contains(component))
             {
-                throw new ArgumentException($"Only components of type {AllowedComponentsType} can be added");
-            }
-          
-            if(this.MaxComponentsCount.HasValue)
-            {              
-                if (this.Components.Count < MaxComponentsCount)
+                if (component.GetType().GetInterface(AllowedComponentsType) == null)
                 {
-                    return base.AddComponent(component);
+                    throw new ArgumentException($"Only components of type {AllowedComponentsType} can be added");
                 }
-                else
+
+                if (this.MaxComponentsCount.HasValue)
                 {
+                    if (this.Components.Count < MaxComponentsCount)
+                    {
+                        return base.AddComponent(component);
+                    }
                     throw new InvalidOperationException($"Allowed capacity of {MaxComponentsCount} already reached. Can't add any more child component to {this}");
                 }
-            }           
-
+            }
             return this;
         }
 

--- a/src/Pixel.Automation.Core.Components/Loops/DoWhileLoopEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Loops/DoWhileLoopEntity.cs
@@ -16,6 +16,7 @@ namespace Pixel.Automation.Core.Components.Loops
     [ToolBoxItem("Do..While Loop", "Loops", iconSource: null, description: "Contains a group of automation entity that will be prcossed in a while loop", tags: new string[] { "while loop" })]
     [Scriptable("ScriptFile")]
     [Initializer(typeof(ScriptFileInitializer))]
+    [NoDropTarget]
     public class DoWhileLoopEntity : Entity, ILoop
     {
 
@@ -109,9 +110,7 @@ namespace Pixel.Automation.Core.Components.Loops
         }
 
         public override Entity AddComponent(Interfaces.IComponent component)
-        {
-            var placeHolderEntity = this.GetFirstComponentOfType<PlaceHolderEntity>();
-            placeHolderEntity.AddComponent(component);
+        {           
             return this;
         }
     }

--- a/src/Pixel.Automation.Core.Components/Loops/ForEachLoopEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Loops/ForEachLoopEntity.cs
@@ -16,7 +16,7 @@ namespace Pixel.Automation.Core.Components.Loops
     [DataContract]
     [Serializable]
     [ToolBoxItem("For..Each Loop", "Loops", iconSource: null, description: "Contains a group of automation entity that will be prcossed in a for each loop", tags: new string[] { "foreach loop" })]
-
+    [NoDropTarget]
     public class ForEachLoopEntity : Entity, ILoop , IScopedEntity
     {
 
@@ -125,9 +125,7 @@ namespace Pixel.Automation.Core.Components.Loops
         }
 
         public override Entity AddComponent(Interfaces.IComponent component)
-        {
-            var placeHolderEntity = this.GetFirstComponentOfType<PlaceHolderEntity>();
-            placeHolderEntity.AddComponent(component);
+        {         
             return this;
         }
 

--- a/src/Pixel.Automation.Core.Components/Loops/ForLoopEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Loops/ForLoopEntity.cs
@@ -17,6 +17,7 @@ namespace Pixel.Automation.Core.Components.Loops
     [ToolBoxItem("For Loop", "Loops", iconSource: null, description: "Contains a group of automation entity that will be prcossed in a for loop", tags: new string[] { "for loop" })]
     [Scriptable("ScriptFile")]
     [Initializer(typeof(ScriptFileInitializer))]
+    [NoDropTarget]
     public class ForLoopEntity : Entity, ILoop
     {
 
@@ -135,9 +136,7 @@ namespace Pixel.Automation.Core.Components.Loops
         }
 
         public override Entity AddComponent(Interfaces.IComponent component)
-        {
-            var placeHolderEntity =  this.GetFirstComponentOfType<PlaceHolderEntity>();
-            placeHolderEntity.AddComponent(component);
+        {        
             return this;
         }
     }

--- a/src/Pixel.Automation.Core.Components/Loops/WhileLoopEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Loops/WhileLoopEntity.cs
@@ -16,6 +16,7 @@ namespace Pixel.Automation.Core.Components.Loops
     [ToolBoxItem("While Loop", "Loops", iconSource: null, description: "Contains a group of automation entity that will be prcossed in a while loop", tags: new string[] { "while loop" })]
     [Scriptable("ScriptFile")]
     [Initializer(typeof(ScriptFileInitializer))]
+    [NoDropTarget]
     public class WhileLoopEntity : Entity, ILoop
     {
         protected string scriptFile;
@@ -110,9 +111,7 @@ namespace Pixel.Automation.Core.Components.Loops
             
         }
         public override Entity AddComponent(Interfaces.IComponent component)
-        {
-            var placeHolderEntity = this.GetFirstComponentOfType<PlaceHolderEntity>();
-            placeHolderEntity.AddComponent(component);
+        {          
             return this;
         }
     }

--- a/src/Pixel.Automation.Core.Components/Processors/ParallelEntityProcessor.cs
+++ b/src/Pixel.Automation.Core.Components/Processors/ParallelEntityProcessor.cs
@@ -13,6 +13,7 @@ namespace Pixel.Automation.Core.Components.Processors
     [DataContract]
     [Serializable]
     [ToolBoxItem("Parallel Processor", "Entity Processor", iconSource: null, description: "Process it's child entities parallely", tags: new string[] { "Parallel Processor" })]
+    [NoDropTarget]
     public class ParallelEntityProcessor : EntityProcessor
     {
         private readonly ILogger logger = Log.ForContext<ParallelEntityProcessor>();
@@ -47,12 +48,7 @@ namespace Pixel.Automation.Core.Components.Processors
 
             await Task.CompletedTask;
         }
-
-        public void AddParallelBlock()
-        {
-            base.AddComponent(new SequenceEntity() { Name = $"Parallel Block #{this.Entities.Count() + 1}" });
-        }
-
+      
         public override void ResolveDependencies()
         {
             if (this.Components.Count() > 0)
@@ -66,6 +62,10 @@ namespace Pixel.Automation.Core.Components.Processors
 
         public override Entity AddComponent(IComponent component)
         {
+            if(component is SequenceEntity sequenceEntity)
+            {
+                base.AddComponent(sequenceEntity);
+            }
             return this;
         }
 

--- a/src/Pixel.Automation.Core/Attributes/NoDropTargetAttribute.cs
+++ b/src/Pixel.Automation.Core/Attributes/NoDropTargetAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Pixel.Automation.Core.Attributes
+{
+    /// <summary>
+    /// Entities decorated with NoDropTargetAttribute won't receive any other components on drag drop at design time. 
+    /// </summary>
+    public class NoDropTargetAttribute : Attribute
+    {
+    }
+}

--- a/src/Pixel.Automation.Core/Component/Component.cs
+++ b/src/Pixel.Automation.Core/Component/Component.cs
@@ -24,10 +24,7 @@ namespace Pixel.Automation.Core
         /// <inheritdoc/>
         public virtual string Id
         {
-            get
-            {
-                return id;
-            }
+            get => this.id;
             protected set
             {
                 id = value;
@@ -41,11 +38,7 @@ namespace Pixel.Automation.Core
         /// <inheritdoc/>
         public virtual string Name
         {
-            get
-            {
-                return this.name;
-            }
-
+            get => this.name;
             set
             {
                 this.name = value;
@@ -60,13 +53,9 @@ namespace Pixel.Automation.Core
         /// <inheritdoc/>
         public virtual string Tag
         {
-            get
-            {
-                return tag;
-            }
-
+            get => this.tag;
             set
-            {                
+            {
                 this.tag = value;
                 OnPropertyChanged();
             }
@@ -78,29 +67,22 @@ namespace Pixel.Automation.Core
         /// <inheritdoc/>
         public bool IsEnabled
         {
-            get
-            {
-                return isEnabled;
-            }
+            get => this.isEnabled;
             set
             {
-                isEnabled = value;
+                this.isEnabled = value;
                 OnPropertyChanged();
             }
         }
 
-        int processOrder=1;
+        int processOrder = 1;
         [DataMember(Name= "ProcessOrder", Order =50,IsRequired =true)] 
         [Display(Name = "Order", Order = 40, GroupName = "Component", Description ="Process order of the component")]
         [ReadOnly(true)]
         /// <inheritdoc/>
         public int ProcessOrder
         {
-            get
-            {
-                return processOrder;
-            }
-
+            get => this.processOrder;
             set
             {
                 this.processOrder = value;
@@ -115,15 +97,12 @@ namespace Pixel.Automation.Core
         /// <inheritdoc/>
         public Entity Parent
         {
-            get
-            {
-                return parent;
-            }         
+            get => this.parent;
             set
             {
-              parent = value;
+                this.parent = value;
             }
-        }       
+        }
 
         [NonSerialized]
         IEntityManager entityManager;
@@ -131,40 +110,26 @@ namespace Pixel.Automation.Core
         [IgnoreDataMember]     
         public IEntityManager EntityManager
         {
-            get
-            {               
-                return this.entityManager;
-            }
-
+            get => this.entityManager;
             set
-            {            
+            {
                 this.entityManager = value;
                 OnPropertyChanged();
             }
         }
 
         [Browsable(false)]
-        public IArgumentProcessor ArgumentProcessor
-        {
-            get
-            {
-                return this.EntityManager.GetArgumentProcessor();
-            }
-        }
-
-
+        public IArgumentProcessor ArgumentProcessor  => this.EntityManager.GetArgumentProcessor();
+       
         [NonSerialized]
-        protected bool isValid=true;   
+        protected bool isValid = true;   
         [Browsable(false)]
         public bool IsValid
         {
-            get
-            {
-                return isValid;
-            }
+            get => this.isValid;
             protected set
             {
-                isValid = value;
+                this.isValid = value;
                 OnPropertyChanged();
             }
         }
@@ -179,13 +144,10 @@ namespace Pixel.Automation.Core
         [IgnoreDataMember]
         public bool IsFaulted
         {
-            get
-            {
-                return isFaulted;
-            }
+            get => this.isFaulted;
             set
             {
-                isFaulted = value;
+                this.isFaulted = value;
                 OnPropertyChanged();
             }
         }
@@ -198,7 +160,7 @@ namespace Pixel.Automation.Core
             this.Tag = GetType().Name;
         }
 
-        public Component(string name="", string tag="")
+        public Component(string name = "", string tag = "")
         {
             this.Id = Guid.NewGuid().ToString();
             this.IsEnabled = true;
@@ -246,7 +208,8 @@ namespace Pixel.Automation.Core
         public virtual void ResetComponent()
         {
             
-        }      
+        }   
+        
         /// <inheritdoc/>
         public virtual void ResolveDependencies()
         {
@@ -318,7 +281,7 @@ namespace Pixel.Automation.Core
       
 
         [NonSerialized]
-        private List<string> errorMessages = new List<string>();
+        private List<string> errorMessages = new ();
         [Browsable(false)]
         [IgnoreDataMember]
         public List<string> ErrorMessages
@@ -334,7 +297,7 @@ namespace Pixel.Automation.Core
 
         }
 
-        public ActorComponent(string name = "", string tag = "") : base(name,tag)
+        public ActorComponent(string name = "", string tag = "") : base(name, tag)
         {
 
         }
@@ -397,7 +360,7 @@ namespace Pixel.Automation.Core
         }        
 
         [NonSerialized]
-        private List<string> errorMessages = new List<string>();
+        private List<string> errorMessages = new ();
         [Browsable(false)]
         [IgnoreDataMember]
         public List<string> ErrorMessages
@@ -450,7 +413,7 @@ namespace Pixel.Automation.Core
 
         }
 
-        public ServiceComponent(string name = "", string tag = ""):base(name,tag)
+        public ServiceComponent(string name = "", string tag = ""):base(name, tag)
         {
 
         }

--- a/src/Pixel.Automation.Core/Component/Entity.cs
+++ b/src/Pixel.Automation.Core/Component/Entity.cs
@@ -1,7 +1,6 @@
 ﻿using Pixel.Automation.Core.Interfaces;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -16,8 +15,7 @@ namespace Pixel.Automation.Core
     [Serializable]
     public class Entity : Component
     {
-        protected List<IComponent> components = new List<IComponent>();
-       
+        protected List<IComponent> components = new ();       
         /// <summary>
         /// List of all components added to Entity
         /// </summary>
@@ -34,24 +32,7 @@ namespace Pixel.Automation.Core
                 components = value;
             }
         }
-
-        protected ObservableCollection<IComponent> componentCollection;
-        /// <summary>
-        /// This is bound in view
-        /// </summary>
-        [Browsable(false)]
-        public virtual ObservableCollection<IComponent> ComponentCollection
-        {
-            get
-            {
-                if(componentCollection == null)
-                {
-                    componentCollection = new ObservableCollection<IComponent>(this.Components);
-                }
-                return componentCollection;
-            }
-        }       
-
+       
         /// <summary>
         /// Get all child components of type Entity
         /// </summary>
@@ -74,7 +55,7 @@ namespace Pixel.Automation.Core
         /// </summary>
         /// <param name="name">Name of the entity</param>
         /// <param name="tag">Tag assigned to entity</param>
-        public Entity(string name="", string tag="") : base(name:name, tag:tag)
+        public Entity(string name = "", string tag = "") : base(name :name, tag:tag)
         {
            
         }
@@ -115,11 +96,7 @@ namespace Pixel.Automation.Core
                         component.ProcessOrder = this.components.Last().ProcessOrder + 1;
                     }
                   
-                    this.Components.Add(component);
-                    if(!this.ComponentCollection.Contains(component))
-                    {
-                        this.ComponentCollection.Add(component);
-                    }
+                    this.Components.Add(component);                  
                     component.ValidateComponent();
                         
                 }
@@ -139,16 +116,11 @@ namespace Pixel.Automation.Core
         /// Remove component from this entity and set component's parent to null 
         /// </summary>
         /// <param name="component"></param>
-        public virtual void RemoveComponent(IComponent component,bool dispose=true)
+        public virtual void RemoveComponent(IComponent component, bool dispose = true)
         {           
             if (component != null && this.components.Contains(component))
             {                
-                this.Components.Remove(component);
-                if(this.ComponentCollection.Contains(component))
-                {
-                    this.ComponentCollection.Remove(component);
-                }
-
+                this.components.Remove(component);               
                 component.Parent = null;
                 component.EntityManager = null;
                
@@ -173,20 +145,15 @@ namespace Pixel.Automation.Core
         /// <param name="target">Component to be moved to a new index</param>
         /// <param name="oldIndex">Old index of the component</param>
         /// <param name="newIndex">New index of the component</param>
-        public void MoveComponent(IComponent target, int oldIndex, int newIndex)
+        public void MoveComponent(int oldIndex, int newIndex)
         {
-            //int count = this.ComponentCollection.Count;
-            if(this.ComponentCollection.Contains(target))
+            var componentToMove = this.Components.ElementAt(oldIndex);
+            this.Components.RemoveAt(oldIndex);
+            this.Components.Insert(newIndex, componentToMove);
+            int i = 1;
+            foreach (var c in this.components)
             {
-                this.ComponentCollection.Move(oldIndex, newIndex);
-                int processOrder = 1;
-                foreach (var component in this.ComponentCollection)
-                {
-                    component.ProcessOrder = processOrder;
-                    processOrder++;
-                }
-
-                this.Components = this.Components.OrderBy(c => c.ProcessOrder).ToList();
+                c.ProcessOrder = i++;
             }
         }
 
@@ -196,7 +163,7 @@ namespace Pixel.Automation.Core
         /// <returns></returns>
         public virtual IEnumerable<IComponent> GetNextComponentToProcess()
         {
-            foreach (var component in this.ComponentCollection)
+            foreach (var component in this.components)
             {
                 if (!component.IsEnabled)
                 {

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
@@ -10,6 +10,7 @@ using Pixel.Automation.Designer.ViewModels.AutomationBuilder;
 using Pixel.Automation.Editor.Core;
 using Pixel.Automation.Editor.Core.Interfaces;
 using Pixel.Automation.Editor.Core.Notfications;
+using Pixel.Automation.Editor.Core.ViewModels;
 using Pixel.Scripting.Editor.Core.Contracts;
 using Serilog;
 using System;
@@ -28,7 +29,8 @@ namespace Pixel.Automation.Designer.ViewModels
         #region data members        
 
         private readonly ILogger logger = Log.ForContext<AutomationEditorViewModel>();
-        private readonly IAutomationProjectManager projectManager;    
+        private readonly IAutomationProjectManager projectManager;
+        private readonly IComponentViewBuilder componentViewBuilder;
         private readonly IServiceResolver serviceResolver;
         private readonly ITestExplorer testExplorer;
         private readonly ITestExplorerHost testExplorerHost;        
@@ -41,13 +43,14 @@ namespace Pixel.Automation.Designer.ViewModels
         #region constructor
         public AutomationEditorViewModel(IServiceResolver serviceResolver, IEventAggregator globalEventAggregator, IWindowManager windowManager, 
             ISerializer serializer, IEntityManager entityManager, ITestExplorer testExplorer, ITestDataRepository testDataRepository,
-            IAutomationProjectManager projectManager, IScriptExtactor scriptExtractor, IReadOnlyCollection<IAnchorable> anchorables, 
+            IAutomationProjectManager projectManager, IComponentViewBuilder componentViewBuilder, IScriptExtactor scriptExtractor, IReadOnlyCollection<IAnchorable> anchorables, 
             IVersionManagerFactory versionManagerFactory, IDropTarget dropTarget, ApplicationSettings applicationSettings)
             : base(globalEventAggregator, windowManager, serializer, entityManager, scriptExtractor, versionManagerFactory, dropTarget, applicationSettings)
         {
 
             this.serviceResolver = Guard.Argument(serviceResolver).NotNull().Value;
-            this.projectManager = Guard.Argument(projectManager).NotNull().Value;           
+            this.projectManager = Guard.Argument(projectManager).NotNull().Value;
+            this.componentViewBuilder = Guard.Argument(componentViewBuilder).NotNull().Value;
             this.testExplorer = Guard.Argument(testExplorer).NotNull().Value;
             this.testDataRepository = Guard.Argument(testDataRepository).NotNull().Value;
             Guard.Argument(anchorables).NotNull().NotEmpty().DoesNotContainNull();
@@ -186,7 +189,13 @@ namespace Pixel.Automation.Designer.ViewModels
                 logger.Error(ex, ex.Message);
             }
         }
-     
+
+        protected override void BuildWorkFlow(EntityComponentViewModel root)
+        {
+            base.BuildWorkFlow(root);
+            this.componentViewBuilder.SetRoot(root);
+        }
+
         #endregion Automation Project
 
         #region OnLoad

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ComponentViewBuilder.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ComponentViewBuilder.cs
@@ -1,0 +1,55 @@
+﻿using Dawn;
+using Pixel.Automation.Core.TestData;
+using Pixel.Automation.Editor.Core.Interfaces;
+using Pixel.Automation.Editor.Core.ViewModels;
+
+namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
+{
+    internal class ComponentViewBuilder : IComponentViewBuilder
+    {
+        private EntityComponentViewModel root;
+
+        public ComponentViewBuilder()
+        {
+
+        }
+
+        public void SetRoot(EntityComponentViewModel root)
+        {
+            this.root = Guard.Argument(root);
+        }
+
+        public void OpenTestFixture(TestFixture fixture)
+        {
+            root.AddComponent(fixture.TestFixtureEntity);
+        }
+
+        public void CloseTestFixture(TestFixture fixture)
+        {
+            root.RemoveComponent(fixture.TestFixtureEntity);
+        }
+
+        public void OpenTestCase(TestCase testCase)
+        {
+            foreach(var component in root.ComponentCollection)
+            {
+                if(component.Model.Tag.Equals(testCase.FixtureId) && component is EntityComponentViewModel fixtureEntityViewmodel)
+                {
+                    fixtureEntityViewmodel.AddComponent(testCase.TestCaseEntity);
+                }
+            }
+        }
+
+        public void CloseTestCase(TestCase testCase)
+        {
+            foreach (var component in root.ComponentCollection)
+            {
+                if (component.Model.Tag.Equals(testCase.FixtureId) && component is EntityComponentViewModel fixtureEntityViewmodel)
+                {
+                    fixtureEntityViewmodel.RemoveComponent(testCase.TestCaseEntity);
+                }
+            }
+        }      
+
+    }
+}

--- a/src/Pixel.Automation.Designer.ViewModels/Modules/WorkspaceModules.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Modules/WorkspaceModules.cs
@@ -22,6 +22,7 @@ namespace Pixel.Automation.Designer.ViewModels.Modules
             Kernel.Bind<IPrefabEditor>().To<PrefabEditorViewModel>().InSingletonScope();
             Kernel.Bind<ITestExplorer>().To<TestExplorerViewModel>();
             Kernel.Bind<ITestDataRepository>().To<TestDataRepositoryViewModel>();
+            Kernel.Bind<IComponentViewBuilder>().To<ComponentViewBuilder>().InSingletonScope();
 
             Kernel.Bind<IAutomationProjectManager>().To<AutomationProjectManager>().InSingletonScope();
             Kernel.Bind<IPrefabProjectManager>().To<PrefabProjectManager>().InSingletonScope();

--- a/src/Pixel.Automation.Designer.Views/AutomationEditorView.xaml.cs
+++ b/src/Pixel.Automation.Designer.Views/AutomationEditorView.xaml.cs
@@ -80,8 +80,7 @@ namespace Pixel.Automation.Designer.Views
 
         public AutomationEditorView()
         {
-            InitializeComponent();
-            WorkFlowRoot.RequestBringIntoView += WorkFlowRoot_RequestBringIntoView;           
+            InitializeComponent();              
         }      
 
         private void OnScroll(object sender, MouseWheelEventArgs e)
@@ -95,11 +94,6 @@ namespace Pixel.Automation.Designer.Views
             }
 
             this.TransformY += e.Delta/5;          
-        }
-
-        private void WorkFlowRoot_RequestBringIntoView(object sender, RequestBringIntoViewEventArgs e)
-        {
-            e.Handled = true;
         }
         
         private void ZoomIn_Click(object sender, RoutedEventArgs e)

--- a/src/Pixel.Automation.Designer.Views/Resources/Component.Templates.Common.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Component.Templates.Common.xaml
@@ -16,24 +16,14 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleButton">
-                    <Grid
-          Width="15"
-          Height="13"
-          Background="Transparent">
-                        <Path x:Name="ExpandPath"
-            HorizontalAlignment="Left" 
-            VerticalAlignment="Center" 
-            Margin="1,1,1,1"
-            Fill="{StaticResource GlyphBrush}"
-            Data="M 4 0 L 8 4 L 4 8 Z"/>
-                        <!--<Ellipse x:Name="ExpandPath" Width="10" Height="10" HorizontalAlignment="Center" VerticalAlignment="Center" Fill="{StaticResource GlyphBrush}"></Ellipse>-->
+                    <Grid Width="15" Height="13" Background="Transparent">
+                        <Path x:Name="ExpandPath" HorizontalAlignment="Left" 
+                                VerticalAlignment="Center" Margin="1,1,1,1"
+                                Fill="{StaticResource GlyphBrush}" Data="M 4 0 L 8 4 L 4 8 Z"/>
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsChecked"
-               Value="True">
-                            <Setter Property="Data"
-                TargetName="ExpandPath"
-                Value="M 0 4 L 8 4 L 4 8 Z"/>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Data"  TargetName="ExpandPath" Value="M 0 4 L 8 4 L 4 8 Z"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/Pixel.Automation.Designer.Views/Resources/Component.Templates.Slim.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Component.Templates.Slim.xaml
@@ -25,7 +25,7 @@
                 Background="{DynamicResource MahApps.Brushes.Control.Background}">
             <DockPanel Grid.Row="0" LastChildFill="True" Margin="4" Width="Auto" HorizontalAlignment="Stretch"
                       IsHitTestVisible="True">
-                <Label DockPanel.Dock="Left"  Content="{Binding Name}" MaxWidth="160" 
+                <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}" MaxWidth="160" 
                        HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
                 <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                             HorizontalAlignment="Right" Orientation="Horizontal">
@@ -45,14 +45,13 @@
             <Trigger Property="IsMouseOver"  Value="true">
                 <Setter TargetName="pnlActions"  Property="Visibility" Value="Visible"/>
             </Trigger>
-            <DataTrigger Binding="{Binding IsValid}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Gray"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding
-                            RelativeSource={RelativeSource
+            <DataTrigger Binding="{Binding  RelativeSource={RelativeSource
                                 Mode=FindAncestor,
                                 AncestorType={x:Type TreeViewItem}},
                                 Path=IsSelected}" Value="True">
@@ -67,7 +66,7 @@
                 Background="{DynamicResource MahApps.Brushes.Control.Background}">
             <DockPanel LastChildFill="True" Margin="4" Width="Auto" HorizontalAlignment="Stretch"
                       IsHitTestVisible="True">
-                <Label DockPanel.Dock="Left"  Content="{Binding Name}" MaxWidth="160" 
+                <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}" MaxWidth="160" 
                        HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
                 <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                             HorizontalAlignment="Right" Orientation="Horizontal">
@@ -83,14 +82,13 @@
             <Trigger Property="IsMouseOver"  Value="true">
                 <Setter TargetName="pnlActions"  Property="Visibility" Value="Visible"/>
             </Trigger>
-            <DataTrigger Binding="{Binding IsValid}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Gray"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding
-                            RelativeSource={RelativeSource
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource
                                 Mode=FindAncestor,
                                 AncestorType={x:Type TreeViewItem}},
                                 Path=IsSelected}" Value="True">
@@ -104,8 +102,8 @@
                 HorizontalAlignment="Stretch" Margin="0,4,0,4" MinWidth="220" dd:DragDrop.IsDragSource="True"
                 Background="{DynamicResource MahApps.Brushes.Control.Background}">
             <DockPanel Grid.Row="0" LastChildFill="True" Margin="4" Width="Auto" HorizontalAlignment="Stretch"
-                       IsHitTestVisible="True">               
-                <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                       IsHitTestVisible="True">
+                <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
                 <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                             HorizontalAlignment="Right" Orientation="Horizontal">
                     <Button x:Name="RunProcessor" Width="20"  Height="20" HorizontalAlignment="Right"  Margin="0,0,0,0"
@@ -128,14 +126,13 @@
             <Trigger Property="IsMouseOver"  Value="true">
                 <Setter TargetName="pnlActions"  Property="Visibility" Value="Visible"/>
             </Trigger>
-            <DataTrigger Binding="{Binding IsValid}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Gray"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding
-                            RelativeSource={RelativeSource
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource
                                 Mode=FindAncestor,
                                 AncestorType={x:Type TreeViewItem}},
                                 Path=IsSelected}" Value="True">
@@ -151,7 +148,7 @@
             <DockPanel Grid.Row="0" LastChildFill="True" Margin="4" Width="Auto" HorizontalAlignment="Stretch"
                       IsHitTestVisible="True">
 
-                <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
 
                 <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                             HorizontalAlignment="Right" Orientation="Horizontal">
@@ -171,20 +168,19 @@
             <Trigger Property="IsMouseOver"  Value="true">
                 <Setter TargetName="pnlActions"  Property="Visibility" Value="Visible"/>
             </Trigger>
-            <DataTrigger Binding="{Binding IsExecuting}" Value="true">
+            <DataTrigger Binding="{Binding Model.IsExecuting}" Value="true">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Green"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsFaulted}" Value="true">
+            <DataTrigger Binding="{Binding Model.IsFaulted}" Value="true">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsValid}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Gray"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding
-                            RelativeSource={RelativeSource
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource
                                 Mode=FindAncestor,
                                 AncestorType={x:Type TreeViewItem}},
                                 Path=IsSelected}" Value="True">
@@ -199,7 +195,7 @@
                 Background="{DynamicResource MahApps.Brushes.Control.Background}">
             <DockPanel Grid.Row="0" LastChildFill="True" Margin="4" Width="Auto" HorizontalAlignment="Stretch"
                        IsHitTestVisible="True">
-                <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
                 <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                             HorizontalAlignment="Right" Orientation="Horizontal">
                     <Button x:Name="btnDeleteComponent" Width="20"  Height="20" HorizontalAlignment="Right"  Margin="0,0,0,0"
@@ -216,14 +212,13 @@
             <Trigger Property="IsMouseOver"  Value="true">
                 <Setter TargetName="btnDeleteComponent"  Property="Visibility" Value="Visible"/>
             </Trigger>
-            <DataTrigger Binding="{Binding IsValid}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Gray"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding
-                            RelativeSource={RelativeSource
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource
                                 Mode=FindAncestor,
                                 AncestorType={x:Type TreeViewItem}},
                                 Path=IsSelected}" Value="True">
@@ -241,19 +236,19 @@
                                             ToolTip="Control">
                     <iconPacks:PackIconSimpleIcons Kind="Buffer" Foreground="{DynamicResource MahApps.Brushes.Accent}" Background="{DynamicResource MahApps.Brushes.Control.Background}"/>
                 </StackPanel>
-                <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
                 <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                             HorizontalAlignment="Right" Orientation="Horizontal">
-                    <prefabs:InputMappingButton ScriptFile="{Binding InputMappingScriptFile, Mode=OneWay}"
-                                                AssignFrom="{Binding DataModelType, Mode=OneWay}"
-                                                OwnerComponent="{Binding}"
-                                                EntityManager="{Binding EntityManager, Mode=OneWay}"
-                                                AssignTo="{Binding PrefabDataModelType, Mode=OneWay}"></prefabs:InputMappingButton>
-                    <prefabs:OutputMappingButton ScriptFile="{Binding OutputMappingScriptFile, Mode=OneWay}" 
-                                                AssignFrom="{Binding PrefabDataModelType, Mode=OneWay}" 
-                                                OwnerComponent="{Binding}"
-                                                EntityManager="{Binding EntityManager, Mode=OneWay}"
-                                                AssignTo="{Binding DataModelType, Mode=OneWay}"></prefabs:OutputMappingButton>
+                    <prefabs:InputMappingButton ScriptFile="{Binding Model.InputMappingScriptFile, Mode=OneWay}"
+                                                AssignFrom="{Binding Model.DataModelType, Mode=OneWay}"
+                                                OwnerComponent="{Binding Model}"
+                                                EntityManager="{Binding Model.EntityManager, Mode=OneWay}"
+                                                AssignTo="{Binding Model.PrefabDataModelType, Mode=OneWay}"></prefabs:InputMappingButton>
+                    <prefabs:OutputMappingButton ScriptFile="{Binding Model.OutputMappingScriptFile, Mode=OneWay}" 
+                                                AssignFrom="{Binding Model.PrefabDataModelType, Mode=OneWay}" 
+                                                OwnerComponent="{Binding Model}"
+                                                EntityManager="{Binding Model.EntityManager, Mode=OneWay}"
+                                                AssignTo="{Binding Model.DataModelType, Mode=OneWay}"></prefabs:OutputMappingButton>
                     <Button x:Name="btnDeleteComponent" Width="20"  Height="20" HorizontalAlignment="Right"  Margin="0,0,0,0"
                       cal:Message.Attach="[Event Click] = [Action DeleteComponent($dataContext)]"
                       Style="{DynamicResource EditControlButtonStyle}" ToolTip="Delete"
@@ -268,14 +263,13 @@
             <Trigger Property="IsMouseOver"  Value="true">
                 <Setter TargetName="btnDeleteComponent"  Property="Visibility" Value="Visible"/>
             </Trigger>
-            <DataTrigger Binding="{Binding IsValid}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Gray"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding
-                            RelativeSource={RelativeSource
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource
                                 Mode=FindAncestor,
                                 AncestorType={x:Type TreeViewItem}},
                                 Path=IsSelected}" Value="True">
@@ -286,15 +280,15 @@
 
     <HierarchicalDataTemplate x:Key="ParallelProcessorTemplate"  ItemsSource="{Binding ComponentCollection}">
         <DockPanel LastChildFill="True" Width="Auto" HorizontalAlignment="Stretch" Margin="4" 
-                   Background="{DynamicResource MahApps.Brushes.Control.Background}" IsHitTestVisible="True">          
-            <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                   Background="{DynamicResource MahApps.Brushes.Control.Background}" IsHitTestVisible="True">
+            <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
             <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed" HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button x:Name="RunProcessor" Width="20"  Height="20" HorizontalAlignment="Right"  Margin="0,0,2,0"
                                                     cal:Message.Attach="[Event Click] = [Action RunComponent($dataContext)]" 
                                                     Style="{DynamicResource EditControlButtonStyle}" ToolTip="Run" 
                                                     Content="{iconPacks:FontAwesome PlayCircleSolid}"/>
                 <Button x:Name="AddParallelBlock" Margin="0,0,2,0" HorizontalAlignment="Right" 
-                                            Height="20" Width="20" ToolTip="Edit Script"
+                                            Height="20" Width="20" ToolTip="Add parallel block"                                         
                                             cal:Message.Attach="[Event Click] = [Action AddParallelBlock()]"                   
                                             Style="{DynamicResource EditControlButtonStyle}"
                                             Content="{iconPacks:MaterialLight PlusCircle}"/>
@@ -322,7 +316,7 @@
                 Background="{DynamicResource MahApps.Brushes.Control.Background}">
             <DockPanel LastChildFill="True" Margin="4" Width="Auto" HorizontalAlignment="Stretch"
                       IsHitTestVisible="True">
-                <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
                 <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed" HorizontalAlignment="Right" Orientation="Horizontal">
                     <Button x:Name="RunProcessor" Width="20"  Height="20" HorizontalAlignment="Right"  Margin="0,0,2,0"
                                                     cal:Message.Attach="[Event Click] = [Action RunComponent($dataContext)]" 
@@ -354,7 +348,7 @@
                 <iconPacks:PackIconMaterial Kind="ViewSequential" Foreground="{DynamicResource MahApps.Brushes.Accent}" 
                                                                   Background="{DynamicResource MahApps.Brushes.Control.Background}"/>
             </StackPanel>
-            <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Left" VerticalAlignment="Center"></Label>
+            <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Left" VerticalAlignment="Center"></Label>
             <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                                                 HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button x:Name="btnDrillIn" Margin="0,0,2,0" HorizontalAlignment="Right" 
@@ -385,7 +379,7 @@
                 <iconPacks:PackIconMaterial Kind="Application"  Foreground="{DynamicResource MahApps.Brushes.Accent}" 
                                                                   Background="{DynamicResource MahApps.Brushes.Control.Background}"/>
             </StackPanel>
-            <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Left" VerticalAlignment="Center"></Label>
+            <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Left" VerticalAlignment="Center"></Label>
             <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                                                 HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button x:Name="btnDrillIn" Margin="0,0,2,0" HorizontalAlignment="Right" 
@@ -422,7 +416,7 @@
     </HierarchicalDataTemplate>
   
     <Style TargetType="TreeViewItem" x:Key="GroupedStyle">
-        <Setter Property="IsExpanded" Value="True"/>
+        <Setter Property="IsExpanded" Value="True"/>       
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="TreeViewItem">
@@ -465,11 +459,11 @@
                                             ToolTip="Control">
                                         <iconPacks:PackIconSimpleIcons Kind="UIkit" Foreground="{DynamicResource MahApps.Brushes.Accent}" />
                                     </StackPanel>
-                                    <Label DockPanel.Dock="Left"  Content="{Binding Name}" MaxWidth="160" 
+                                    <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}" MaxWidth="160" 
                                             HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
                                     <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                                             HorizontalAlignment="Right" Orientation="Horizontal">
-                                        <Button x:Name="Run" Margin="0,0,2,0" HorizontalAlignment="Right" Height="20" Width="20" ToolTip="Run" DataContext="{Binding GroupActor}"
+                                        <Button x:Name="Run" Margin="0,0,2,0" HorizontalAlignment="Right" Height="20" Width="20" ToolTip="Run" DataContext="{Binding Model.GroupActor}"
                                             cal:Message.Attach="[Action RunComponent($dataContext)]" Style="{DynamicResource EditControlButtonStyle}"
                                             Content="{iconPacks:MaterialLight Play}"/>
                                         <Button x:Name="btnDrillIn" Margin="0,0,2,0" HorizontalAlignment="Right" 
@@ -496,12 +490,11 @@
                                         </Border>
 
                                         <ItemsPresenter x:Name="ItemsHost" MinWidth="200" Margin="8" Visibility="Visible"                                               
-                                                HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+                                              HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
                                     </Grid>
                                 </StackPanel>
                             </DockPanel>
-                        </Border>                      
-                      
+                        </Border>                     
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
@@ -512,19 +505,19 @@
                             <Setter TargetName="ContentHost"   Property="Visibility"  Value="Visible"/>
                             <Setter TargetName="ComponentControl"   Property="MinWidth"  Value="460"/>
                         </Trigger>
-                        <DataTrigger Binding="{Binding IsValid}" Value="false">
+                        <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Red"></Setter>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding GroupActor.IsValid}" Value="false">
+                        <DataTrigger Binding="{Binding Model.GroupActor.IsValid}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Red"></Setter>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding GroupActor.IsExecuting}" Value="true">
+                        <DataTrigger Binding="{Binding Model.GroupActor.IsExecuting}" Value="true">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Green"></Setter>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding GroupActor.IsFaulted}" Value="true">
+                        <DataTrigger Binding="{Binding Model.GroupActor.IsFaulted}" Value="true">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Red"></Setter>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+                        <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Gray"></Setter>
                         </DataTrigger>
                         <Trigger Property="IsSelected" Value="true">

--- a/src/Pixel.Automation.Designer.Views/Resources/Components.TreeViewItem.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Components.TreeViewItem.xaml
@@ -194,10 +194,10 @@
                         <DataTrigger Binding="{Binding ElementName=LeftConnector, Path=Height}" Value="1">
                             <Setter TargetName="LeftConnector"  Property="Visibility" Value="Visible" />
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding IsValid}" Value="false">
+                        <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Red"></Setter>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+                        <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Gray"></Setter>
                         </DataTrigger>
                         <Trigger Property="IsSelected" Value="true">

--- a/src/Pixel.Automation.Designer.Views/Resources/Control.Components.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Control.Components.xaml
@@ -12,7 +12,7 @@
     <HierarchicalDataTemplate x:Key="ControlTemplate" ItemsSource="{Binding ComponentCollection}">        
                 <DockPanel LastChildFill="True" MinWidth="220" Width="220" Grid.Row="2"
                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsHitTestVisible="True">
-            <Image DockPanel.Dock="Left" Margin="10" Source="{Binding ControlDescription.ControlImage, Converter={StaticResource bitMapConverter}}"
+            <Image DockPanel.Dock="Left" Margin="10" Source="{Binding Model.ControlDescription.ControlImage, Converter={StaticResource bitMapConverter}}"
                         HorizontalAlignment="Center" Stretch="Uniform" 
                         Height="50">              
             </Image>
@@ -40,7 +40,7 @@
                                             ToolTip="Control">
                                         <iconPacks:PackIconModern Kind="ControllerSnes" Foreground="{DynamicResource MahApps.Brushes.Accent}"/>
                                     </StackPanel>
-                                    <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"></Label>
+                                    <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"></Label>
                                     <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                                                 HorizontalAlignment="Right" Orientation="Horizontal">                                       
                                         <Button x:Name="btnDrillIn" Margin="0,0,2,0" HorizontalAlignment="Right" 
@@ -76,11 +76,11 @@
                         </Trigger>
                         <Trigger Property="HasItems"  Value="false">
                             <Setter TargetName="ItemsHost"   Property="Visibility"  Value="Collapsed"/>
-                        </Trigger>                      
-                        <DataTrigger Binding="{Binding IsValid}" Value="false">
+                        </Trigger>
+                        <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Red"></Setter>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+                        <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Gray"></Setter>
                         </DataTrigger>
                         <Trigger Property="IsSelected" Value="true">

--- a/src/Pixel.Automation.Designer.Views/Resources/Decisions.Components.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Decisions.Components.xaml
@@ -15,7 +15,7 @@
             <StackPanel Orientation="Vertical" Grid.Row="0">
             <Label Content="Condition" Padding="4,0,4,0" FontSize="10"></Label>
             <se:InlineScriptEditorUserControl VerticalContentAlignment="Center"  Margin="2"          
-                    OwnerComponent="{Binding}" ScriptFile="{Binding ScriptFile}"/>
+                    OwnerComponent="{Binding Model}" ScriptFile="{Binding Model.ScriptFile}"/>
         </StackPanel>         
     </HierarchicalDataTemplate>  
 

--- a/src/Pixel.Automation.Designer.Views/Resources/Loops.Components.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Loops.Components.xaml
@@ -14,21 +14,20 @@
             <Label Content="Condition" Padding="4,0,4,0" FontSize="12" VerticalContentAlignment="Center"></Label>
             <se:InlineScriptEditorUserControl VerticalContentAlignment="Center" Margin="2"  
                     HorizontalAlignment="Stretch"       
-                    OwnerComponent="{Binding}" ScriptFile="{Binding ScriptFile}"/>
+                    OwnerComponent="{Binding Model}" ScriptFile="{Binding Model.ScriptFile}"/>
         </StackPanel>
     </HierarchicalDataTemplate>
     
     <HierarchicalDataTemplate x:Key="ForEachTemplate" ItemsSource="{Binding ComponentCollection}">
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" Grid.Row="0" Margin="6,6,6,2">
             <Label Content="Foreach" Padding="4,0,4,0" FontSize="10" VerticalContentAlignment="Center"></Label>
-            <ae:OutArgumentUserControl x:Name="CurrentObjectArgument" Argument="{Binding Current}"                                                                   
-                                      OwnerComponent="{Binding}"  MinWidth="180" Height="37.26" 
+            <ae:OutArgumentUserControl x:Name="CurrentObjectArgument" MinWidth="180" Height="37.26"                                                                  
+                                      OwnerComponent="{Binding Model}" Argument="{Binding Model.Current}"   
                                       HorizontalAlignment="Left" VerticalAlignment="Center"
                                       DockPanel.Dock="Left"/>
             <Label Content="in" Margin="2,0,2,0" Padding="4,0,4,0" FontSize="10" VerticalContentAlignment="Center"></Label>
-            <ae:InArgumentUserControl  x:Name="TargetCollectionArgument" Argument="{Binding TargetCollection}" 
-                                       MinWidth="180" Height="37.26" HorizontalAlignment="Stretch" VerticalAlignment="Center"
-                                       OwnerComponent="{Binding}" DockPanel.Dock="Left"/>
+            <ae:InArgumentUserControl  x:Name="TargetCollectionArgument"  MinWidth="180" Height="37.26" HorizontalAlignment="Stretch" VerticalAlignment="Center"
+                                       OwnerComponent="{Binding Model}" Argument="{Binding Model.TargetCollection}"  DockPanel.Dock="Left"/>
         </StackPanel>
     </HierarchicalDataTemplate>
 
@@ -37,7 +36,7 @@
             <Label Content="Condition" Padding="4,0,4,0" FontSize="12" VerticalContentAlignment="Center"></Label>
             <se:InlineScriptEditorUserControl VerticalContentAlignment="Center"  Margin="2"
                     HorizontalContentAlignment="Stretch"
-                    OwnerComponent="{Binding}" ScriptFile="{Binding ScriptFile}"/>
+                    OwnerComponent="{Binding Model}" ScriptFile="{Binding Model.ScriptFile}"/>
         </StackPanel>
     </HierarchicalDataTemplate>
 
@@ -46,12 +45,12 @@
             <Label Content="Condition" Padding="4,0,4,0" FontSize="12" HorizontalAlignment="Stretch" VerticalContentAlignment="Center"></Label>
             <se:InlineScriptEditorUserControl VerticalContentAlignment="Center"  Margin="2,2,2,6"   HorizontalAlignment="Stretch"
                     HorizontalContentAlignment="Stretch"                                              
-                    OwnerComponent="{Binding}" ScriptFile="{Binding ScriptFile}"/>
+                    OwnerComponent="{Binding Model}" ScriptFile="{Binding Model.ScriptFile}"/>
         </StackPanel>
     </HierarchicalDataTemplate>    
 
     <Style TargetType="TreeViewItem" x:Key="LoopStyle">
-        <Setter Property="IsExpanded" Value="True"/>
+        <Setter Property="IsExpanded" Value="True"/>       
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="TreeViewItem">
@@ -97,7 +96,7 @@
                                             ToolTip="Control">
                                         <iconPacks:PackIconModern Kind="Repeat" Foreground="{DynamicResource MahApps.Brushes.Accent}" />
                                     </StackPanel>
-                                    <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"></Label>
+                                    <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"></Label>
                                     <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                                                 HorizontalAlignment="Right" Orientation="Horizontal">
                                         <Button x:Name="btnDrillIn" Margin="0,0,2,0" HorizontalAlignment="Right" 
@@ -140,10 +139,10 @@
                             <Setter TargetName="ContentHost"   Property="Visibility"  Value="Visible"/>
                             <Setter TargetName="ComponentControl"   Property="MinWidth"  Value="460"/>
                         </Trigger>
-                        <DataTrigger Binding="{Binding IsValid}" Value="false">
+                        <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Red"></Setter>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+                        <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Gray"></Setter>
                         </DataTrigger>
                         <Trigger Property="IsSelected" Value="true">
@@ -168,7 +167,7 @@
     </Style>
 
     <Style TargetType="TreeViewItem" x:Key="DoWhileStyle">
-        <Setter Property="IsExpanded" Value="True"/>
+        <Setter Property="IsExpanded" Value="True"/>  
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="TreeViewItem">
@@ -218,7 +217,7 @@
                                             ToolTip="Control">
                                         <iconPacks:PackIconModern Kind="Repeat" Foreground="{DynamicResource MahApps.Brushes.Accent}" />
                                     </StackPanel>
-                                    <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"></Label>
+                                    <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"></Label>
                                     <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" Visibility="Collapsed"
                                                 HorizontalAlignment="Right" Orientation="Horizontal">                                       
                                         <Button x:Name="btnDrillIn" Margin="0,0,2,0" HorizontalAlignment="Right" 
@@ -260,10 +259,10 @@
                             <Setter TargetName="ContentHost"   Property="Visibility"  Value="Visible"/>
                             <Setter TargetName="ComponentControl"   Property="MinWidth"  Value="460"/>
                         </Trigger>
-                        <DataTrigger Binding="{Binding IsValid}" Value="false">
+                        <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Red"></Setter>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+                        <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Gray"></Setter>
                         </DataTrigger>
                         <Trigger Property="IsSelected" Value="true">
@@ -290,7 +289,7 @@
     <Style TargetType="TreeViewItem" x:Key="PlaceHolderStyle">
         <Setter Property="IsExpanded" Value="True"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
-        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>       
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="TreeViewItem">
@@ -300,7 +299,7 @@
                             <RowDefinition></RowDefinition>
                             <RowDefinition></RowDefinition>
                         </Grid.RowDefinitions>
-                        <Label x:Name="Name" Content="{Binding Name}" Grid.Row="0" HorizontalAlignment="Stretch"/>
+                        <Label x:Name="Name" Content="{Binding Model.Name}" Grid.Row="0" HorizontalAlignment="Stretch"/>
                         <Border x:Name="ComponentControl" Grid.Row="1" BorderThickness="1"
                                 BorderBrush="{DynamicResource MahApps.Brushes.Accent}" 
                                 CornerRadius="2" Margin="4,4,4,8" HorizontalAlignment="Stretch" VerticalAlignment="Center"
@@ -330,10 +329,10 @@
                             <Setter TargetName="EmptyMessage"   Property="Visibility"  Value="Visible"/>
                             <Setter TargetName="ItemsHost"   Property="Visibility"  Value="Collapsed"/>
                         </Trigger>
-                        <DataTrigger Binding="{Binding IsValid}" Value="false">
+                        <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Red"></Setter>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+                        <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                             <Setter TargetName="ComponentControl" Property="BorderBrush" Value="Gray"></Setter>
                         </DataTrigger>
                         <Trigger Property="IsSelected" Value="true">

--- a/src/Pixel.Automation.Designer.Views/Resources/Scripting.Components.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Scripting.Components.xaml
@@ -19,8 +19,8 @@
                             ToolTip="C# Script">
                     <iconPacks:MaterialLight Kind="Script"/>
                 </StackPanel>
-              
-                <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+
+                <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
 
                 <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" HorizontalAlignment="Right" 
                             Orientation="Horizontal" Visibility="Collapsed">                  
@@ -29,7 +29,7 @@
                             cal:Message.Attach="[Action RunComponent($dataContext)]"                   
                             Style="{DynamicResource EditControlButtonStyle}"
                             Content="{iconPacks:MaterialLight Play}"/>                 
-                    <editors:ScriptEditorButton x:Name="btnEditScript" ScriptFile="{Binding ScriptFile}" ActorComponent="{Binding}" HorizontalAlignment="Right" Margin="0,0,2,0"/>
+                    <editors:ScriptEditorButton x:Name="btnEditScript" ScriptFile="{Binding Model.ScriptFile}" ActorComponent="{Binding Model}" HorizontalAlignment="Right" Margin="0,0,2,0"/>
                     <Button x:Name="btnDeleteComponent" Width="20"  Height="20" HorizontalAlignment="Right"  Margin="0,0,0,0"
                       cal:Message.Attach="[Event Click] = [Action DeleteComponent($dataContext)]"
                       Style="{DynamicResource EditControlButtonStyle}" ToolTip="Delete"
@@ -41,16 +41,16 @@
             <Trigger Property="IsMouseOver"  Value="true">              
                 <Setter TargetName="pnlActions"  Property="Visibility" Value="Visible"/>
             </Trigger>
-            <DataTrigger Binding="{Binding IsExecuting}" Value="true">
+            <DataTrigger Binding="{Binding Model.IsExecuting}" Value="true">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Green"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsFaulted}" Value="true">
+            <DataTrigger Binding="{Binding Model.IsFaulted}" Value="true">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsValid}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Gray"></Setter>
             </DataTrigger>
             <DataTrigger Binding="{Binding
@@ -75,11 +75,10 @@
                 </Grid.RowDefinitions>
                 <DockPanel Grid.Row="0" LastChildFill="True" Margin="4,4,4,0" MinWidth="165" HorizontalAlignment="Stretch"
                        IsHitTestVisible="True">
-                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="2"
-                                ToolTip="C# Script">
+                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="2" ToolTip="C# Script">
                         <iconPacks:MaterialLight Kind="Script"/>
                     </StackPanel>
-                    <Label DockPanel.Dock="Left"  Content="{Binding Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"></Label>
+                    <Label DockPanel.Dock="Left"  Content="{Binding Model.Name}"  HorizontalAlignment="Stretch" VerticalAlignment="Center"></Label>
                     <StackPanel x:Name="pnlActions" DockPanel.Dock="Right" HorizontalAlignment="Right"
                                 Orientation="Horizontal" Visibility="Collapsed">
                         <Button x:Name="btnExecuteScript"  Margin="0,0,2,0" HorizontalAlignment="Right" 
@@ -98,30 +97,26 @@
                     HorizontalAlignment="Stretch" Background="{DynamicResource MahApps.Brushes.Control.Background}"/>
                 <se:InlineScriptEditorUserControl Grid.Row="2" VerticalContentAlignment="Center"  Margin="2"     
                     HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" dd:DragDrop.DragSourceIgnore="true"
-                    OwnerComponent="{Binding}" ScriptFile="{Binding ScriptFile}"/>
+                    OwnerComponent="{Binding Model}" ScriptFile="{Binding Model.ScriptFile}"/>
             </Grid>
         </Border>
         <DataTemplate.Triggers>
             <Trigger Property="IsMouseOver"  Value="true">
                 <Setter TargetName="pnlActions"  Property="Visibility" Value="Visible"/>
             </Trigger>
-            <DataTrigger Binding="{Binding IsExecuting}" Value="true">
+            <DataTrigger Binding="{Binding Model.IsExecuting}" Value="true">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Green"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsFaulted}" Value="true">
+            <DataTrigger Binding="{Binding Model.IsFaulted}" Value="true">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsValid}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsValid}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Red"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding IsEnabled}" Value="false">
+            <DataTrigger Binding="{Binding Model.IsEnabled}" Value="false">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="Gray"></Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding
-                            RelativeSource={RelativeSource
-                                Mode=FindAncestor,
-                                AncestorType={x:Type TreeViewItem}},
-                                Path=IsSelected}" Value="True">
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TreeViewItem}}, Path=IsSelected}" Value="True">
                 <Setter TargetName="brdContainer" Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.AccentBase}"/>
             </DataTrigger>
         </DataTemplate.Triggers>

--- a/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
@@ -97,7 +97,7 @@
             <Setter.Value>
                 <DataTemplate>
                     <StackPanel Background="{Binding TemplatedParent}"  DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type GroupBox}}}"  Orientation="Horizontal">
-                        <Label  Content="{Binding Name}"  HorizontalAlignment="Left" VerticalAlignment="Center"></Label>
+                        <Label  Content="{Binding Model.Name}"  HorizontalAlignment="Left" VerticalAlignment="Center"></Label>
 
                         <Button Margin="0,0,2,0" HorizontalAlignment="Right" x:Name="btnEditControl" 
                             Height="20"
@@ -130,7 +130,7 @@
             <Setter.Value>
                 <DataTemplate>
                     <DockPanel  DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type GroupBox}}}" LastChildFill="True">
-                        <Label  Content="{Binding Name}"  Width="Auto" DockPanel.Dock="Left" HorizontalAlignment="Left" VerticalAlignment="Center"></Label>
+                        <Label  Content="{Binding Model.Name}"  Width="Auto" DockPanel.Dock="Left" HorizontalAlignment="Left" VerticalAlignment="Center"></Label>
                         <!--<Button x:Name="btnDeleteComponent" DockPanel.Dock="Right" Width="20"  Height="20" Margin="5,0,0,0" Style="{DynamicResource MahApps.Styles.Button.Circle}"
                                 cal:Message.Attach="[Event Click] = [Action DeleteComponent($dataContext)]">
                             <Rectangle Width="10"  Height="10"  Fill="{Binding Path=Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Button}}}">
@@ -190,7 +190,7 @@
                         <Button x:Name="ZoomOutToEntity" Style="{StaticResource BreadCrumbLink}" 
                             Margin="5"
                             cal:Message.Attach="[Event Click] = [Action ZoomOutToEntity($dataContext)]"
-                            Content="{Binding Name}"/>
+                            Content="{Binding Model.Name}"/>
                         <iconPacks:PackIconMaterial Kind="ChevronRight" Margin="0,4,0,0" HorizontalAlignment="Center"
                                                     VerticalAlignment="Center" Height="10"
                                                     Foreground="{DynamicResource MahApps.Brushes.Accent4}" />

--- a/src/Pixel.Automation.Designer.Views/TemplateSelectors/ComponentDataTemplateSelector.cs
+++ b/src/Pixel.Automation.Designer.Views/TemplateSelectors/ComponentDataTemplateSelector.cs
@@ -1,52 +1,53 @@
 ﻿using Pixel.Automation.Core;
 using Pixel.Automation.Core.Components.Processors;
+using Pixel.Automation.Editor.Core.ViewModels;
 using System.Windows;
 using System.Windows.Controls;
 
 namespace Pixel.Automation.Designer.Views
 {
+    /// <summary>
+    /// DataTempalteSelector resonsible for selecting the correct data template for a given component.
+    /// Mapping is stored in TemplateMapping.xml. If no mapping exists, default template is provided.
+    /// </summary>
     public class ComponentDataTemplateSelector : DataTemplateSelector
-    {
-      
+    {      
         public override DataTemplate SelectTemplate(object item, DependencyObject container)
         {
-            FrameworkElement element = container as FrameworkElement;           
-            if (element != null && item != null)
+            if (item is ComponentViewModel cvm && container is FrameworkElement element)
             {
-               
-                string typeName = item.GetType().Name;
+                string typeName = cvm.Model.GetType().Name;
                 string dataTemplateKey = TemplateMapper.GetDataTemplateKey(typeName);
-                if(!string.IsNullOrEmpty(dataTemplateKey))
+                if (!string.IsNullOrEmpty(dataTemplateKey))
                 {
                     DataTemplate componentTemplate = element.TryFindResource(dataTemplateKey) as DataTemplate;
                     return componentTemplate;
-                }           
+                }
 
                 string templateKey = "Entity"; //default
-                if (item is EntityProcessor)
+                if (cvm.Model is EntityProcessor)
                 {
                     templateKey = nameof(EntityProcessor);
                 }
-                else if (item is Entity)
+                else if (cvm.Model is Entity)
                 {
                     templateKey = nameof(Entity);
-                }                   
-                else if (item is ActorComponent)
+                }
+                else if (cvm.Model is ActorComponent)
                 {
                     templateKey = nameof(ActorComponent);
                 }
-                else if (item is DataComponent)
+                else if (cvm.Model is DataComponent)
                 {
                     templateKey = nameof(DataComponent);
                 }
-                else if (item is ServiceComponent)
+                else if (cvm.Model is ServiceComponent)
                 {
                     templateKey = nameof(ServiceComponent);
-                }                
+                }
                 DataTemplate defaultTemplate = element.FindResource(templateKey) as DataTemplate;
                 return defaultTemplate;
-            }            
-
+            }
             return null;
         }
     }

--- a/src/Pixel.Automation.Designer.Views/TemplateSelectors/ComponentStyleSelector.cs
+++ b/src/Pixel.Automation.Designer.Views/TemplateSelectors/ComponentStyleSelector.cs
@@ -1,37 +1,37 @@
 ﻿using Pixel.Automation.Core;
+using Pixel.Automation.Editor.Core.ViewModels;
 using System.Windows;
 using System.Windows.Controls;
 
 namespace Pixel.Automation.Designer.Views
 {
+    /// <summary>
+    /// StyleSelector resonsible for selecting the correct style for a given component.
+    /// Mapping is stored in TemplateMapping.xml. If no mapping exists, default style is provided.
+    /// </summary>
     public class ComponentStyleSelector : StyleSelector
     {
-
         public override Style SelectStyle(object item, DependencyObject container)
         {
-            FrameworkElement element = container as FrameworkElement;        
-
-            if (element != null && item != null)
+            if (item is ComponentViewModel cvm && container is FrameworkElement element)
             {
-
-                string typeName = item.GetType().Name;
+                string typeName = cvm.Model.GetType().Name;
                 string styleKey = TemplateMapper.GetStyleKey(typeName);
-                if(!string.IsNullOrEmpty(styleKey))
+                if (!string.IsNullOrEmpty(styleKey))
                 {
                     Style componentStyle = element.TryFindResource(styleKey) as Style;
                     return componentStyle;
                 }
-                else
+                else if(cvm.Model is ActorComponent || cvm.Model is ServiceComponent)
                 {
-                   if(item is ActorComponent || item is ServiceComponent)
-                    {
-                        Style actorDefaultStyle = element.FindResource("SlimStyle") as Style;
-                        return actorDefaultStyle;
-                    }
-                   Style style = element.FindResource("DefaultStyle") as Style;
-                   return style;
-                }             
-               
+                    Style actorDefaultStyle = element.FindResource("SlimStyle") as Style;
+                    return actorDefaultStyle;
+                }
+                else
+                {                    
+                    Style style = element.FindResource("DefaultStyle") as Style;
+                    return style;
+                }
             }
 
             return null;

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IComponentViewBuilder.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IComponentViewBuilder.cs
@@ -1,0 +1,18 @@
+﻿using Pixel.Automation.Core.TestData;
+using Pixel.Automation.Editor.Core.ViewModels;
+
+namespace Pixel.Automation.Editor.Core.Interfaces
+{  
+    public interface IComponentViewBuilder
+    {
+        void SetRoot(EntityComponentViewModel root);
+
+        void OpenTestFixture(TestFixture fixture);
+
+        void CloseTestFixture(TestFixture fixture);
+
+        void OpenTestCase(TestCase testCase);
+
+        void CloseTestCase(TestCase testCase);
+    }
+}

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IEditor.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IEditor.cs
@@ -1,4 +1,5 @@
 ﻿using Pixel.Automation.Core.Interfaces;
+using Pixel.Automation.Editor.Core.ViewModels;
 using System;
 using System.Threading.Tasks;
 
@@ -17,10 +18,10 @@ namespace Pixel.Automation.Editor.Core.Interfaces
         Task ManageProjectVersionAsync();
 
         /// <summary>
-        /// Remove component from its parent
+        /// Remove a component from view
         /// </summary>
-        /// <param name="component"></param>
-        void DeleteComponent(IComponent component);
+        /// <param name="componentViewModel"></param>
+        void DeleteComponent(ComponentViewModel componentViewModel);
 
         /// <summary>
         /// Open code editor that can be used to add , remove or modify existing data models for the project

--- a/src/Pixel.Automation.Editor.Core/ViewModels/ComponentViewModel.cs
+++ b/src/Pixel.Automation.Editor.Core/ViewModels/ComponentViewModel.cs
@@ -1,0 +1,41 @@
+﻿using Caliburn.Micro;
+using Dawn;
+using Pixel.Automation.Core;
+using Pixel.Automation.Core.Interfaces;
+
+namespace Pixel.Automation.Editor.Core.ViewModels
+{
+    public class ComponentViewModel : PropertyChangedBase
+    {       
+        public int ProcessOrder
+        {
+            get => Model.ProcessOrder;
+        }
+
+        [System.ComponentModel.Browsable(false)]
+        public IComponent Model { get; protected set; }
+
+        protected EntityComponentViewModel parent;
+        public EntityComponentViewModel Parent
+        {
+            get => this.parent;
+            set
+            {
+                this.parent = value;
+                this.Model.Parent = this.parent?.Model as Entity;
+            }
+        }
+   
+        protected ComponentViewModel()
+        {
+
+        }
+
+        public ComponentViewModel(IComponent model, EntityComponentViewModel parent)
+        {
+            Model = Guard.Argument(model).NotNull().Value;
+            Parent = Guard.Argument(parent).NotNull();
+        }
+
+    }  
+}

--- a/src/Pixel.Automation.Editor.Core/ViewModels/EntityComponentViewModel.cs
+++ b/src/Pixel.Automation.Editor.Core/ViewModels/EntityComponentViewModel.cs
@@ -1,0 +1,141 @@
+﻿using Dawn;
+using Pixel.Automation.Core;
+using Pixel.Automation.Core.Attributes;
+using Pixel.Automation.Core.Components.Processors;
+using Pixel.Automation.Core.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Pixel.Automation.Editor.Core.ViewModels
+{
+    public class EntityComponentViewModel : ComponentViewModel
+    {
+        public bool IsDropTarget { get; protected set; } = true;
+
+        public ObservableCollection<ComponentViewModel> ComponentCollection { get; private set; } = new();
+
+        public EntityComponentViewModel(Entity model)
+        {
+            Model = Guard.Argument(model).NotNull().Value;
+        }
+
+        public EntityComponentViewModel(Entity model, EntityComponentViewModel parent) : base(model, parent)
+        {
+            if (model.GetType().GetCustomAttributes(true).Any(a => a is NoDropTargetAttribute))
+            {
+                this.IsDropTarget = false;
+            }
+        }
+
+        public void AddComponent(ComponentViewModel component)
+        {
+            Guard.Argument(component).NotNull();
+            if (component.Model.EntityManager != null && component.Model.EntityManager != this.Model.EntityManager)
+            {
+                throw new InvalidOperationException("Reparenting is allowed only when EntityManager are same");
+            }
+            if (component.Parent != null)
+            {
+                component.Parent.RemoveComponent(component);
+            }          
+            var entityModel = this.Model as Entity;
+            entityModel.AddComponent(component.Model);
+            //some entities e.g. GroupEntity, loops, etc don't allow component to be added to them and simply  return itself without 
+            //actually doing anything.We check that component was actually added as a child before we added view model as child.
+            if (entityModel.Components.Contains(component.Model))
+            {
+                component.Parent = this;
+                this.ComponentCollection.Add(component);
+            }
+        }
+
+        public void RemoveComponent(ComponentViewModel componentToDelete)
+        {
+            if (this.ComponentCollection.Contains(componentToDelete))
+            {
+                (this.Model as Entity).RemoveComponent(componentToDelete.Model);
+                componentToDelete.Parent = null;
+                this.ComponentCollection.Remove(componentToDelete);               
+            }
+        }
+
+        public void AddComponent(IComponent componentToAdd)
+        {
+            var model = this.Model as Entity;
+            model.AddComponent(componentToAdd);
+            //some entities e.g. GroupEntity, loops, etc don't allow component to be added to them and simply  return itself without 
+            //actually doing anything.We check that component was actually added as a child before we added view model as child.
+            if (model.Components.Contains(componentToAdd))
+            {
+                if (componentToAdd is Entity entity)
+                {
+                    var root = GetViewModelForComponent(entity, this);
+                    this.ComponentCollection.Add(root);
+                    if (entity.Components.Any())
+                    {
+                        Queue<ComponentViewModel> componentViewModels = new();
+                        componentViewModels.Enqueue(root);
+                        while (componentViewModels.TryDequeue(out ComponentViewModel componentViewModel) 
+                            && componentViewModel is EntityComponentViewModel current)
+                        {
+                            var entityModel = current.Model as Entity;
+                            foreach (var component in entityModel.Components)
+                            {                             
+                                if (component is Entity e)
+                                {
+                                    var evm = GetViewModelForComponent(e, current);
+                                    current.AddComponent(evm);
+                                    componentViewModels.Enqueue(evm);
+                                    continue;
+                                }                                
+                                current.AddComponent(GetViewModelForComponent(component, current));
+                            }
+                        }
+                    }                    
+                }
+                else
+                {
+                    this.ComponentCollection.Add(GetViewModelForComponent(componentToAdd, this));
+                }
+            }           
+        }
+
+        protected ComponentViewModel GetViewModelForComponent(IComponent component, EntityComponentViewModel parent)
+        {
+            if(component is EntityProcessor entityProcessor)
+            {
+                return new EntityProcessorViewModel(entityProcessor, parent);
+            }
+            if(component is Entity entity)
+            {
+                return new EntityComponentViewModel(entity, parent);
+            }
+            return new ComponentViewModel(component, parent);
+        }
+
+
+        public void RemoveComponent(IComponent componentToDelete)
+        {
+            for (int i = 0; i < this.ComponentCollection.Count; i++)
+            {
+                if (this.ComponentCollection[i].Model.Equals(componentToDelete))
+                {
+                    RemoveComponent(this.ComponentCollection[i]);
+                    break;
+                }
+            }
+        }
+
+        public void MoveChildComponent(int oldIndex, int newIndex)
+        {
+            if (this.ComponentCollection.Count > oldIndex && this.ComponentCollection.Count > newIndex)
+            {
+                (Model as Entity).MoveComponent(oldIndex, newIndex);
+                this.ComponentCollection.Move(oldIndex, newIndex);
+                NotifyOfPropertyChange(nameof(ProcessOrder));
+            }
+        }
+    }
+}

--- a/src/Pixel.Automation.Editor.Core/ViewModels/EntityProcessorViewModel.cs
+++ b/src/Pixel.Automation.Editor.Core/ViewModels/EntityProcessorViewModel.cs
@@ -1,0 +1,23 @@
+﻿using Pixel.Automation.Core;
+using Pixel.Automation.Core.Components.Sequences;
+using System.Linq;
+
+namespace Pixel.Automation.Editor.Core.ViewModels
+{
+    public class EntityProcessorViewModel : EntityComponentViewModel
+    {
+        public EntityProcessorViewModel(Entity model) : base(model)
+        {
+        }
+
+        public EntityProcessorViewModel(Entity model, EntityComponentViewModel parent) : base(model, parent)
+        {
+           
+        }
+
+        public void AddParallelBlock()
+        {
+            base.AddComponent(new SequenceEntity() { Name = $"Parallel Block #{(this.Model as Entity).Components.Count() + 1}" });
+        }
+    }
+}

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Controls/FindAllControlActorComponentTests.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Controls/FindAllControlActorComponentTests.cs
@@ -41,7 +41,7 @@ namespace Pixel.Automation.Core.Components.Tests
             var containerEntity = findAllControlActorComponentBuilder.CreateComponent() as GroupEntity;
             containerEntity.EntityManager = entityManager;
             containerEntity.ResolveDependencies();
-            containerEntity.AddComponent(controlEntity);
+            containerEntity.GroupPlaceHolder.AddComponent(controlEntity);
 
             List<UIControl> foundControls = default;
             int foundControlsCount = 0;

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Controls/FindControlActorComponentTest.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Controls/FindControlActorComponentTest.cs
@@ -38,7 +38,7 @@ namespace Pixel.Automation.Core.Components.Tests
             var containerEntity = findControlActorComponentBuilder.CreateComponent() as GroupEntity;
             containerEntity.EntityManager = entityManager;
             containerEntity.ResolveDependencies();
-            containerEntity.AddComponent(controlEntity);
+            containerEntity.GroupPlaceHolder.AddComponent(controlEntity);
 
             UIControl foundControl = default;
             bool wasLocated = false;

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Controls/FindFirstControlActorComponentTest.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Controls/FindFirstControlActorComponentTest.cs
@@ -70,9 +70,9 @@ namespace Pixel.Automation.Core.Components.Tests
             var containerEntity = findFirstControlActorComponentBuilder.CreateComponent() as GroupEntity;
             containerEntity.EntityManager = entityManager;
             containerEntity.ResolveDependencies();
-            containerEntity.AddComponent(firstControlEntity);
-            containerEntity.AddComponent(secondControlEntity);
-
+            containerEntity.GroupPlaceHolder.AddComponent(firstControlEntity);
+            containerEntity.GroupPlaceHolder.AddComponent(secondControlEntity);
+      
             UIControl foundControl = default;
             bool wasLocated = false;
 

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Controls/HighlightControlActorComponentTest.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Controls/HighlightControlActorComponentTest.cs
@@ -48,7 +48,7 @@ namespace Pixel.Automation.Core.Components.Tests
             var containerEntity = componentBuilder.CreateComponent() as GroupEntity;
             containerEntity.EntityManager = entityManager;
             containerEntity.ResolveDependencies();
-            containerEntity.AddComponent(controlEntity);
+            containerEntity.GroupPlaceHolder.AddComponent(controlEntity);
           
             containerEntity.GroupActor.Act();       
 

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Loops/DoWhileLoopEntityTest.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Loops/DoWhileLoopEntityTest.cs
@@ -27,9 +27,11 @@ namespace Pixel.Automation.Core.Components.Tests
             var whileLoopEntity = new DoWhileLoopEntity() { ScriptFile = Guid.NewGuid().ToString() };
             whileLoopEntity.EntityManager = entityManager;
             whileLoopEntity.ResolveDependencies();
+            var placeHolderEntity = whileLoopEntity.Components[0] as PlaceHolderEntity;
+            Assert.IsNotNull(placeHolderEntity);
 
             var actorComponent = Substitute.For<ActorComponent>();
-            whileLoopEntity.AddComponent(actorComponent);
+            placeHolderEntity.AddComponent(actorComponent);
 
             var iterationResult = whileLoopEntity.GetNextComponentToProcess().ToList();
 
@@ -57,6 +59,8 @@ namespace Pixel.Automation.Core.Components.Tests
             var whileLoopEntity = new DoWhileLoopEntity() { ScriptFile = Guid.NewGuid().ToString() };
             whileLoopEntity.EntityManager = entityManager;
             whileLoopEntity.ResolveDependencies();
+            var placeHolderEntity = whileLoopEntity.Components[0] as PlaceHolderEntity;
+            Assert.IsNotNull(placeHolderEntity);
 
             var actorComponent = Substitute.For<ActorComponent>();
             var nestedLoopEntity = Substitute.For<Entity, ILoop>();
@@ -64,7 +68,7 @@ namespace Pixel.Automation.Core.Components.Tests
             //This is because GetNextComponentProcess checks IComponent.IsEnabled to decide if component should be processed.
             (nestedLoopEntity as ILoop).IsEnabled.Returns(true);
 
-            whileLoopEntity.AddComponent(nestedLoopEntity);
+            placeHolderEntity.AddComponent(nestedLoopEntity);
             nestedLoopEntity.GetNextComponentToProcess().Returns(new List<IComponent>() { actorComponent });
             nestedLoopEntity.Components.Returns(new List<IComponent>() { actorComponent });
 

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Loops/ForEachLoopEntityTest.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Loops/ForEachLoopEntityTest.cs
@@ -32,9 +32,11 @@ namespace Pixel.Automation.Core.Components.Tests
 
             forEachLoopEntity.EntityManager = entityManager;
             forEachLoopEntity.ResolveDependencies();
+            var placeHolderEntity = forEachLoopEntity.Components[0] as PlaceHolderEntity;
+            Assert.IsNotNull(placeHolderEntity);
 
             var actorComponent = Substitute.For<ActorComponent>();
-            forEachLoopEntity.AddComponent(actorComponent);
+            placeHolderEntity.AddComponent(actorComponent);
 
             var iterationResult = forEachLoopEntity.GetNextComponentToProcess().ToList();
 
@@ -69,14 +71,16 @@ namespace Pixel.Automation.Core.Components.Tests
 
             forEachLoopEntity.EntityManager = entityManager;
             forEachLoopEntity.ResolveDependencies();
+            var placeHolderEntity = forEachLoopEntity.Components[0] as PlaceHolderEntity;
+            Assert.IsNotNull(placeHolderEntity);
 
             var actorComponent = Substitute.For<ActorComponent>();
             var nestedLoopEntity = Substitute.For<Entity, ILoop>();
             //Entity.IsEnabled and ILoop.IsEnabled are differnt. We need to typecast to ILoop and mock it
             //This is because GetNextComponentProcess checks IComponent.IsEnabled to decide if component should be processed.
-            (nestedLoopEntity as ILoop).IsEnabled.Returns(true);         
-        
-            forEachLoopEntity.AddComponent(nestedLoopEntity);
+            (nestedLoopEntity as ILoop).IsEnabled.Returns(true);
+
+            placeHolderEntity.AddComponent(nestedLoopEntity);
             nestedLoopEntity.GetNextComponentToProcess().Returns(new List<IComponent>() { actorComponent });
             nestedLoopEntity.Components.Returns(new List<IComponent>() { actorComponent });
 

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Loops/ForLoopEntityTest.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Loops/ForLoopEntityTest.cs
@@ -33,9 +33,11 @@ namespace Pixel.Automation.Core.Components.Tests
             var forLoopEntity = new ForLoopEntity() { ScriptFile = Guid.NewGuid().ToString() };
             forLoopEntity.EntityManager = entityManager;
             forLoopEntity.ResolveDependencies();
+            var placeHolderEntity = forLoopEntity.Components[0] as PlaceHolderEntity;
+            Assert.IsNotNull(placeHolderEntity);
 
             var actorComponent = Substitute.For<ActorComponent>();
-            forLoopEntity.AddComponent(actorComponent);
+            placeHolderEntity.AddComponent(actorComponent);
 
             var iterationResult = forLoopEntity.GetNextComponentToProcess().ToList();
 
@@ -68,14 +70,16 @@ namespace Pixel.Automation.Core.Components.Tests
             var forLoopEntity = new ForLoopEntity() { ScriptFile = Guid.NewGuid().ToString() };
             forLoopEntity.EntityManager = entityManager;
             forLoopEntity.ResolveDependencies();
+            var placeHolderEntity = forLoopEntity.Components[0] as PlaceHolderEntity;
+            Assert.IsNotNull(placeHolderEntity);
 
             var actorComponent = Substitute.For<ActorComponent>();
             var nestedLoopEntity = Substitute.For<Entity, ILoop>();
             //Entity.IsEnabled and ILoop.IsEnabled are differnt. We need to typecast to ILoop and mock it
             //This is because GetNextComponentProcess checks IComponent.IsEnabled to decide if component should be processed.
             (nestedLoopEntity as ILoop).IsEnabled.Returns(true);
-        
-            forLoopEntity.AddComponent(nestedLoopEntity);
+
+            placeHolderEntity.AddComponent(nestedLoopEntity);
             nestedLoopEntity.GetNextComponentToProcess().Returns(new List<IComponent>() { actorComponent });           
             nestedLoopEntity.Components.Returns(new List<IComponent>() { actorComponent });
        

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Loops/WhileLoopEntityTest.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Loops/WhileLoopEntityTest.cs
@@ -27,9 +27,12 @@ namespace Pixel.Automation.Core.Components.Tests
             var whileLoopEntity = new WhileLoopEntity() { ScriptFile = Guid.NewGuid().ToString() };
             whileLoopEntity.EntityManager = entityManager;
             whileLoopEntity.ResolveDependencies();
+            var placeHolderEntity = whileLoopEntity.Components[0] as PlaceHolderEntity;
+
+            Assert.IsNotNull(placeHolderEntity);
 
             var actorComponent = Substitute.For<ActorComponent>();
-            whileLoopEntity.AddComponent(actorComponent);
+            placeHolderEntity.AddComponent(actorComponent);
 
             var iterationResult = whileLoopEntity.GetNextComponentToProcess().ToList();
 
@@ -57,14 +60,16 @@ namespace Pixel.Automation.Core.Components.Tests
             var whileLoopEntity = new WhileLoopEntity() { ScriptFile = Guid.NewGuid().ToString() };
             whileLoopEntity.EntityManager = entityManager;
             whileLoopEntity.ResolveDependencies();
-
+            var placeHolderEntity = whileLoopEntity.Components[0] as PlaceHolderEntity;           
+            Assert.IsNotNull(placeHolderEntity);
+          
             var actorComponent = Substitute.For<ActorComponent>();
             var nestedLoopEntity = Substitute.For<Entity, ILoop>();
             //Entity.IsEnabled and ILoop.IsEnabled are differnt. We need to typecast to ILoop and mock it
             //This is because GetNextComponentProcess checks IComponent.IsEnabled to decide if component should be processed.
             (nestedLoopEntity as ILoop).IsEnabled.Returns(true);
 
-            whileLoopEntity.AddComponent(nestedLoopEntity);
+            placeHolderEntity.AddComponent(nestedLoopEntity);
             nestedLoopEntity.GetNextComponentToProcess().Returns(new List<IComponent>() { actorComponent });
             nestedLoopEntity.Components.Returns(new List<IComponent>() { actorComponent });
 

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Processors/ParallelEntityProcessorTest.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Processors/ParallelEntityProcessorTest.cs
@@ -1,6 +1,7 @@
 ﻿using NSubstitute;
 using NUnit.Framework;
 using Pixel.Automation.Core.Components.Processors;
+using Pixel.Automation.Core.Components.Sequences;
 using Pixel.Automation.Core.Interfaces;
 using System;
 using System.Threading.Tasks;
@@ -28,10 +29,9 @@ namespace Pixel.Automation.Core.Components.Tests
 
             ParallelEntityProcessor processor = new ParallelEntityProcessor();
             processor.EntityManager = entityManager;
-            processor.AddParallelBlock();
-            processor.AddParallelBlock();
-        
-                     
+            processor.ResolveDependencies();
+
+
             Assert.AreEqual(2, processor.Components.Count);
 
             var parallelBlockOne = processor.Components[0] as Entity;
@@ -75,9 +75,8 @@ namespace Pixel.Automation.Core.Components.Tests
 
             ParallelEntityProcessor processor = new ParallelEntityProcessor();
             processor.EntityManager = entityManager;
-            processor.AddParallelBlock();
-            processor.AddParallelBlock();
-          
+            processor.ResolveDependencies();
+
             Assert.AreEqual(2, processor.Components.Count);
 
 


### PR DESCRIPTION
Entity used to have two collections Components of type List<IComponent> and ComponentCollection of type ObservableCollectoin<IComponent>. UI binds to ComponentCollection so that it can be updated when adding/removing components. However,  ObservableCollection needs to be updated on UI Thread. Often user actions end up adding or removing components from a non-UI thread and this causes exception. Hence this change introduces view models like ComponentViewModel, EntityComponentViewModel and EntityProcessorViewModel which will have the ObservableCollection instead. Although, this introduces complexity to keep view models and underlying components in sync but at the same time provides some good feature i.e. we don't need to open test fixtures and test cases on designer when we just want to execute them in design time. Also, if we run in to a situation now where any non-UI thread tries to add/remove components now and these view model run in to exception, we can simply introduce dispatcher thread in the view models which was not possible earlier due to the fact that we would need a dependency on WPF in Pixel.Automation.Core library which contains Entity class.