### PR TITLE
Broken build after move Pixel.OpenId.Authenticator to src folder

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/Pixel.Automation.Designer.ViewModels.csproj
+++ b/src/Pixel.Automation.Designer.ViewModels/Pixel.Automation.Designer.ViewModels.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>    
-    <ProjectReference Include="..\..\Pixel.OpenId.Authenticator\Pixel.OpenId.Authenticator.csproj" />    
+    <ProjectReference Include="..\Pixel.OpenId.Authenticator\Pixel.OpenId.Authenticator.csproj" />    
     <ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj">
       <Private>false</Private>
     </ProjectReference>

--- a/src/Pixel.OpenId.Authenticator/Pixel.OpenId.Authenticator.csproj
+++ b/src/Pixel.OpenId.Authenticator/Pixel.OpenId.Authenticator.csproj
@@ -13,7 +13,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\src\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
+	  <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
**Description**
Broke build with last commit while moving  Pixel.OpenId.Authenticator . This PR should fix the build issue.