### PR TITLE
Add support for resolution and theme for image based automation

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ControlEditorBaseViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ControlEditorBaseViewModel.cs
@@ -1,0 +1,182 @@
+﻿using Caliburn.Micro;
+using Dawn;
+using Pixel.Automation.Core.Enums;
+using System;
+using System.Drawing;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Pixel.Automation.AppExplorer.ViewModels.ControlEditor
+{
+    public abstract class ControlEditorBaseViewModel : Screen
+    {
+        protected FrameworkElement view;
+
+        System.Drawing.Point pivotPoint;
+        System.Drawing.Point offset;
+        System.Drawing.Point absOffset;
+        public System.Drawing.Point Offset
+        {
+            get
+            {
+                return absOffset;
+            }
+        }
+
+        protected Rectangle templateBoundingBox;
+
+        protected Visibility isOffsetPointerVisible = Visibility.Collapsed;
+        public Visibility IsOffsetPoiniterVisible
+        {
+            get => isOffsetPointerVisible;
+            set
+            {
+                isOffsetPointerVisible = value;
+                NotifyOfPropertyChange(() => IsOffsetPoiniterVisible);
+            }
+        }
+
+        public ControlEditorBaseViewModel()
+        {
+            
+        }
+
+        protected abstract (double width, double height) GetImageDimension();
+
+        protected abstract System.Drawing.Point GetOffSet();
+
+        protected abstract void SetOffSet(System.Drawing.Point offSet);
+
+        protected abstract Pivots GetPivotPoint();
+
+        protected abstract void SetPivotPoint(Pivots pivotPoint);
+       
+        #region Offset Editor
+
+        protected void ShowOffSetPointer()
+        {
+            FrameworkElement canvas = this.view.FindName("DesignerCanvas") as FrameworkElement;
+            FrameworkElement imageHolder = this.view.FindName("ControlImage") as FrameworkElement;
+
+            (double width, double height) = GetImageDimension();
+            this.templateBoundingBox = new Rectangle(Convert.ToInt32((canvas.ActualWidth - width) / 2), Convert.ToInt32((canvas.ActualHeight - height) / 2), Convert.ToInt32(width), Convert.ToInt32(height));
+
+            this.offset = GetOffSet();
+            UpdatePivotPoint();
+            this.absOffset = new System.Drawing.Point(pivotPoint.X + offset.X - 16, pivotPoint.Y + offset.Y - 16);
+            NotifyOfPropertyChange(() => Offset);
+        }
+
+        private void UpdatePivotPoint()
+        {
+            //Note : Don't delete 
+
+            //Use this if you want to allow offset within the bounds of control
+            //switch (leafControl.PivotPoint)
+            //{
+            //    case TestSuite.Models.Pivots.Center:
+            //        this.pivotPoint = new System.Drawing.Point((this.templateBoundingBox.X + this.templateBoundingBox.Width / 2), (this.templateBoundingBox.Y + this.templateBoundingBox.Height / 2));
+            //        break;
+            //    case TestSuite.Models.Pivots.TopLeft:
+            //        this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X, this.templateBoundingBox.Y);
+            //        break;
+            //    case TestSuite.Models.Pivots.TopRight:
+            //        this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X + this.templateBoundingBox.Width, this.templateBoundingBox.Y);
+            //        break;
+            //    case TestSuite.Models.Pivots.BottomLeft:
+            //        this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X, this.templateBoundingBox.Y + this.templateBoundingBox.Height);
+            //        break;
+            //    case TestSuite.Models.Pivots.BottomRight:
+            //        this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X + this.templateBoundingBox.Width, this.templateBoundingBox.Y + this.templateBoundingBox.Height);
+            //        break;
+            //}
+
+            switch (GetPivotPoint())
+            {
+                case Pivots.Center:
+                    this.pivotPoint = new System.Drawing.Point((this.templateBoundingBox.X + this.templateBoundingBox.Width / 2), (this.templateBoundingBox.Y + this.templateBoundingBox.Height / 2));
+                    break;
+                case Pivots.TopLeft:
+                    this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X, this.templateBoundingBox.Y);
+                    break;
+                case Pivots.TopRight:
+                    this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X + this.templateBoundingBox.Width, this.templateBoundingBox.Y);
+                    break;
+                case Pivots.BottomLeft:
+                    this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X, this.templateBoundingBox.Y + this.templateBoundingBox.Height);
+                    break;
+                case Pivots.BottomRight:
+                    this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X + this.templateBoundingBox.Width, this.templateBoundingBox.Y + this.templateBoundingBox.Height);
+                    break;
+            }
+
+        }
+
+        public void ChangePivotPoint(string name)
+        {
+            Guard.Argument(name).NotNull().NotEmpty();
+            switch (name)
+            {
+                case "Center":
+                    SetPivotPoint(Pivots.Center);
+                    break;
+                case "TopLeft":
+                    SetPivotPoint(Pivots.TopLeft);
+                    break;
+                case "TopRight":
+                    SetPivotPoint(Pivots.TopRight);
+                    break;
+                case "BottomLeft":
+                    SetPivotPoint(Pivots.BottomLeft);
+                    break;
+                case "BottomRight":
+                    SetPivotPoint(Pivots.BottomRight);
+                    break;
+
+            }
+            offset.X = 0;
+            offset.Y = 0;
+
+            UpdatePivotPoint();
+
+            absOffset.X = pivotPoint.X + offset.X - 16;
+            absOffset.Y = pivotPoint.Y + offset.Y - 16;
+
+            SetOffSet(offset);          
+
+            FrameworkElement offsetPointer = view.FindName("OffsetPointer") as FrameworkElement;
+            offsetPointer.SetValue(Canvas.LeftProperty, (double)this.Offset.X);
+            offsetPointer.SetValue(Canvas.TopProperty, (double)this.Offset.Y);
+
+
+        }
+
+        public void ChangeOffset(MouseEventArgs args, IInputElement sender)
+        {
+            System.Windows.Point mouseDownPoint = args.GetPosition(sender);
+
+            //Note : Don't delete 
+
+            //Use this if you want to allow offset within the bounds of control
+            //offset.X = this.templateBoundingBox.X + (int)mouseDownPoint.X - pivotPoint.X;
+            //offset.Y = this.templateBoundingBox.Y + (int)mouseDownPoint.Y - pivotPoint.Y;
+
+            offset.X = (int)mouseDownPoint.X - pivotPoint.X;
+            offset.Y = (int)mouseDownPoint.Y - pivotPoint.Y;
+
+            SetOffSet(offset);
+
+            absOffset.X = pivotPoint.X + offset.X - 16;
+            absOffset.Y = pivotPoint.Y + offset.Y - 16;
+            NotifyOfPropertyChange(() => Offset);
+
+            FrameworkElement offsetPointer = view.FindName("OffsetPointer") as FrameworkElement;
+            offsetPointer.SetValue(Canvas.LeftProperty, (double)this.Offset.X);
+            offsetPointer.SetValue(Canvas.TopProperty, (double)this.Offset.Y);
+        }
+
+        #endregion Offset Editor
+
+    }
+}

--- a/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ControlEditorFactory.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ControlEditorFactory.cs
@@ -1,0 +1,26 @@
+﻿using Dawn;
+using Pixel.Automation.Core.Interfaces;
+using Pixel.Automation.Editor.Core.Interfaces;
+using Pixel.Persistence.Services.Client;
+
+namespace Pixel.Automation.AppExplorer.ViewModels.ControlEditor
+{
+    public class ControlEditorFactory : IControlEditorFactory
+    {
+        private readonly IApplicationDataManager applicationDataManager;
+       
+        public ControlEditorFactory(IApplicationDataManager applicationDataManager)
+        {
+            this.applicationDataManager = Guard.Argument(applicationDataManager).NotNull().Value;
+        }
+
+        public IControlEditor CreateControlEditor(IControlIdentity controlIdentity)
+        {
+            if(controlIdentity is IImageControlIdentity)
+            {
+                return new ImageControlEditorViewModel(this.applicationDataManager);
+            }
+            return new ControlEditorViewModel();
+        }
+    }
+}

--- a/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ControlEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ControlEditorViewModel.cs
@@ -15,7 +15,7 @@ using System.Windows.Media.Imaging;
 
 namespace Pixel.Automation.AppExplorer.ViewModels.ControlEditor
 {
-    public class ControlEditorViewModel : Screen, IControlEditor
+    public class ControlEditorViewModel : ControlEditorBaseViewModel, IControlEditor
     {
 
         IControlIdentity rootControl;
@@ -71,33 +71,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.ControlEditor
                 NotifyOfPropertyChange(() => ImageSource);
             }
         }
-
-        FrameworkElement view;
-
-        System.Drawing.Point pivotPoint;
-        System.Drawing.Point offset;
-        System.Drawing.Point absOffset;
-        public System.Drawing.Point Offset
-        {
-            get
-            {
-                return absOffset;
-            }
-        }
-
-        Rectangle templateBoundingBox;
-
-        Visibility isOffsetPointerVisible = Visibility.Collapsed;
-        public Visibility IsOffsetPoiniterVisible
-        {
-            get => isOffsetPointerVisible;
-            set
-            {
-                isOffsetPointerVisible = value;
-                NotifyOfPropertyChange(() => IsOffsetPoiniterVisible);
-            }
-        }
-
+      
         public ControlEditorViewModel()
         {
             this.DisplayName = "Control Editor";
@@ -128,10 +102,33 @@ namespace Pixel.Automation.AppExplorer.ViewModels.ControlEditor
             }
         }
 
+        protected override (double width, double height) GetImageDimension()
+        {
+            return (ImageSource.Width, ImageSource.Height);
+        }
+
+        protected override System.Drawing.Point GetOffSet()
+        {
+            return new System.Drawing.Point((int)this.rootControl.XOffSet, (int)this.rootControl.YOffSet);
+        }
+
+        protected override void SetOffSet(System.Drawing.Point offSet)
+        {
+            this.rootControl.XOffSet = offSet.X;
+            this.rootControl.YOffSet = offSet.Y;
+        }
+
+        protected override Pivots GetPivotPoint()
+        {
+            return this.rootControl.PivotPoint;
+        }
+
+        protected override void SetPivotPoint(Pivots pivotPoint)
+        {
+            this.rootControl.PivotPoint = pivotPoint;
+        }
 
         #region Control Hierarchy
-
-
 
         public void RemoveFromControlHierarchy(IControlIdentity controlToRemove)
         {
@@ -201,138 +198,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.ControlEditor
         }
 
         #endregion Control Hierarchy
-
-        #region Offset Editor
-
-        private void ShowOffSetPointer()
-        {
-            FrameworkElement canvas = this.view.FindName("DesignerCanvas") as FrameworkElement;
-            FrameworkElement imageHolder = this.view.FindName("ControlImage") as FrameworkElement;
-
-            this.templateBoundingBox = new Rectangle(Convert.ToInt32((canvas.ActualWidth - imageSource.Width) / 2), Convert.ToInt32((canvas.ActualHeight - imageSource.Height) / 2), Convert.ToInt32(imageSource.Width), Convert.ToInt32(imageSource.Height));
-
-            this.offset = new System.Drawing.Point((int)leafControl.XOffSet, (int)leafControl.YOffSet);
-            UpdatePivotPoint();
-            this.absOffset = new System.Drawing.Point(pivotPoint.X + offset.X - 16, pivotPoint.Y + offset.Y - 16);
-            NotifyOfPropertyChange(() => Offset);
-        }
-
-        private void UpdatePivotPoint()
-        {
-            //Note : Don't delete 
-
-            //Use this if you want to allow offset within the bounds of control
-            //switch (leafControl.PivotPoint)
-            //{
-            //    case TestSuite.Models.Pivots.Center:
-            //        this.pivotPoint = new System.Drawing.Point((this.templateBoundingBox.X + this.templateBoundingBox.Width / 2), (this.templateBoundingBox.Y + this.templateBoundingBox.Height / 2));
-            //        break;
-            //    case TestSuite.Models.Pivots.TopLeft:
-            //        this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X, this.templateBoundingBox.Y);
-            //        break;
-            //    case TestSuite.Models.Pivots.TopRight:
-            //        this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X + this.templateBoundingBox.Width, this.templateBoundingBox.Y);
-            //        break;
-            //    case TestSuite.Models.Pivots.BottomLeft:
-            //        this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X, this.templateBoundingBox.Y + this.templateBoundingBox.Height);
-            //        break;
-            //    case TestSuite.Models.Pivots.BottomRight:
-            //        this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X + this.templateBoundingBox.Width, this.templateBoundingBox.Y + this.templateBoundingBox.Height);
-            //        break;
-            //}
-
-            switch (leafControl.PivotPoint)
-            {
-                case Pivots.Center:
-                    this.pivotPoint = new System.Drawing.Point((this.templateBoundingBox.X + this.templateBoundingBox.Width / 2), (this.templateBoundingBox.Y + this.templateBoundingBox.Height / 2));
-                    break;
-                case Pivots.TopLeft:
-                    this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X, this.templateBoundingBox.Y);
-                    break;
-                case Pivots.TopRight:
-                    this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X + this.templateBoundingBox.Width, this.templateBoundingBox.Y);
-                    break;
-                case Pivots.BottomLeft:
-                    this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X, this.templateBoundingBox.Y + this.templateBoundingBox.Height);
-                    break;
-                case Pivots.BottomRight:
-                    this.pivotPoint = new System.Drawing.Point(this.templateBoundingBox.X + this.templateBoundingBox.Width, this.templateBoundingBox.Y + this.templateBoundingBox.Height);
-                    break;
-            }
-
-        }
-
-        public void ChangePivotPoint(string name)
-        {
-            Guard.Argument(name).NotNull().NotEmpty();
-            switch (name)
-            {
-                case "Center":
-                    leafControl.PivotPoint = Pivots.Center;
-                    break;
-                case "TopLeft":
-                    leafControl.PivotPoint = Pivots.TopLeft;
-                    break;
-                case "TopRight":
-                    leafControl.PivotPoint = Pivots.TopRight;
-                    break;
-                case "BottomLeft":
-                    leafControl.PivotPoint = Pivots.BottomLeft;
-                    break;
-                case "BottomRight":
-                    leafControl.PivotPoint = Pivots.BottomRight;
-                    break;
-
-            }
-            offset.X = 0;
-            offset.Y = 0;
-
-            UpdatePivotPoint();
-
-            absOffset.X = pivotPoint.X + offset.X - 16;
-            absOffset.Y = pivotPoint.Y + offset.Y - 16;
-
-
-            leafControl.XOffSet = offset.X;
-            leafControl.YOffSet = offset.Y;
-
-            FrameworkElement offsetPointer = view.FindName("OffsetPointer") as FrameworkElement;
-            offsetPointer.SetValue(Canvas.LeftProperty, (double)this.Offset.X);
-            offsetPointer.SetValue(Canvas.TopProperty, (double)this.Offset.Y);
-
-
-        }
-
-        public void ChangeOffset(MouseEventArgs args, IInputElement sender)
-        {
-            System.Windows.Point mouseDownPoint = args.GetPosition(sender);
-
-            //Note : Don't delete 
-
-            //Use this if you want to allow offset within the bounds of control
-            //offset.X = this.templateBoundingBox.X + (int)mouseDownPoint.X - pivotPoint.X;
-            //offset.Y = this.templateBoundingBox.Y + (int)mouseDownPoint.Y - pivotPoint.Y;
-
-            offset.X = (int)mouseDownPoint.X - pivotPoint.X;
-            offset.Y = (int)mouseDownPoint.Y - pivotPoint.Y;
-
-
-            leafControl.XOffSet = offset.X;
-            leafControl.YOffSet = offset.Y;
-
-
-
-            absOffset.X = pivotPoint.X + offset.X - 16;
-            absOffset.Y = pivotPoint.Y + offset.Y - 16;
-            NotifyOfPropertyChange(() => Offset);
-
-            FrameworkElement offsetPointer = view.FindName("OffsetPointer") as FrameworkElement;
-            offsetPointer.SetValue(Canvas.LeftProperty, (double)this.Offset.X);
-            offsetPointer.SetValue(Canvas.TopProperty, (double)this.Offset.Y);
-        }
-
-        #endregion Offset Editor
-
+            
         public async void Save()
         {
             CleanUp();
@@ -352,6 +218,6 @@ namespace Pixel.Automation.AppExplorer.ViewModels.ControlEditor
             this.rootControl = null;
             this.selectedControl = null;
             this.imageSource = null;
-        }
+        }     
     }
 }

--- a/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ImageControlEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ImageControlEditorViewModel.cs
@@ -1,0 +1,217 @@
+﻿using Dawn;
+using Microsoft.Win32;
+using Pixel.Automation.Core.Enums;
+using Pixel.Automation.Core.Interfaces;
+using Pixel.Automation.Core.Models;
+using Pixel.Automation.Editor.Core.Interfaces;
+using Pixel.Persistence.Services.Client;
+using Serilog;
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Pixel.Automation.AppExplorer.ViewModels.ControlEditor
+{
+    public  class ImageControlEditorViewModel : ControlEditorBaseViewModel, IImageControlEditor
+    {
+        private readonly ILogger logger = Log.ForContext<ImageControlEditorViewModel>();
+        private readonly IApplicationDataManager applicationDataManager;
+
+        private ControlDescription controlDescription;
+        private IImageControlIdentity controlIdentity;          
+     
+        public ObservableCollection<ImageDescriptionViewModel> ControlImages { get; private set; } = new ();
+
+        private object selectedObject;
+        public object SelectedObject
+        {
+            get => selectedObject;
+            set
+            {
+                selectedObject = value;
+                NotifyOfPropertyChange(nameof(SelectedObject));
+            }
+        }
+
+        ImageDescriptionViewModel selectedImage;
+        public ImageDescriptionViewModel SelectedImage
+        {
+            get => selectedImage;
+            set
+            {
+                selectedImage = value;    
+                if(value != null)
+                {
+                    ShowOffSetPointer();
+                    IsOffsetPoiniterVisible = Visibility.Visible;
+                    SelectedObject = value;                 
+                }
+                else
+                {
+                    IsOffsetPoiniterVisible = Visibility.Hidden;
+                }
+                NotifyOfPropertyChange(nameof(SelectedImage));
+                NotifyOfPropertyChange(nameof(CanDeleteImage));
+                NotifyOfPropertyChange(nameof(IsImageSelected));
+            }
+        }   
+        
+        public bool IsImageSelected
+        {
+            get => this.selectedImage != null;
+        }
+
+        public ImageControlEditorViewModel(IApplicationDataManager applicationDataManager)
+        {
+            this.DisplayName = "Control Editor";
+            this.applicationDataManager = Guard.Argument(applicationDataManager).NotNull().Value;
+            CreateCollectionView();
+        }
+
+        private void CreateCollectionView()
+        {
+            var groupedItems = CollectionViewSource.GetDefaultView(ControlImages);          
+            groupedItems.Filter = new Predicate<object>((a) =>
+            {
+                if(a is ImageDescriptionViewModel imageDescription)
+                {
+                    return !imageDescription.IsMarkedForDelete;
+                }
+                return false;
+            });
+        }
+
+        public void ConfigureControl()
+        {
+            this.SelectedImage = null;
+            this.SelectedObject = this.controlIdentity;
+        }
+     
+        public void AddImageFromFile()
+        {
+            OpenFileDialog openFileDialog = new OpenFileDialog();
+            openFileDialog.Filter = "PNG File (*.Png)|*.Png";
+            openFileDialog.InitialDirectory = Environment.CurrentDirectory;
+            if (openFileDialog.ShowDialog() == true)
+            {
+                string fileName = openFileDialog.FileName;
+                using (FileStream fs = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+                {
+                    var imageDescription = new ImageDescription()
+                    {
+                        ControlImage = fileName,
+                        PivotPoint = Pivots.Center
+                    };                                  
+                    this.ControlImages.Add(new ImageDescriptionViewModel(imageDescription) { IsNewAddition = true });                    
+                }
+            }
+        }
+
+        public bool CanDeleteImage
+        {
+            get => this.SelectedImage != null && this.ControlImages.Where(a => !a.IsMarkedForDelete).Count() > 1;
+        }
+
+        public void DeleteImage()
+        { 
+            if(this.SelectedImage != null && this.ControlImages.Where(a => !a.IsMarkedForDelete).Count() > 1)
+            {
+                var imageDescription = this.SelectedImage;
+                if (this.ControlImages.Contains(imageDescription))
+                {
+                    int index = this.ControlImages.IndexOf(imageDescription);
+                    this.SelectedImage = this.ControlImages[Math.Max(index - 1, 0)];
+                    imageDescription.IsMarkedForDelete = true;
+                    var view = CollectionViewSource.GetDefaultView(this.ControlImages);
+                    view.Refresh();
+                    NotifyOfPropertyChange(nameof(CanDeleteImage));
+                }
+            }       
+        }       
+
+        protected override void OnViewReady(object view)
+        {
+            this.view = view as FrameworkElement;          
+            if (this.ControlImages.Count > 0)
+            {                   
+                this.SelectedImage = this.ControlImages.ElementAt(0);
+            }
+            base.OnViewReady(view);
+        }
+
+        public void Initialize(ControlDescription controlDescription)
+        {
+            this.controlDescription = Guard.Argument(controlDescription).NotNull();
+            if(controlDescription.ControlDetails is IImageControlIdentity imageControlIdentity)
+            {
+                this.controlIdentity = imageControlIdentity;            
+                foreach (var imageDescription in this.controlIdentity.GetImages())
+                {
+                    this.ControlImages.Add(new ImageDescriptionViewModel(imageDescription));
+                }
+            }           
+        }
+
+        protected override (double width, double height) GetImageDimension()
+        {
+            return (SelectedImage.ImageSource.Width, SelectedImage.ImageSource.Height);
+        }
+
+        protected override System.Drawing.Point GetOffSet()
+        {
+            return new System.Drawing.Point((int)this.SelectedImage.XOffSet, (int)this.SelectedImage.YOffSet);
+        }
+
+        protected override void SetOffSet(System.Drawing.Point offSet)
+        {
+            this.SelectedImage.XOffSet = offSet.X;
+            this.SelectedImage.YOffSet = offSet.Y;
+        }
+
+        protected override Pivots GetPivotPoint()
+        {
+            return this.SelectedImage.PivotPoint;
+        }
+
+        protected override void SetPivotPoint(Pivots pivotPoint)
+        {
+            this.SelectedImage.PivotPoint = pivotPoint;
+        }
+       
+        public async void Save()
+        {
+            try
+            {
+                foreach (var image in this.ControlImages)
+                {
+                    if (image.IsNewAddition)
+                    {
+                        using (FileStream fs = new FileStream(image.ControlImage, FileMode.Open, FileAccess.Read))
+                        {
+                            image.ControlImage = await this.applicationDataManager.AddOrUpdateControlImageAsync(this.controlDescription, fs);
+                        }
+                        this.controlIdentity.AddImage(image.ImageDescription);
+                    }
+                    if (image.IsMarkedForDelete)
+                    {
+                        await this.applicationDataManager.DeleteControlImageAsync(this.controlDescription, image.ControlImage);
+                        this.controlIdentity.DeleteImage(image.ImageDescription);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Error("Error occured while saving changes in image control editor", ex);
+            }
+            await this.TryCloseAsync(true);
+        }
+
+        public async void Cancel()
+        {           
+            await this.TryCloseAsync(false);
+        }
+    }
+}

--- a/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ImageDescriptionViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/ControlEditor/ImageDescriptionViewModel.cs
@@ -1,0 +1,156 @@
+﻿using Dawn;
+using Pixel.Automation.Core;
+using Pixel.Automation.Core.Enums;
+using Pixel.Automation.Core.Models;
+using System;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace Pixel.Automation.AppExplorer.ViewModels.ControlEditor
+{
+    public class ImageDescriptionViewModel : NotifyPropertyChanged
+    {
+        private readonly ImageDescription imageDescription;
+        [Browsable(false)]
+        public ImageDescription ImageDescription 
+        {
+            get => imageDescription;  
+        }
+
+        private string displayName;
+        [Browsable(false)]
+        public string DisplayName
+        {
+            get => Path.GetFileName(imageDescription.ControlImage);            
+        }
+
+        [Display(Name = "Image File", Order = 20)]
+        [ReadOnly(true)]
+        public string ControlImage
+        {
+            get => imageDescription.ControlImage;
+            set
+            {
+                imageDescription.ControlImage = value;
+                OnPropertyChanged();
+            }
+        }
+          
+        [Display(Name = "Pivot Point", Order = 20, GroupName = "Clickable Point")]
+        [ReadOnly(true)]
+        public Pivots PivotPoint
+        {
+            get => imageDescription.PivotPoint;
+            set
+            {
+                imageDescription.PivotPoint = value;
+                OnPropertyChanged();
+            }
+        }
+        
+        [Description("X offset to be added to control top left coordinates if simulating mouse actions on this control")]
+        [Display(Name = "X-Offset", Order = 20, GroupName = "Clickable Point")]
+        [ReadOnly(true)]
+        public double XOffSet
+        {
+            get
+            {
+                return imageDescription.XOffSet;
+            }
+            set
+            {
+                imageDescription.XOffSet = value;
+                OnPropertyChanged();
+            }
+        }
+      
+        [Description("Y offset to be added to control top left coordinates if simulating mouse actions on this control")]
+        [Display(Name = "Y-Offset", Order = 30, GroupName = "Clickable Point")]
+        [ReadOnly(true)]
+        public double YOffSet
+        {
+            get
+            {
+                return imageDescription.YOffSet;
+            }
+            set
+            {
+                imageDescription.YOffSet = value;
+                OnPropertyChanged();
+            }
+        }
+      
+        [Description("Use this image when screen resolution width matches specified ScreenWidth")]
+        [Display(Name = "Screen Width", Order = 30, GroupName = "Match Criteria")]
+        public short ScreenWidth
+        {
+            get => imageDescription.ScreenWidth;
+            set
+            {
+                imageDescription.ScreenWidth = value;
+                OnPropertyChanged();
+            }
+        }
+    
+        [Description("Use this image when screen resolution height matches specified ScreenWidth")]
+        [Display(Name = "Screen Height", Order = 30, GroupName = "Match Criteria")]
+        public short ScreenHeight
+        {
+            get => imageDescription.ScreenHeight;
+            set
+            {
+                imageDescription.ScreenHeight = value;
+                OnPropertyChanged();
+            }
+        }
+       
+        [Description("Use this image when specified theme on image locator matches this theme")]
+        [Display(Name = "Theme", Order = 30, GroupName = "Match Criteria")]      
+        public string Theme
+        {
+            get => imageDescription.Theme;
+            set
+            {
+                imageDescription.Theme = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private ImageSource imageSource;
+        [Browsable(false)]
+        public ImageSource ImageSource
+        {
+            get
+            {
+                if(imageSource == null)
+                {
+                    if (!string.IsNullOrEmpty(this.ControlImage))
+                    {
+                        var source = new BitmapImage();
+                        source.BeginInit();
+                        source.CacheOption = BitmapCacheOption.OnLoad;
+                        source.UriSource = new Uri(this.ControlImage, UriKind.Relative);
+                        source.EndInit();
+                        this.imageSource = source;
+                    }
+                }
+                return imageSource;
+            }
+        }
+
+        [Browsable(false)]
+        public bool IsMarkedForDelete { get; set; }
+
+        [Browsable(false)]
+        public bool IsNewAddition { get; set; }
+       
+        public ImageDescriptionViewModel(ImageDescription imageDescription)
+        {
+            Guard.Argument(imageDescription).NotNull();
+            this.imageDescription = imageDescription;            
+        }
+    }
+}

--- a/src/Pixel.Automation.AppExplorer.Views/ControlEditor/ImageControlEditorView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/ControlEditor/ImageControlEditorView.xaml
@@ -1,0 +1,173 @@
+﻿<Controls:MetroWindow x:Class="Pixel.Automation.AppExplorer.Views.ControlEditor.ImageControlEditorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Pixel.Automation.AppExplorer.Views.ControlEditor"
+             xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:cal="http://www.caliburnproject.org" cal:Bind.AtDesignTime="True"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit" ResizeMode="NoResize"
+             mc:Ignorable="d"  WindowStartupLocation="CenterScreen"  GlowBrush="{DynamicResource AccentColorBrush}"
+             d:DesignHeight="600" d:DesignWidth="800">
+    <Controls:MetroWindow.Resources>
+
+        <ResourceDictionary>
+
+            <Thickness x:Key="ControlMargin">10 10 10 10</Thickness>
+            <BooleanToVisibilityConverter x:Key="boolToVisibilityConverter"/>
+
+            <DataTemplate x:Key="ImageDescriptionTemplate">
+                <Border x:Name="brdContainer"  BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}" Background="{x:Null}" Width="180" Height="60" Margin="0,0,0,15">
+                    <Label Content="{Binding DisplayName}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Border>
+                <DataTemplate.Triggers>                    
+                    <DataTrigger Binding="{Binding
+                            RelativeSource={RelativeSource
+                                Mode=FindAncestor,
+                                AncestorType={x:Type ListBoxItem}},
+                                Path=IsSelected}" Value="True">
+                        <Setter TargetName="brdContainer" Property="Background" Value="{DynamicResource MahApps.Brushes.Accent4}"/>
+                        <Setter TargetName="brdContainer" Property="BorderThickness" Value="2"/>                                       
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding Path=IsLoopAware}" Value="True">
+                        <Setter TargetName="brdContainer" Property="Background" Value="{DynamicResource MahApps.Brushes.Accent3}"/>
+                    </DataTrigger>
+                </DataTemplate.Triggers>
+            </DataTemplate>
+            
+        </ResourceDictionary>
+
+    </Controls:MetroWindow.Resources>
+
+    <Grid Background="{DynamicResource MahApps.Brushes.Control.Background}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"></RowDefinition>
+            <RowDefinition Height="60"></RowDefinition>
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0">
+
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="7*"></ColumnDefinition>
+                <ColumnDefinition Width="2"></ColumnDefinition>
+                <ColumnDefinition Width="3*"></ColumnDefinition>
+            </Grid.ColumnDefinitions>
+
+            <Grid Grid.Column="0" Margin="10" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                    <ColumnDefinition Width="2"></ColumnDefinition>
+                    <ColumnDefinition Width="*"></ColumnDefinition>
+                </Grid.ColumnDefinitions>
+
+
+                <StackPanel Orientation="Vertical" Grid.Column="0">
+                    <Label Content="Control Images" Padding="0" Margin="10,5,0,5"/>
+                    <StackPanel x:Name="ToolBar" Orientation="Horizontal" Margin="5,5,5,0" Grid.Row="0">                    
+                        <Button x:Name="AddImageFromFile" Margin="4,0,4,0" HorizontalAlignment="Right" 
+                                            Height="20" Width="20" ToolTip="Add image from file"
+                                            cal:Message.Attach="[Event Click] = [Action AddImageFromFile()]"                       
+                                            Style="{StaticResource EditControlButtonStyle}"
+                                            Content="{iconPacks:BoxIcons RegularImageAdd}"/>
+                        <!--<Button x:Name="AddImageFromSnapShot" Margin="0,0,4,0" HorizontalAlignment="Right" 
+                                            Height="20" Width="20" ToolTip="Capture imgae"
+                                            cal:Message.Attach="[Event Click] = [Action AddImageFromSnapShot()]"                       
+                                            Style="{StaticResource EditControlButtonStyle}"
+                                            Content="{iconPacks:Unicons CameraPlus}"/>-->                       
+                        <Button x:Name="DeleteImage" Margin="0,0,4,0" HorizontalAlignment="Right" 
+                                            Height="20" Width="20" ToolTip="Delete Image"
+                                            cal:Message.Attach="[Event Click] = [Action DeleteImage()]"                       
+                                            Style="{StaticResource EditControlButtonStyle}"
+                                            Content="{iconPacks:Unicons ImageMinus}" IsEnabled="{Binding CanDeleteImage}"/>
+                        <Button x:Name="ConfigureControl" Margin="0,0,4,0" HorizontalAlignment="Right"
+                                 Height="20" Width="20" ToolTip="Configure Control"
+                                            cal:Message.Attach="[Event Click] = [Action ConfigureControl()]"                       
+                                            Style="{StaticResource EditControlButtonStyle}"
+                                            Content="{iconPacks:Material CogOutline}"/>                             
+                    </StackPanel>                  
+                    <ListBox x:Name="ControlImages" Height="{Binding Path=ActualHeight, RelativeSource={RelativeSource AncestorType=Grid}}"
+                                 ItemTemplate="{StaticResource ImageDescriptionTemplate}" SelectedItem="{Binding SelectedImage}" ScrollViewer.PanningMode="VerticalOnly" ScrollViewer.VerticalScrollBarVisibility="Hidden"
+                      Grid.Column="0" Margin="10">
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Vertical"  IsItemsHost="True" ScrollViewer.CanContentScroll="True" ScrollViewer.VerticalScrollBarVisibility="Hidden"
+                                                Width="{Binding Path=Width, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"/>
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="ListBoxItem">
+                                            <ContentPresenter/>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                    </ListBox>
+
+                </StackPanel>
+
+
+                <Border Grid.Column="1" Width="2" BorderThickness="2" BorderBrush="#FFF0F0F0" VerticalAlignment="Stretch"></Border>
+
+                <Canvas x:Name="DesignerCanvas" Grid.Column="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource MahApps.Brushes.Control.Background}"  cal:Message.Attach="[Event MouseLeftButtonDown] = [Action ChangeOffset($eventArgs, $source)]"
+                        DataContext="{Binding}" ClipToBounds="True" Tag="{Binding Path=DataContext,RelativeSource={RelativeSource Self}}" SnapsToDevicePixels="True">
+
+                    <Canvas.ContextMenu>
+                        <ContextMenu x:Name="CanvasMenu" cal:Action.TargetWithoutContext="{Binding Path=PlacementTarget.Tag, RelativeSource={RelativeSource Self}}">
+
+                            <MenuItem x:Name="changePivot" Header="Change Pivot">
+                                <MenuItem x:Name="Center" Header="Center"   cal:Message.Attach="ChangePivotPoint('Center')"></MenuItem>
+                                <MenuItem x:Name="TopLeft" Header="Top Left" cal:Message.Attach="ChangePivotPoint('TopLeft')"></MenuItem>
+                                <MenuItem x:Name="TopRight" Header="Top Right" cal:Message.Attach="ChangePivotPoint('TopRight')"></MenuItem>
+                                <MenuItem x:Name="BottomLeft" Header="Bottom Left" cal:Message.Attach="ChangePivotPoint('BottomLeft')"></MenuItem>
+                                <MenuItem x:Name="BottomRight" Header="Bottom Right" cal:Message.Attach="ChangePivotPoint('BottomRight')"></MenuItem>
+                            </MenuItem>
+                        </ContextMenu>
+                    </Canvas.ContextMenu>
+
+                    <Grid Width="{Binding ActualWidth, ElementName=DesignerCanvas}"  Height="{Binding ActualHeight, ElementName=DesignerCanvas}">
+                        <StackPanel x:Name="ImageHolder"  HorizontalAlignment="Center" VerticalAlignment="Center"
+                                    Visibility="{Binding IsImageSelected, Converter={StaticResource boolToVisibilityConverter}}" >
+                            <Border x:Name="ControlBorder" BorderBrush="{DynamicResource MahApps.Brushes.Accent}" BorderThickness="2" CornerRadius="4">
+                                <Image x:Name="ControlImage" Source="{Binding SelectedImage.ImageSource}" Stretch="None" Margin="5" 
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </StackPanel>
+                    </Grid>
+
+                    <ContentControl x:Name="OffsetPointer" Width="32" MaxWidth="32" Panel.ZIndex="1000" Visibility="{Binding IsOffsetPoiniterVisible}"
+                      Height="32"  MaxHeight="32"
+                      Canvas.Left="{Binding Offset.X}"
+                      Canvas.Top="{Binding Offset.Y}"
+                      Padding="0" ToolTip="Offset">
+                        <Border HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsHitTestVisible="False" BorderBrush="Transparent" BorderThickness="2">
+                            <Image IsHitTestVisible="False"  Source="/Pixel.Automation.Designer.Views;component/Images/OffsetPicker.Png" />
+                        </Border>
+                    </ContentControl>
+
+                </Canvas>
+
+            </Grid>
+
+            <Border Grid.Column="1" Width="2" BorderThickness="2" BorderBrush="#FFF0F0F0" VerticalAlignment="Stretch" Margin="0,10,0,10"></Border>
+
+            <Grid Grid.Column="2" Margin="5,0,0,0">
+                <xctk:PropertyGrid x:Name="propertyGrid" SelectedObject="{Binding SelectedObject}"  ShowSortOptions="True" IsCategorized="True"
+                                   PropertyContainerStyle="{StaticResource PropertyItemStyle}" Style="{StaticResource PropertyGridStyle}"
+                                   BorderThickness="0"  ShowSearchBox="True"/>
+            </Grid>
+
+        </Grid>
+
+        <DockPanel Grid.Row="1" LastChildFill="False">
+            <Border DockPanel.Dock="Top" BorderThickness="1" Height="1" HorizontalAlignment="Stretch" Width="{Binding Path=Width,RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type DockPanel}}}" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+            <Button x:Name="Cancel" Content="CANCEL" Width="100" DockPanel.Dock="Right"  Margin="{StaticResource ControlMargin}" Style="{DynamicResource MahApps.Styles.Button.Square}"/>
+            <Button x:Name="Save" Content="SAVE" DockPanel.Dock="Right" Width="100"  Margin="{StaticResource ControlMargin}" Style="{DynamicResource MahApps.Styles.Button.Square.Accent}"/>
+        </DockPanel>
+    </Grid>
+</Controls:MetroWindow>

--- a/src/Pixel.Automation.AppExplorer.Views/ControlEditor/ImageControlEditorView.xaml.cs
+++ b/src/Pixel.Automation.AppExplorer.Views/ControlEditor/ImageControlEditorView.xaml.cs
@@ -1,0 +1,13 @@
+﻿namespace Pixel.Automation.AppExplorer.Views.ControlEditor
+{
+    /// <summary>
+    /// Interaction logic for ImageControlEditorView.xaml
+    /// </summary>
+    public partial class ImageControlEditorView
+    {
+        public ImageControlEditorView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Pixel.Automation.Core.Components/Entities/ControlEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Entities/ControlEntity.cs
@@ -37,7 +37,7 @@ namespace Pixel.Automation.Core.Components
         [DisplayName("Search Root")]
         [Category("Control Details")]
         [Browsable(true)]
-        public Argument SearchRoot { get; set; } = new InArgument<UIControl>()
+        public virtual Argument SearchRoot { get; set; } = new InArgument<UIControl>()
         {
             Mode = ArgumentMode.DataBound,
             CanChangeType = false

--- a/src/Pixel.Automation.Core/Interfaces/IControlIdentity.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IControlIdentity.cs
@@ -1,5 +1,7 @@
 ﻿using Pixel.Automation.Core.Enums;
+using Pixel.Automation.Core.Models;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 
 namespace Pixel.Automation.Core.Interfaces
@@ -96,9 +98,10 @@ namespace Pixel.Automation.Core.Interfaces
 
     public interface IImageControlIdentity : IControlIdentity
     {
-        /// <summary>
-        /// Relative path of the ControlImage for the control
-        /// </summary>
-        string ControlImage { get; set; }
+        void AddImage(ImageDescription imageDescription);
+
+        void DeleteImage(ImageDescription imageDescription);
+
+        IEnumerable<ImageDescription> GetImages();
     }
 }

--- a/src/Pixel.Automation.Core/Interfaces/IScreenCapture.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IScreenCapture.cs
@@ -5,6 +5,8 @@ namespace Pixel.Automation.Core.Interfaces
 {
     public interface IScreenCapture
     {
+        (short width, short height) GetScreenResolution();
+
         Bitmap CaptureDesktop();
 
         Bitmap CaptureArea(Rectangle rectangle);

--- a/src/Pixel.Automation.Core/Models/ControlDescription.cs
+++ b/src/Pixel.Automation.Core/Models/ControlDescription.cs
@@ -40,11 +40,7 @@ namespace Pixel.Automation.Core.Models
             get => controlImage;
             set
             {
-                controlImage = value;  
-                if(ControlDetails is IImageControlIdentity imageControl)
-                {
-                    imageControl.ControlImage = value;
-                }
+                controlImage = value;                  
             }
         }
 

--- a/src/Pixel.Automation.Core/Models/ImageDescription.cs
+++ b/src/Pixel.Automation.Core/Models/ImageDescription.cs
@@ -1,0 +1,73 @@
+﻿using Pixel.Automation.Core.Enums;
+using System;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Core.Models
+{
+    [DataContract]
+    [Serializable]
+    public class ImageDescription : ICloneable
+    {
+        /// <summary>
+        /// Relative path of the image
+        /// </summary>
+        [DataMember(Order = 10)]
+        public string ControlImage { get; set; }
+    
+        /// <summary>
+        /// Pivot point used for offset
+        /// </summary>
+        [DataMember(Order = 20)]     
+        public Pivots PivotPoint { get; set; } = Pivots.Center;
+
+        /// <summary>
+        /// X offset to be added to control top left coordinates if simulating mouse actions on this control
+        /// </summary>
+        [DataMember(Order = 30)]    
+        public double XOffSet { get; set; } = 0.0f;
+
+        /// <summary>
+        /// Y offset to be added to control top left coordinates if simulating mouse actions on this control
+        /// </summary>
+        [DataMember(Order = 40)]
+        public double YOffSet { get; set; } = 0.0f;
+
+        /// <summary>
+        /// Use this image when screen resolution width matches specified ScreenWidth
+        /// </summary>
+        [DataMember(Order = 50)]    
+        public short ScreenWidth { get; set; } = 0;
+        
+        /// <summary>
+        /// Use this image when screen resolution height matches specified ScreenWidth
+        /// </summary>
+        [DataMember(Order = 60)]      
+        public short ScreenHeight { get; set; } = 0;
+
+        /// <summary>
+        /// Use this image when specified theme on image locator matches this theme
+        /// </summary>
+        [DataMember(Order = 70)]
+        public string Theme { get; set; } = string.Empty;
+        
+       
+        public  bool IsDefault
+        {
+            get => string.IsNullOrEmpty(this.Theme) && this.ScreenHeight == 0 && this.ScreenWidth == 0;
+        }
+
+        public object Clone()
+        {
+            return new ImageDescription()
+            {
+                ControlImage = this.ControlImage,
+                PivotPoint = this.PivotPoint,
+                XOffSet = this.XOffSet,
+                YOffSet = this.YOffSet,
+                ScreenHeight = this.ScreenHeight,
+                ScreenWidth = this.ScreenWidth,
+                Theme = this.Theme
+            };
+        }
+    }
+}

--- a/src/Pixel.Automation.Designer.ViewModels/Modules/ViewModules.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Modules/ViewModules.cs
@@ -26,7 +26,7 @@ namespace Pixel.Automation.Designer.ViewModels.Modules
             Kernel.Bind<INewProject>().To<NewProjectViewModel>();
             Kernel.Bind<IEditorFactory>().To<EditorFactory>();        
           
-            Kernel.Bind<IControlEditor>().To<ControlEditorViewModel>();
+            Kernel.Bind<IControlEditorFactory>().To<ControlEditorFactory>();
            
             Kernel.Bind<IPrefabBuilder>().To<PrefabBuilderViewModel>();
             Kernel.Bind<IPrefabBuilderFactory>().ToFactory();

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IControlEditor.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IControlEditor.cs
@@ -1,5 +1,4 @@
-﻿using Pixel.Automation.Core.Interfaces;
-using Pixel.Automation.Core.Models;
+﻿using Pixel.Automation.Core.Models;
 
 namespace Pixel.Automation.Editor.Core.Interfaces
 {
@@ -13,17 +12,6 @@ namespace Pixel.Automation.Editor.Core.Interfaces
         /// </summary>
         /// <param name="targetControl">targetControl is the control that is being opened for edit</param>
         void Initialize(ControlDescription targetControl);
-
-        /// <summary>
-        /// Remove a node from control hierarcy.
-        /// </summary>
-        /// <param name="controlToRemove"></param>
-        void RemoveFromControlHierarchy(IControlIdentity controlToRemove);
-
-        /// <summary>
-        /// Insert a new node in control hierarchy
-        /// </summary>
-        /// <param name="controlIdentity"></param>
-        void InsertIntoControlHierarchy(IControlIdentity controlIdentity);
+      
     }
 }

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IControlEditorFactory.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IControlEditorFactory.cs
@@ -1,0 +1,9 @@
+﻿using Pixel.Automation.Core.Interfaces;
+
+namespace Pixel.Automation.Editor.Core.Interfaces
+{
+    public interface IControlEditorFactory
+    {
+        IControlEditor CreateControlEditor(IControlIdentity controlIdentity);
+    }
+}

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IImageControlEditor.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IImageControlEditor.cs
@@ -1,0 +1,12 @@
+﻿using Pixel.Automation.Core.Models;
+
+namespace Pixel.Automation.Editor.Core.Interfaces
+{
+    /// <summary>
+    /// IImageControlEditor 
+    /// </summary>
+    public interface IImageControlEditor : IControlEditor
+    {    
+       
+    }
+}

--- a/src/Pixel.Automation.Image.Matching.Components/ImageControlEntity.cs
+++ b/src/Pixel.Automation.Image.Matching.Components/ImageControlEntity.cs
@@ -1,6 +1,5 @@
 ﻿using Pixel.Automation.Core;
 using Pixel.Automation.Core.Arguments;
-using Pixel.Automation.Core.Attributes;
 using Pixel.Automation.Core.Components;
 using Pixel.Automation.Core.Enums;
 using Pixel.Automation.Core.Exceptions;
@@ -26,6 +25,14 @@ namespace Pixel.Automation.Image.Matching.Components
     [Serializable]    
     public class ImageControlEntity : ControlEntity
     {
+        [DataMember]      
+        [Browsable(false)]
+        public override Argument SearchRoot
+        {
+            get => base.SearchRoot;
+            set => base.SearchRoot = value;
+        }
+
         private ImageSearchScope imageSearchScope = ImageSearchScope.Application;
         [DataMember]
         [Display(Name = "Search scope", GroupName = "Search Strategy", Order = 5)]
@@ -57,8 +64,7 @@ namespace Pixel.Automation.Image.Matching.Components
                 this.imageSearchScope = value;              
                 OnPropertyChanged();
             }
-        }
-        
+        }       
                 
 
         /// <summary>

--- a/src/Pixel.Automation.Native.Windows/ScreenCapture.cs
+++ b/src/Pixel.Automation.Native.Windows/ScreenCapture.cs
@@ -49,7 +49,7 @@ namespace Pixel.Automation.Native.Windows
             var hBmp = CreateCompatibleBitmap(hSrce, sz.Width, sz.Height);
             var hOldBmp = SelectObject(hDest, hBmp);
             BitBlt(hDest, 0, 0, sz.Width, sz.Height, hSrce, 0, 0, CopyPixelOperation.SourceCopy | CopyPixelOperation.CaptureBlt);
-            Bitmap bmp = System.Drawing.Image.FromHbitmap(hBmp);
+            Bitmap bmp =  Image.FromHbitmap(hBmp);
             SelectObject(hDest, hOldBmp);
             DeleteObject(hBmp);
             DeleteDC(hDest);
@@ -60,10 +60,16 @@ namespace Pixel.Automation.Native.Windows
         public virtual Bitmap CaptureArea(Rectangle rectangle)
         {
             var bmp = new Bitmap(rectangle.Width, rectangle.Height, PixelFormat.Format32bppArgb);
-            var graphics = Graphics.FromImage(bmp);
-            graphics.CopyFromScreen(rectangle.Left, rectangle.Top, 0, 0, new Size(rectangle.Width, rectangle.Height), CopyPixelOperation.SourceCopy);
+            using (var graphics = Graphics.FromImage(bmp))
+            {
+                graphics.CopyFromScreen(rectangle.Left, rectangle.Top, 0, 0, new Size(rectangle.Width, rectangle.Height), CopyPixelOperation.SourceCopy);
+            }
             return bmp;
         }
 
+        public (short width, short height) GetScreenResolution()
+        {
+            return ((short)System.Windows.SystemParameters.PrimaryScreenWidth, (short)System.Windows.SystemParameters.PrimaryScreenHeight);
+        }
     }
 }

--- a/src/Pixel.Persistence.Respository/ControlRepository.cs
+++ b/src/Pixel.Persistence.Respository/ControlRepository.cs
@@ -83,7 +83,7 @@ namespace Pixel.Persistence.Respository
         public async Task DeleteImageAsync(ControlImageMetaData imageMetaData)
         {
             Guard.Argument(imageMetaData, nameof(imageMetaData)).NotNull();
-            var filter = CreateImageFilter(imageMetaData.ApplicationId, imageMetaData.ControlId);
+            var filter = CreateImageFilter(imageMetaData.FileName, imageMetaData.ApplicationId, imageMetaData.ControlId);
             var sort = Builders<GridFSFileInfo>.Sort.Descending(x => x.UploadDateTime);
             var options = new GridFSFindOptions
             {
@@ -188,6 +188,21 @@ namespace Pixel.Persistence.Respository
         {
             var filterBuilder = Builders<GridFSFileInfo>.Filter;
             var filter = filterBuilder.Eq(x => x.Metadata["applicationId"], applicationId);
+            filter = filterBuilder.And(filter, filterBuilder.Eq(x => x.Metadata["controlId"], controlId));
+            return filter;
+        }
+
+        /// <summary>
+        /// Create filter condition for image with given applicationId and controlId.        
+        /// </summary>
+        /// <param name="applicationId"></param>
+        /// <param name="controlId"></param>
+        /// <returns></returns>
+        private FilterDefinition<GridFSFileInfo> CreateImageFilter(string imageName, string applicationId, string controlId)
+        {
+            var filterBuilder = Builders<GridFSFileInfo>.Filter;
+            var filter = filterBuilder.Eq(x => x.Filename, imageName);
+            filter = filterBuilder.And(filter, filterBuilder.Eq(x => x.Metadata["applicationId"], applicationId));
             filter = filterBuilder.And(filter, filterBuilder.Eq(x => x.Metadata["controlId"], controlId));
             return filter;
         }

--- a/src/Pixel.Persistence.Services.Api/Controllers/ControlController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/ControlController.cs
@@ -94,7 +94,7 @@ namespace Pixel.Persistence.Services.Api.Controllers
         }
 
         /// <summary>
-        /// Sae the control image in database
+        /// Save the control image in database
         /// </summary>
         /// <param name="controlImage">Metadata for the image</param>
         /// <param name="imageFile">Image file</param>
@@ -120,5 +120,25 @@ namespace Pixel.Persistence.Services.Api.Controllers
             }
         }
 
+        /// <summary>
+        /// Delete an image from the database
+        /// </summary>
+        /// <param name="controlImage"></param>
+        /// <returns></returns>
+        [Route("image/delete")]
+        [HttpPost]
+        public async Task<IActionResult> Delete([FromBody] ControlImageMetaData controlImage)
+        {
+            try
+            {
+                await controlRepository.DeleteImageAsync(controlImage);
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
     }
 }

--- a/src/Pixel.Persistence.Services.Client/ApplicationDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/ApplicationDataManager.cs
@@ -258,6 +258,19 @@ namespace Pixel.Persistence.Services.Client
             return saveLocation;
         }
 
+        public async Task DeleteControlImageAsync(ControlDescription controlDescription, string imageFile)
+        {
+           if(!File.Exists(imageFile))
+           {
+                throw new FileNotFoundException($"{imageFile} doesn't exist");
+           }
+           File.Delete(imageFile);
+           if (IsOnlineMode)
+           {
+                await controlRepositoryClient.DeleteControlImageAsync(controlDescription, imageFile);
+           }
+        }
+
         public IEnumerable<ControlDescription> GetAllControls(ApplicationDescription applicationDescription)
         {
             foreach (var controlId in applicationDescription.AvailableControls)

--- a/src/Pixel.Persistence.Services.Client/ControlRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/ControlRepositoryClient.cs
@@ -80,5 +80,25 @@ namespace Pixel.Persistence.Services.Client
             var result = await client.ExecuteAsync(restRequest);
             result.EnsureSuccess();
         }
+
+        public async Task DeleteControlImageAsync(ControlDescription controlDescription, string imageFile)
+        {
+            Guard.Argument(controlDescription).NotNull();
+            Guard.Argument(imageFile).NotNull().NotEmpty();
+            string fileName = Path.GetFileName(imageFile);
+            logger.Debug("Delete control image {0} for control : {1} with Id : {2}", fileName, controlDescription.ControlName, controlDescription.ControlId);
+
+            RestRequest restRequest = new RestRequest("control/image/delete") { Method = Method.POST };
+            var controlImageMetaData = new ControlImageMetaData()
+            {
+                ApplicationId = controlDescription.ApplicationId,
+                ControlId = controlDescription.ControlId,
+                FileName = fileName
+            };
+            restRequest.AddJsonBody(serializer.Serialize<ControlImageMetaData>(controlImageMetaData));    
+            var client = this.clientFactory.GetOrCreateClient();
+            var result = await client.ExecuteAsync(restRequest);
+            result.EnsureSuccess();
+        }
     }
 }

--- a/src/Pixel.Persistence.Services.Client/Interfaces/IApplicationDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/IApplicationDataManager.cs
@@ -48,12 +48,20 @@ namespace Pixel.Persistence.Services.Client
         Task AddOrUpdateControlAsync(ControlDescription controlDescription);
       
         /// <summary>
-        /// Add or update control image with a given resolution
+        /// Add or update control image for control
         /// </summary>
         /// <param name="controlDescription"></param>
         /// <param name="stream"></param>      
         /// <returns></returns>
-        Task<string> AddOrUpdateControlImageAsync(ControlDescription controlDescription, Stream stream);       
+        Task<string> AddOrUpdateControlImageAsync(ControlDescription controlDescription, Stream stream);
+
+        /// <summary>
+        /// Delete specified imageFile for control
+        /// </summary>
+        /// <param name="controlDescription"></param>
+        /// <param name="imageFile"></param>
+        /// <returns></returns>
+        Task DeleteControlImageAsync(ControlDescription controlDescription, string imageFile);
 
         /// <summary>
         /// Load all the automatin project from disk and return loaded projects

--- a/src/Pixel.Persistence.Services.Client/Interfaces/IControlRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/IControlRepositoryClient.cs
@@ -28,5 +28,13 @@ namespace Pixel.Persistence.Services.Client
         /// <param name="resolution"></param>
         /// <returns></returns>
         Task AddOrUpdateControlImage(ControlDescription controlDescription, string imageFile);
+
+        /// <summary>
+        /// Delete specified control image for a control
+        /// </summary>
+        /// <param name="controlDescription"></param>
+        /// <param name="imageFile"></param>
+        /// <returns></returns>
+        Task DeleteControlImageAsync(ControlDescription controlDescription, string imageFile);
     }
 }

--- a/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Control/ControlDescriptionViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Control/ControlDescriptionViewModelFixture.cs
@@ -15,9 +15,8 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public void ValidateThatControlDescriptionViewModelCanBeCorrectlyInitialized()
         {
-            var controlIdentity = Substitute.For<IImageControlIdentity>();
-            controlIdentity.ApplicationId.Returns("application-id");
-            controlIdentity.ControlImage.Returns("SaveButton.Png");
+            var controlIdentity = Substitute.For<IControlIdentity>();
+            controlIdentity.ApplicationId.Returns("application-id");         
             var controlDescription = new ControlDescription(controlIdentity)
             {
                 ControlName = "SaveButton",

--- a/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Control/ControlExplorerViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Control/ControlExplorerViewModelFixture.cs
@@ -20,6 +20,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
     [TestFixture]
     public class ControlExplorerViewModelFixture
     {
+        private IControlEditorFactory controlEditorFactory;
         private IControlEditor controlEditor;
         private IEventAggregator eventAggregator;
         private IWindowManager windowManager;
@@ -28,10 +29,12 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
+            controlEditorFactory = Substitute.For<IControlEditorFactory>();
             controlEditor = Substitute.For<IControlEditor>();
             eventAggregator = Substitute.For<IEventAggregator>();
             windowManager = Substitute.For<IWindowManager>();
-            applicationDataManager = Substitute.For<IApplicationDataManager>();         
+            applicationDataManager = Substitute.For<IApplicationDataManager>();
+            controlEditorFactory.CreateControlEditor(Arg.Any<IControlIdentity>()).Returns(controlEditor);
                       
             var controlDescription = CreateControl("SaveButton");
             applicationDataManager.GetAllControls(Arg.Any<ApplicationDescription>()).Returns(new [] { controlDescription });
@@ -53,7 +56,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public void ValidateThatControlExplorerViewModelCanBeInitializedCorrectly()
         {
-            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditor, applicationDataManager);
+            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditorFactory, applicationDataManager);
 
             Assert.AreEqual(0, controlExplorer.Controls.Count);
             Assert.IsNull(controlExplorer.SelectedControl);
@@ -65,7 +68,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public void ValidateThatCanToggleRename()
         {
-            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditor, applicationDataManager);
+            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditorFactory, applicationDataManager);
             var applicationDescription = CreateApplicationDescription();
             controlExplorer.SetActiveApplication(new Application.ApplicationDescriptionViewModel(applicationDescription));
             var controlToRename = controlExplorer.Controls.First();
@@ -84,7 +87,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public void ValidateThatControlsAreLoadedWhenApplicationIsActivated()
         {
-            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditor, applicationDataManager);
+            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditorFactory, applicationDataManager);
             var applicationDescription = CreateApplicationDescription();
             controlExplorer.SetActiveApplication(new Application.ApplicationDescriptionViewModel(applicationDescription));
 
@@ -108,7 +111,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         {         
             windowManager.ShowDialogAsync(Arg.Any<IControlEditor>()).Returns(wasSaved);
 
-            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditor, applicationDataManager);
+            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditorFactory, applicationDataManager);
             var applicationDescription = CreateApplicationDescription();
             controlExplorer.SetActiveApplication(new Application.ApplicationDescriptionViewModel(applicationDescription));
             var controlToConfigure = controlExplorer.Controls.First();
@@ -131,7 +134,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public async Task ValidateThatPropertyGridDisplayControlDetailsToBeEditedWhenEditOptionIsSelected()
         {
-            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditor, applicationDataManager);
+            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditorFactory, applicationDataManager);
             var applicationDescription = CreateApplicationDescription();
             controlExplorer.SetActiveApplication(new Application.ApplicationDescriptionViewModel(applicationDescription));
             var controlToEdit = controlExplorer.Controls.First();
@@ -148,7 +151,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public async Task ValidateThatExistingControlCanBeCloned()
         {
-            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditor, applicationDataManager);
+            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditorFactory, applicationDataManager);
             var applicationDescription = CreateApplicationDescription();
             controlExplorer.SetActiveApplication(new Application.ApplicationDescriptionViewModel(applicationDescription));
             var controlToEdit = controlExplorer.Controls.First();
@@ -169,7 +172,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public async Task ValidateThatControlExplorerCanProcessScrapedControls()
         {
-            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditor, applicationDataManager);
+            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditorFactory, applicationDataManager);
             var applicationDescription = CreateApplicationDescription();
             controlExplorer.SetActiveApplication(new Application.ApplicationDescriptionViewModel(applicationDescription));
 
@@ -200,7 +203,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public async Task ValidateThatCanSaveControlDetails()
         {
-            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditor, applicationDataManager);
+            var controlExplorer = new ControlExplorerViewModel(windowManager, eventAggregator, controlEditorFactory, applicationDataManager);
             var applicationDescription = CreateApplicationDescription();
             controlExplorer.SetActiveApplication(new Application.ApplicationDescriptionViewModel(applicationDescription));
             var controlToEdit = controlExplorer.Controls.First();

--- a/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/MockControlIdentity.cs
+++ b/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/MockControlIdentity.cs
@@ -4,7 +4,7 @@ using System.Drawing;
 
 namespace Pixel.Automation.AppExplorer.ViewModels.Tests
 {
-    class MockControlIdentity : IImageControlIdentity
+    class MockControlIdentity : IControlIdentity
     {
         public string ControlImage { get; set; }
         public string ApplicationId { get; set; }


### PR DESCRIPTION
It is possible to add multiple image now to a image control identity. The  template image at runtime will be picked based on configured theme and screen resolution(width and height).  Default image can be specified as well when no match exists at runtime. 
