### PR TITLE
TestDataRepositoryViewModel not handling ShowTestDataSourceNotification message

### DIFF
--- a/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataRepositoryViewModel.cs
+++ b/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataRepositoryViewModel.cs
@@ -29,7 +29,8 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
         private readonly IScriptEditorFactory scriptEditorFactory;
         private readonly ISerializer serializer;      
         private readonly IArgumentTypeBrowserFactory typeBrowserFactory;
-        private readonly IWindowManager windowManager;      
+        private readonly IWindowManager windowManager;
+        private readonly IEventAggregator eventAggregator;
 
         /// <summary>
         /// Collection of TestDataSource available for the associated automation project
@@ -62,14 +63,17 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
         /// <param name="typeProvider"></param>
         /// <param name="typeBrowserFactory"></param>
         public TestDataRepositoryViewModel(ISerializer serializer, IProjectFileSystem projectFileSystem, IScriptEditorFactory scriptEditorFactory,
-            IWindowManager windowManager, IArgumentTypeBrowserFactory typeBrowserFactory)
+            IWindowManager windowManager, IEventAggregator eventAggregator, IArgumentTypeBrowserFactory typeBrowserFactory)
         {
             this.serializer = Guard.Argument(serializer, nameof(serializer)).NotNull().Value;
             this.projectFileSystem = Guard.Argument(projectFileSystem, nameof(projectFileSystem)).NotNull().Value;
             this.scriptEditorFactory = Guard.Argument(scriptEditorFactory, nameof(scriptEditorFactory)).NotNull().Value;
-            this.windowManager = Guard.Argument(windowManager, nameof(windowManager)).NotNull().Value;
-            this.typeBrowserFactory = Guard.Argument(typeBrowserFactory, nameof(typeBrowserFactory)).NotNull().Value;     
-            CreateCollectionView();
+            this.windowManager = Guard.Argument(windowManager, nameof(windowManager)).NotNull().Value;           
+            this.typeBrowserFactory = Guard.Argument(typeBrowserFactory, nameof(typeBrowserFactory)).NotNull().Value;
+            this.eventAggregator = Guard.Argument(eventAggregator, nameof(eventAggregator)).NotNull().Value;
+           
+            this.eventAggregator.SubscribeOnPublishedThread(this);
+            CreateCollectionView();          
         }
 
         /// <summary>
@@ -307,13 +311,13 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
         /// <param name="message"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task HandleAsync(ShowTestDataSourceNotification message, CancellationToken cancellationToken)
+        public async Task HandleAsync(ShowTestDataSourceNotification message, CancellationToken cancellationToken)
         {
             if (message != null)
             {                
                 this.FilterText = message.TestDataId ?? string.Empty; 
             }
-            return Task.CompletedTask;
+            await Task.CompletedTask;
         }
 
         #endregion Notifications

--- a/src/Unit.Tests/Pixel.Automation.TestData.Repository.ViewModels.Tests/TestDataRepositoryViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.TestData.Repository.ViewModels.Tests/TestDataRepositoryViewModelFixture.cs
@@ -25,6 +25,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
         private IScriptEditorFactory scriptEditorFactory;
         private IArgumentTypeBrowserFactory typeBrowserFactory;
         private IWindowManager windowManager;
+        private IEventAggregator eventAggregator;
 
         [OneTimeSetUp]
         public void OneTimeSetup()
@@ -34,6 +35,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
             scriptEditorFactory = Substitute.For<IScriptEditorFactory>();
             typeBrowserFactory = Substitute.For<IArgumentTypeBrowserFactory>();
             windowManager = Substitute.For<IWindowManager>();
+            eventAggregator = Substitute.For<IEventAggregator>();
 
 
             var codeDataSource = new TestDataSource()
@@ -43,7 +45,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
                 ScriptFile = "CodeDataSource.csx",
                 MetaData = new DataSourceConfiguration()
                 {
-                     TargetTypeName = typeof(EmptyModel).Name
+                    TargetTypeName = typeof(EmptyModel).Name
                 }
             };
 
@@ -61,7 +63,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
 
             projectFileSystem.WorkingDirectory.Returns(Environment.CurrentDirectory);
             projectFileSystem.TestDataRepository.Returns(Path.Combine(Environment.CurrentDirectory, "TestDataRepository"));
-            projectFileSystem.GetTestDataSources().Returns(new [] { codeDataSource, csvDataSource });
+            projectFileSystem.GetTestDataSources().Returns(new[] { codeDataSource, csvDataSource });
 
             typeBrowserFactory.CreateArgumentTypeBrowser().Returns(Substitute.For<IArgumentTypeBrowser>());
 
@@ -84,7 +86,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
         [TestCase]
         public async Task ValidateThatTestDataRepositoryViewModelCanBeCorrectlyInitialized()
         {
-            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, typeBrowserFactory);
+            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, eventAggregator, typeBrowserFactory);
 
             Assert.AreEqual(0, testDataRepositoryViewModel.TestDataSourceCollection.Count);
             Assert.IsNull(testDataRepositoryViewModel.SelectedTestDataSource);
@@ -99,7 +101,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
         [TestCase]
         public async Task ValidateThatCanCreateNewCodeDataSource()
         {
-            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, typeBrowserFactory);
+            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, eventAggregator, typeBrowserFactory);
             await testDataRepositoryViewModel.ActivateAsync();
 
             testDataRepositoryViewModel.CreateCodedTestDataSource();
@@ -112,8 +114,8 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
         [TestCase]
         public async Task ValidateThatCanCreateNewCsvDataSource()
         {
-            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, typeBrowserFactory);
-            await testDataRepositoryViewModel .ActivateAsync();
+            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, eventAggregator, typeBrowserFactory);
+            await testDataRepositoryViewModel.ActivateAsync();
 
             testDataRepositoryViewModel.CreateCsvTestDataSource();
 
@@ -132,7 +134,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
             scriptEditorFactory.When(x => x.AddProject(Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<Type>())).Do(XamlGeneratedNamespace => { });
             scriptEditorFactory.When(x => x.RemoveProject(Arg.Any<string>())).Do(x => { });
 
-            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, typeBrowserFactory);
+            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, eventAggregator, typeBrowserFactory);
             await testDataRepositoryViewModel.ActivateAsync();
             var codeDataSource = testDataRepositoryViewModel.TestDataSourceCollection.First(a => a.DataSource.Equals(DataSource.Code));
 
@@ -151,10 +153,10 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
         public async Task ValidateThatCanEditCsvDataSource()
         {
             //Arrange
-            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, typeBrowserFactory);
+            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, eventAggregator, typeBrowserFactory);
             await testDataRepositoryViewModel.ActivateAsync();
             var csvDataSource = testDataRepositoryViewModel.TestDataSourceCollection.First(a => a.DataSource.Equals(DataSource.CsvFile));
-          
+
             //Act
             testDataRepositoryViewModel.EditDataSource(csvDataSource);
 
@@ -167,11 +169,11 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
         public async Task ValidateThatTestDataSourceIsClearedWhenDeactivated()
         {
             //Arrange
-            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, typeBrowserFactory);
-           
+            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, eventAggregator, typeBrowserFactory);
+
             await testDataRepositoryViewModel.ActivateAsync();
             Assert.AreEqual(2, testDataRepositoryViewModel.TestDataSourceCollection.Count);
-          
+
             await testDataRepositoryViewModel.DeactivateAsync(true);
             Assert.AreEqual(0, testDataRepositoryViewModel.TestDataSourceCollection.Count);
         }
@@ -180,8 +182,8 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
         public async Task ValidateThatCanHandleShowTestDataSourceNotificationMessage()
         {
             //Arrange
-            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, typeBrowserFactory);
-            
+            var testDataRepositoryViewModel = new TestDataRepositoryViewModel(serializer, projectFileSystem, scriptEditorFactory, windowManager, eventAggregator, typeBrowserFactory);
+
             //Act
             await testDataRepositoryViewModel.HandleAsync(new ShowTestDataSourceNotification("test-data-id"), CancellationToken.None);
 


### PR DESCRIPTION
**Description**
You can right click on a test case and select show data source from context menu. This raises a message on event aggregator that should be handled by the TestDataRepositoryViewModel and the TestDataRespotioryViewModel will filter the data sources on view based on test data source id received in notification message. However, TestDataRepositoryViewModel  was not subscribing to eventAggregator and hence never received those notification messages.