### PR TITLE
Fix broken style after upgrading AvalonDock to 4.70.1

### DIFF
--- a/src/Pixel.Automation.Designer.Views/Shell/DesignerWindowView.xaml
+++ b/src/Pixel.Automation.Designer.Views/Shell/DesignerWindowView.xaml
@@ -39,10 +39,9 @@
             <Style TargetType="{x:Type Controls:MetroContentControl}">
                 <Setter Property="BorderBrush" Value="{x:Null}"/>
                 <Setter Property="BorderThickness" Value="0"/>
-            </Style>
+            </Style>  
 
         </ResourceDictionary>
-
     </UserControl.Resources>
     
     <DockPanel>        
@@ -80,7 +79,9 @@
             </MenuItem>
         </Menu>
         <avalonDock:DockingManager x:Name="Manager" DocumentsSource="{Binding Items}" AnchorablesSource="{Binding Anchorables}"
-							 ActiveContent="{Binding ActiveItem, Mode=TwoWay}" LayoutUpdated="OnManagerLayoutUpdated">
+                                   GridSplitterVerticalStyle="{DynamicResource {x:Type avalonDock:LayoutGridResizerControl}}"
+                                   GridSplitterHorizontalStyle="{DynamicResource {x:Type avalonDock:LayoutGridResizerControl}}"
+							       ActiveContent="{Binding ActiveItem, Mode=TwoWay}" LayoutUpdated="OnManagerLayoutUpdated">
             <avalonDock:DockingManager.LayoutItemTemplateSelector>
                 <docking:PanesTemplateSelector>
                     <docking:PanesTemplateSelector.ScreenTemplate>

--- a/src/Pixel.Automation.Editor.Core/Pixel.Automation.Editor.Core.csproj
+++ b/src/Pixel.Automation.Editor.Core/Pixel.Automation.Editor.Core.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Caliburn.Micro" Version="4.0.173" />
-    <PackageReference Include="Dirkster.AvalonDock" Version="4.50.2" />
+    <PackageReference Include="Dirkster.AvalonDock" Version="4.70.1" />
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />
   </ItemGroup>
 

--- a/src/Xceed.Wpf.AvalonDock.Themes.MahApps/Xceed.Wpf.AvalonDock.Themes.MahApps.csproj
+++ b/src/Xceed.Wpf.AvalonDock.Themes.MahApps/Xceed.Wpf.AvalonDock.Themes.MahApps.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dirkster.AvalonDock" Version="4.50.2" />
+    <PackageReference Include="Dirkster.AvalonDock" Version="4.70.1" />
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />
   </ItemGroup>
 


### PR DESCRIPTION
**Description**
Grid Splitter resizer is no more visible after upgrading AvalonDock to 4.70.1. This PR fixes the broken style.