### PR TITLE
Fixed issue with image locator failing to find image with search scope of desktop

### DIFF
--- a/src/Pixel.Automation.Core/Controls/UIControl.cs
+++ b/src/Pixel.Automation.Core/Controls/UIControl.cs
@@ -10,6 +10,12 @@ namespace Pixel.Automation.Core.Controls
     {
         protected object TargetControl { get; set; }
 
+        /// <summary>
+        /// Get the underlying control represented by the automation framework in use e.g. IWebElement for Webdriver, Automation element for UIA , etc.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        /// <exception cref="InvalidCastException"></exception>
         public virtual T GetApiControl<T>()
         {
             if (this.TargetControl is T requiredControl)
@@ -19,8 +25,17 @@ namespace Pixel.Automation.Core.Controls
             throw new InvalidCastException($"{typeof(T)} is incompatible with {TargetControl.GetType()}");
         }
 
+        /// <summary>
+        /// Get the bounding box of the control. Bounding box can be used to show a highglight rectangle around control.
+        /// </summary>
+        /// <returns></returns>
         public abstract Task<BoundingBox> GetBoundingBoxAsync();
 
+        /// <summary>
+        /// Get a clickable point on the control. Bounding box of the control is used along with the configured pivot and offset to locate this point.
+        /// Clickable point can be used with different mouse operations e.g. click, mouse over, etc.
+        /// </summary>
+        /// <returns></returns>
         public abstract Task<(double,double)> GetClickablePointAsync();
     }
 }

--- a/src/Pixel.Automation.Image.Matching.Components/ImageControlEntity.cs
+++ b/src/Pixel.Automation.Image.Matching.Components/ImageControlEntity.cs
@@ -14,190 +14,189 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
-namespace Pixel.Automation.Image.Matching.Components
+namespace Pixel.Automation.Image.Matching.Components;
+
+public enum ImageSearchScope
 {
-    public enum ImageSearchScope
+    Desktop,
+    Application,
+    Custom
+}
+
+[DataContract]
+[Serializable]    
+public class ImageControlEntity : ControlEntity
+{
+    [DataMember]      
+    [Browsable(false)]
+    public override Argument SearchRoot
     {
-        Desktop,
-        Application,
-        Custom
+        get => base.SearchRoot;
+        set => base.SearchRoot = value;
     }
 
-    [DataContract]
-    [Serializable]    
-    public class ImageControlEntity : ControlEntity
+    private ImageSearchScope imageSearchScope = ImageSearchScope.Application;
+    [DataMember]
+    [Display(Name = "Search scope", GroupName = "Search Strategy", Order = 5)]
+    [Description("Indicates how the search scope i.e. area on screen where search will be performed")]
+    [RefreshProperties(RefreshProperties.Repaint)]
+    public ImageSearchScope ImageSearchScope
     {
-        [DataMember]      
-        [Browsable(false)]
-        public override Argument SearchRoot
+        get
         {
-            get => base.SearchRoot;
-            set => base.SearchRoot = value;
-        }
-
-        private ImageSearchScope imageSearchScope = ImageSearchScope.Application;
-        [DataMember]
-        [Display(Name = "Search scope", GroupName = "Search Strategy", Order = 5)]
-        [Description("Indicates how the search scope i.e. area on screen where search will be performed")]
-        [RefreshProperties(RefreshProperties.Repaint)]
-        public ImageSearchScope ImageSearchScope
-        {
-            get
-            {
-                switch (this.imageSearchScope)
-                {
-                    case ImageSearchScope.Desktop:
-                        this.SetDispalyAttribute(nameof(TargetWindow), false);
-                        this.SetDispalyAttribute(nameof(AreaOnScreen), false);
-                        break;
-                    case ImageSearchScope.Application:
-                        this.SetDispalyAttribute(nameof(TargetWindow), true);
-                        this.SetDispalyAttribute(nameof(AreaOnScreen), false);
-                        break;
-                    case ImageSearchScope.Custom:
-                        this.SetDispalyAttribute(nameof(TargetWindow), false);
-                        this.SetDispalyAttribute(nameof(AreaOnScreen), true);
-                        break;
-                }
-                return this.imageSearchScope;
-            }
-            set
-            {
-                this.imageSearchScope = value;              
-                OnPropertyChanged();
-            }
-        }       
-                
-
-        /// <summary>
-        /// Optional. When Search scope is Application, by default image lookup is within the bounding box of parent application window.
-        /// However, if search area needs to be restrained to another child window of the owner application or even another application window,
-        /// target window can be specified  as ApplicationWindow. ChildWindow can be searched using FindChildWindowActorComponent. 
-        /// </summary>
-        [DataMember]
-        [Display(Name = "Target window", GroupName = "Search Strategy", Order = 10)]    
-        [Description("Target window within which image lookup will be restricted")]     
-        public InArgument<ApplicationWindow> TargetWindow { get; set; } = new InArgument<ApplicationWindow>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
-
-
-        /// <summary>
-        /// A custom bounding box can be provided when search scope is set to custom. Image lookup is constrained within this bounding box.
-        /// </summary>
-        [DataMember]
-        [Display(Name = "Area on screen", GroupName = "Search Strategy", Order = 15)]
-        [Description("Target window within which image lookup will be restricted")]    
-        public InArgument<BoundingBox> AreaOnScreen { get; set; } = new InArgument<BoundingBox>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
-
-        protected override void InitializeFilter()
-        {
-            if (this.Filter == null)
-            {
-                this.Filter = new PredicateArgument<BoundingBox>() { CanChangeMode = false, CanChangeType = false };
-            }
-        }
-    
-        public override async Task<UIControl> GetControl()
-        {
-            BoundingBox regionOfInterest = await GetRegionOfInterest();
-            ImageControlLocatorComponent controlLocator;
-            if (this.EntityManager.TryGetOwnerApplication(this, out IApplication application))
-            {
-                controlLocator = this.EntityManager.GetControlLocator(this.ControlDetails) as ImageControlLocatorComponent;
-            }
-            else
-            {
-                controlLocator = new ImageControlLocatorComponent();
-            }
-            UIControl targetControl = default;
-            switch (LookupMode)
-            {
-                case LookupMode.FindSingle:
-                    targetControl = await controlLocator.FindControlAsync(this.ControlDetails, new ImageUIControl(this.ControlDetails, regionOfInterest));
-                    break;
-                case LookupMode.FindAll:
-                    var descendantControls = await controlLocator.FindAllControlsAsync(this.ControlDetails, new ImageUIControl(this.ControlDetails, regionOfInterest));
-                    switch (FilterMode)
-                    {
-                        case FilterMode.Index:
-                            targetControl = await GetElementAtIndex(descendantControls);
-                            break;
-                        case FilterMode.Custom:
-                            targetControl = GetElementMatchingCriteria(descendantControls);
-                            break;
-                    }
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
-           
-            return targetControl;
-        }
-
-
-        public override async Task<IEnumerable<UIControl>> GetAllControls()
-        {
-            BoundingBox regionOfInterest = await GetRegionOfInterest();
-            ImageControlLocatorComponent controlLocator = this.EntityManager.GetControlLocator(this.ControlDetails) as ImageControlLocatorComponent;
-            var foundControls = await controlLocator.FindAllControlsAsync(this.ControlDetails, new ImageUIControl(this.ControlDetails, regionOfInterest));          
-            return foundControls;
-        }      
-
-        /// <summary>
-        /// Get bounding box of the application if SearchWithinApplication is true.
-        /// Control locator treats null value as search on entire desktop
-        /// </summary>
-        /// <returns></returns>
-        private async  Task<BoundingBox> GetRegionOfInterest()
-        {
-            switch(this.ImageSearchScope)
+            switch (this.imageSearchScope)
             {
                 case ImageSearchScope.Desktop:
-                    //For now, ImageControlLocator will capture entire desktop when we don't pass any BoundingBox as search scope parameter.
-                    //TODO : Find how can we get screen resolution without relying on System.Windows.Forms.Screen.PrimaryScreen.Bounds which ScreenCapture
-                    //is using.
+                    this.SetDispalyAttribute(nameof(TargetWindow), false);
+                    this.SetDispalyAttribute(nameof(AreaOnScreen), false);
                     break;
                 case ImageSearchScope.Application:
-                    var windowManager = this.EntityManager.GetServiceOfType<IApplicationWindowManager>();
-                    if (TargetWindow.IsConfigured())
-                    {
-                        var targetWindow = await ArgumentProcessor.GetValueAsync<ApplicationWindow>(this.TargetWindow);
-                        return targetWindow.WindowBounds;
-                    }
-                    else
-                    {
-                        if(this.EntityManager.TryGetOwnerApplication<IApplication>(this, out IApplication parentApplication))
-                        {
-                            var appRectangle = windowManager.GetWindowSize(parentApplication.Hwnd);
-                            return appRectangle;
-                        }
-                        throw new ConfigurationException($"Search scope is Application. However, {this} doesn't have a Application Context.");
-                    }                   
+                    this.SetDispalyAttribute(nameof(TargetWindow), true);
+                    this.SetDispalyAttribute(nameof(AreaOnScreen), false);
+                    break;
                 case ImageSearchScope.Custom:
-                    if(AreaOnScreen.IsConfigured())
-                    {
-                        return await ArgumentProcessor.GetValueAsync<BoundingBox>(this.AreaOnScreen);
-                    }
-                    throw new ConfigurationException("Search scope is configured as Custom. However, required input AreaOnScreen is not configured or incorrectly configured");                   
+                    this.SetDispalyAttribute(nameof(TargetWindow), false);
+                    this.SetDispalyAttribute(nameof(AreaOnScreen), true);
+                    break;
             }
-            return null;
+            return this.imageSearchScope;
         }
-
-        public override void ResolveDependencies()
+        set
         {
-            if (this.EntityManager.TryGetOwnerApplication<IApplication>(this, out IApplication parentApplication))
-            {
-                var applicationPoolEntity = this.EntityManager.RootEntity.GetComponentsByTag("ApplicationPoolEntity", SearchScope.Children).FirstOrDefault() as Entity;
-                var applicationsInPool = applicationPoolEntity.GetComponentsOfType<IApplicationEntity>(SearchScope.Descendants);
-                if (applicationsInPool != null)
+            this.imageSearchScope = value;              
+            OnPropertyChanged();
+        }
+    }                       
+
+    /// <summary>
+    /// When Search scope is Application, by default image lookup is within the bounding box of parent application window.
+    /// However, if search area needs to be restrained to another child window of the owner application or even another application window,
+    /// target window can be specified  as ApplicationWindow. ChildWindow can be searched using FindChildWindowActorComponent. 
+    /// </summary>
+    [DataMember]
+    [Display(Name = "Target window", GroupName = "Search Strategy", Order = 10)]    
+    [Description("Target application window within which image lookup will be restricted")]     
+    public Argument TargetWindow { get; set; } = new InArgument<ApplicationWindow>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+
+    /// <summary>
+    /// A custom bounding box can be provided when search scope is set to custom. Image lookup is constrained within this bounding box.
+    /// </summary>
+    [DataMember]
+    [Display(Name = "Area on screen", GroupName = "Search Strategy", Order = 15)]
+    [Description("Target window within which image lookup will be restricted")]    
+    public Argument AreaOnScreen { get; set; } = new InArgument<BoundingBox>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+
+    ///<inheritdoc/>
+    protected override void InitializeFilter()
+    {
+        if (this.Filter == null)
+        {
+            this.Filter = new PredicateArgument<BoundingBox>() { CanChangeMode = false, CanChangeType = false };
+        }
+    }
+
+    ///<inheritdoc/>
+    public override async Task<UIControl> GetControl()
+    {
+        BoundingBox regionOfInterest = await GetRegionOfInterest();
+        ImageControlLocatorComponent controlLocator;
+        if (this.EntityManager.TryGetOwnerApplication(this, out IApplication application))
+        {
+            controlLocator = this.EntityManager.GetControlLocator(this.ControlDetails) as ImageControlLocatorComponent;
+        }
+        else
+        {
+            controlLocator = new ImageControlLocatorComponent();
+        }
+        UIControl targetControl = default;
+        switch (LookupMode)
+        {
+            case LookupMode.FindSingle:
+                targetControl = await controlLocator.FindControlAsync(this.ControlDetails, new ImageUIControl(this.ControlDetails, regionOfInterest));
+                break;
+            case LookupMode.FindAll:
+                var descendantControls = await controlLocator.FindAllControlsAsync(this.ControlDetails, new ImageUIControl(this.ControlDetails, regionOfInterest));
+                switch (FilterMode)
                 {
-                    var targetApp = applicationsInPool.FirstOrDefault(a => a.ApplicationId.Equals(parentApplication.ApplicationId)) as Entity;
-                    if (!targetApp?.GetComponentsOfType<ImageControlLocatorComponent>().Any() ?? false)
+                    case FilterMode.Index:
+                        targetControl = await GetElementAtIndex(descendantControls);
+                        break;
+                    case FilterMode.Custom:
+                        targetControl = GetElementMatchingCriteria(descendantControls);
+                        break;
+                }
+                break;
+            default:
+                throw new NotSupportedException();
+        }
+       
+        return targetControl;
+    }
+
+    ///<inheritdoc/>
+    public override async Task<IEnumerable<UIControl>> GetAllControls()
+    {
+        BoundingBox regionOfInterest = await GetRegionOfInterest();
+        ImageControlLocatorComponent controlLocator = this.EntityManager.GetControlLocator(this.ControlDetails) as ImageControlLocatorComponent;
+        var foundControls = await controlLocator.FindAllControlsAsync(this.ControlDetails, new ImageUIControl(this.ControlDetails, regionOfInterest));          
+        return foundControls;
+    }      
+
+    /// <summary>
+    /// Get bounding box of the application if SearchWithinApplication is true.
+    /// Control locator treats null value as search on entire desktop
+    /// </summary>
+    /// <returns></returns>
+    private async  Task<BoundingBox> GetRegionOfInterest()
+    {
+        switch(this.ImageSearchScope)
+        {
+            case ImageSearchScope.Desktop:
+                var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
+                var (screenWidth, screenHeight) = screenCapture.GetScreenResolution();
+                return new BoundingBox(0, 0, screenWidth, screenHeight);                 
+            case ImageSearchScope.Application:
+                var windowManager = this.EntityManager.GetServiceOfType<IApplicationWindowManager>();
+                if (TargetWindow.IsConfigured())
+                {
+                    var targetWindow = await ArgumentProcessor.GetValueAsync<ApplicationWindow>(this.TargetWindow);
+                    return targetWindow.WindowBounds;
+                }
+                else
+                {
+                    if(this.EntityManager.TryGetOwnerApplication<IApplication>(this, out IApplication parentApplication))
                     {
-                        targetApp.AddComponent(new ImageControlLocatorComponent());
+                        var appRectangle = windowManager.GetWindowSize(parentApplication.Hwnd);
+                        return appRectangle;
                     }
+                    throw new ConfigurationException($"Search scope is Application. However, {this} doesn't have a Application Context.");
+                }                   
+            case ImageSearchScope.Custom:
+                if(AreaOnScreen.IsConfigured())
+                {
+                    return await ArgumentProcessor.GetValueAsync<BoundingBox>(this.AreaOnScreen);
+                }
+                throw new ConfigurationException("Search scope is configured as Custom. However, required input AreaOnScreen is not configured or incorrectly configured");                   
+        }
+        return null;
+    }
+
+    ///<inheritdoc/>
+    public override void ResolveDependencies()
+    {
+        if (this.EntityManager.TryGetOwnerApplication<IApplication>(this, out IApplication parentApplication))
+        {
+            var applicationPoolEntity = this.EntityManager.RootEntity.GetComponentsByTag("ApplicationPoolEntity", SearchScope.Children).FirstOrDefault() as Entity;
+            var applicationsInPool = applicationPoolEntity.GetComponentsOfType<IApplicationEntity>(SearchScope.Descendants);
+            if (applicationsInPool != null)
+            {
+                var targetApp = applicationsInPool.FirstOrDefault(a => a.ApplicationId.Equals(parentApplication.ApplicationId)) as Entity;
+                if (!targetApp?.GetComponentsOfType<ImageControlLocatorComponent>().Any() ?? false)
+                {
+                    targetApp.AddComponent(new ImageControlLocatorComponent());
                 }
             }
         }
     }
-   
 }
+

--- a/src/Pixel.Automation.Image.Matching.Components/ImageControlIdentity.cs
+++ b/src/Pixel.Automation.Image.Matching.Components/ImageControlIdentity.cs
@@ -10,171 +10,200 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.Serialization;
 
-namespace Pixel.Automation.Image.Matching.Components
+namespace Pixel.Automation.Image.Matching.Components;
+
+[DataContract]
+[Serializable]
+[ContainerEntity(typeof(ImageControlEntity))]
+public class ImageControlIdentity : NotifyPropertyChanged, IImageControlIdentity
 {
-    [DataContract]
-    [Serializable]
-    [ContainerEntity(typeof(ImageControlEntity))]
-    public class ImageControlIdentity : NotifyPropertyChanged, IImageControlIdentity
+    #region  General 
+
+    [DataMember(Order = 10)]
+    [Browsable(false)]
+    public string ApplicationId { get; set; }
+
+    [DataMember(Order = 20)]
+    [Browsable(false)]
+    public string Name { get; set; }
+
+    protected BoundingBox boundingBox;
+    [DataMember(Order = 40)]       
+    [Browsable(false)]
+    public BoundingBox BoundingBox
     {
-        #region  General 
-
-        [DataMember(Order = 10)]
-        [Browsable(false)]
-        public string ApplicationId { get; set; }
-
-        [DataMember(Order = 20)]
-        [Browsable(false)]
-        public string Name { get; set; }
-
-        protected BoundingBox boundingBox;
-        [DataMember(Order = 40)]       
-        [Browsable(false)]
-        public BoundingBox BoundingBox
-        {
-            get => boundingBox;
-            set => boundingBox = value;
-        }
-
-        #endregion General
-
-        #region Retry Attempts
-
-        [DataMember(Order = 50)]
-        [Description("Number of times to retry if control can't be located in first attempt")]
-        [Display(Name = "Retry Attempts", Order = 10, GroupName = "Retry Settings")]
-        public int RetryAttempts { get; set; } = 5;
-
-        [DataMember(Order = 60)]
-        [Description("Interval in seconds between each retry attempt")]
-        [Display(Name = "Retry Interval", Order = 20, GroupName = "Retry Settings")]
-        public int RetryInterval { get; set; } = 2;
-
-        #endregion Retry Attempts
-
-        #region Clickable Point Offset
-      
-        [DataMember(Order = 70, IsRequired = false)]
-        [Browsable(false)]
-        public  Pivots PivotPoint { get; set; }     
-
-       
-        [DataMember(Order = 80, IsRequired = false)]
-        [Browsable(false)]
-        public double XOffSet { get; set; } 
-
-       
-        [DataMember(Order = 90, IsRequired = false)]
-        [Browsable(false)]
-        public  double YOffSet { get; set; }
-        
-        #endregion Clickable Point Offset
-
-        #region Search Strategy
-
-        [DataMember(Order = 100, IsRequired = false)]
-        [Browsable(false)]
-        public LookupType LookupType { get; set; } = LookupType.Default;
-
-        [DataMember(Order = 110, IsRequired = false)]
-        [Browsable(false)]
-        public SearchScope SearchScope { get; set; } = SearchScope.Descendants;
-
-        [DataMember(Order = 120, IsRequired = false)]
-        [Browsable(false)]
-        public int Index { get; set; } = 1;
-
-        #endregion Search Strategy
-
-        [NonSerialized]
-        OpenCvSharp.TemplateMatchModes matchStrategy = OpenCvSharp.TemplateMatchModes.CCoeffNormed;
-        [DataMember(Order = 210)]
-        [Display(Name = "Match Strategy", GroupName = "Configuration")]
-        [Description("Specifies the way the template must be compared with image regions")]
-        public OpenCvSharp.TemplateMatchModes MatchStrategy
-        {
-            get => matchStrategy;
-            set => matchStrategy = value;
-        }
-
-        float thresHold = 0.9f;
-        [DataMember(Order = 220)]
-        [Display(Name = "Threshold", GroupName = "Configuration")]
-        [Description("Minimum match percentage for acceptance")]    
-        public float ThreshHold
-        {
-            get => thresHold;
-            set => thresHold = value;
-        }
-
-        [DataMember(Order = 230)]
-        [Browsable(false)]
-        public List<ImageDescription> ControlImages { get; set; } = new ();
-
-        [DataMember(Order = 1000, IsRequired = false)]
-        [Browsable(false)]
-        public IControlIdentity Next { get; set; }
-
-        public ImageControlIdentity() : base()
-        {
-
-        }
-
-        public IEnumerable<ImageDescription> GetImages()
-        {
-            return this.ControlImages;
-        }
-
-        public void AddImage(ImageDescription imageDescription)
-        {            
-            if(!this.ControlImages.Any(a => a.ControlImage.Equals(imageDescription.ControlImage)))
-            {
-                this.ControlImages.Add(imageDescription);
-            }
-        }
-
-        public void DeleteImage(ImageDescription imageDescription)
-        {
-            var imageToDelete = this.ControlImages.FirstOrDefault(a => a.ControlImage.Equals(imageDescription.ControlImage));
-            if(imageToDelete != null)
-            {
-                this.ControlImages.Remove(imageToDelete);
-            }
-        }
-
-        public string GetControlName()
-        {
-            return this.Name;
-        }
-
-        public object Clone()
-        {
-            ImageControlIdentity clone = new ImageControlIdentity()
-            {
-                Name = this.Name,
-                ApplicationId = this.ApplicationId,              
-                BoundingBox = this.BoundingBox,
-                PivotPoint = this.PivotPoint,
-                XOffSet = this.XOffSet,
-                YOffSet = this.YOffSet,
-                RetryAttempts = this.RetryAttempts,
-                RetryInterval = this.RetryInterval,
-                SearchScope = this.SearchScope,
-                MatchStrategy = this.MatchStrategy,
-                ThreshHold = this.ThreshHold,
-                ControlImages = new List<ImageDescription>()
-            };
-            foreach(var imageDescription in this.ControlImages)
-            {
-                clone.ControlImages.Add(imageDescription.Clone() as ImageDescription);
-            }
-
-            return clone;
-        }
-
-        public override string ToString()
-        {
-            return $"{this.Name} -> MatchStrategy:{this.matchStrategy}|Threshold:{this.thresHold}";
-        }       
+        get => boundingBox;
+        set => boundingBox = value;
     }
+
+    #endregion General
+
+    #region Retry Attempts
+
+    [DataMember(Order = 50)]
+    [Description("Number of times to retry if control can't be located in first attempt")]
+    [Display(Name = "Retry Attempts", Order = 10, GroupName = "Retry Settings")]
+    public int RetryAttempts { get; set; } = 5;
+
+    [DataMember(Order = 60)]
+    [Description("Interval in seconds between each retry attempt")]
+    [Display(Name = "Retry Interval", Order = 20, GroupName = "Retry Settings")]
+    public int RetryInterval { get; set; } = 2;
+
+    #endregion Retry Attempts
+
+    #region Clickable Point Offset
+  
+    [DataMember(Order = 70, IsRequired = false)]
+    [Browsable(false)]
+    public  Pivots PivotPoint { get; set; }     
+
+   
+    [DataMember(Order = 80, IsRequired = false)]
+    [Browsable(false)]
+    public double XOffSet { get; set; } 
+
+   
+    [DataMember(Order = 90, IsRequired = false)]
+    [Browsable(false)]
+    public  double YOffSet { get; set; }
+    
+    #endregion Clickable Point Offset
+
+    #region Search Strategy
+
+    [DataMember(Order = 100, IsRequired = false)]
+    [Browsable(false)]
+    public LookupType LookupType { get; set; } = LookupType.Default;
+
+    [DataMember(Order = 110, IsRequired = false)]
+    [Browsable(false)]
+    public SearchScope SearchScope { get; set; } = SearchScope.Descendants;
+
+    [DataMember(Order = 120, IsRequired = false)]
+    [Browsable(false)]
+    public int Index { get; set; } = 1;
+
+    #endregion Search Strategy
+
+    [NonSerialized]
+    OpenCvSharp.TemplateMatchModes matchStrategy = OpenCvSharp.TemplateMatchModes.CCoeffNormed;
+    [DataMember(Order = 210)]
+    [Display(Name = "Match Strategy", GroupName = "Configuration")]
+    [Description("Specifies the way the template must be compared with image regions")]
+    public OpenCvSharp.TemplateMatchModes MatchStrategy
+    {
+        get => matchStrategy;
+        set => matchStrategy = value;
+    }
+
+    float thresHold = 0.9f;
+    [DataMember(Order = 220)]
+    [Display(Name = "Threshold", GroupName = "Configuration")]
+    [Description("Minimum match percentage for acceptance")]    
+    public float ThreshHold
+    {
+        get => thresHold;
+        set => thresHold = value;
+    }
+
+    /// <summary>
+    /// Multiple images can be associated with a image control identity e.g. for different themes and resolutions.
+    /// One of them can be picked at runtime for image matching based on configuration.
+    /// </summary>
+    /// <returns></returns>
+    [DataMember(Order = 230)]
+    [Browsable(false)]
+    public List<ImageDescription> ControlImages { get; set; } = new ();
+
+    [DataMember(Order = 1000, IsRequired = false)]
+    [Browsable(false)]
+    public IControlIdentity Next { get; set; }
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    public ImageControlIdentity() : base()
+    {
+
+    }
+
+   /// <summary>
+   /// Get the configured images for the control. Multiple image can be associated with a image control identity e.g. for different themese and reoslutions.
+   /// One of them can be picked at runtime for image matching based on configuration.
+   /// </summary>
+   /// <returns></returns>
+    public IEnumerable<ImageDescription> GetImages()
+    {
+        return this.ControlImages;
+    }
+
+    /// <summary>
+    /// Add a new <see cref="ImageDescription"/> to the control.
+    /// </summary>
+    /// <param name="imageDescription"></param>
+    public void AddImage(ImageDescription imageDescription)
+    {            
+        if(!this.ControlImages.Any(a => a.ControlImage.Equals(imageDescription.ControlImage)))
+        {
+            this.ControlImages.Add(imageDescription);
+        }
+    }
+
+    /// <summary>
+    /// Remove an existing <see cref="ImageDescription"/> from the control
+    /// </summary>
+    /// <param name="imageDescription"></param>
+    public void DeleteImage(ImageDescription imageDescription)
+    {
+        var imageToDelete = this.ControlImages.FirstOrDefault(a => a.ControlImage.Equals(imageDescription.ControlImage));
+        if(imageToDelete != null)
+        {
+            this.ControlImages.Remove(imageToDelete);
+        }
+    }
+
+    /// <summary>
+    /// Get the name of the control
+    /// </summary>
+    /// <returns></returns>
+    public string GetControlName()
+    {
+        return this.Name;
+    }
+
+    /// <summary>
+    /// Create a deep copy clone of the ImageControlIdentity
+    /// </summary>
+    /// <returns></returns>
+    public object Clone()
+    {
+        ImageControlIdentity clone = new ImageControlIdentity()
+        {
+            Name = this.Name,
+            ApplicationId = this.ApplicationId,              
+            BoundingBox = this.BoundingBox,
+            PivotPoint = this.PivotPoint,
+            XOffSet = this.XOffSet,
+            YOffSet = this.YOffSet,
+            RetryAttempts = this.RetryAttempts,
+            RetryInterval = this.RetryInterval,
+            SearchScope = this.SearchScope,
+            MatchStrategy = this.MatchStrategy,
+            ThreshHold = this.ThreshHold,
+            ControlImages = new List<ImageDescription>()
+        };
+        foreach(var imageDescription in this.ControlImages)
+        {
+            clone.ControlImages.Add(imageDescription.Clone() as ImageDescription);
+        }
+
+        return clone;
+    }
+
+    ///<inheritdoc/>
+    public override string ToString()
+    {
+        return $"{this.Name} -> MatchStrategy:{this.matchStrategy}|Threshold:{this.thresHold}";
+    }       
 }

--- a/src/Pixel.Automation.Image.Matching.Components/ImageControlLocatorComponent.cs
+++ b/src/Pixel.Automation.Image.Matching.Components/ImageControlLocatorComponent.cs
@@ -19,400 +19,402 @@ using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Pixel.Automation.Image.Matching.Components
+namespace Pixel.Automation.Image.Matching.Components;
+
+[DataContract]
+[Serializable]
+[ToolBoxItem("Image Locator", "Control Locators", iconSource: null, description: "Identify a image control on screen", tags: new string[] { "Locator" })]
+public class ImageControlLocatorComponent : ServiceComponent, IControlLocator, ICoordinateProvider
 {
-    [DataContract]
-    [Serializable]
-    [ToolBoxItem("Image Locator", "Control Locators", iconSource: null, description: "Identify a image control on screen", tags: new string[] { "Locator" })]
-    public class ImageControlLocatorComponent : ServiceComponent, IControlLocator, ICoordinateProvider
+    private readonly ILogger logger = Log.ForContext<ImageControlLocatorComponent>();
+
+
+    [NonSerialized]
+    bool showBoundingBox;
+    /// <summary>
+    /// Toggle if bounding box is shown during playback on controls.
+    /// This can help visuall debug the control location process in hierarchy
+    /// </summary>
+    public bool ShowBoundingBox
     {
-        private readonly ILogger logger = Log.ForContext<ImageControlLocatorComponent>();
-
-
-        [NonSerialized]
-        bool showBoundingBox;
-        /// <summary>
-        /// Toggle if bounding box is shown during playback on controls.
-        /// This can help visuall debug the control location process in hierarchy
-        /// </summary>
-        public bool ShowBoundingBox
+        get
         {
-            get
-            {
-                return showBoundingBox;
-            }
-            set
-            {
-                showBoundingBox = value;
-            }
+            return showBoundingBox;
         }
-
-        [NonSerialized]
-        int retryAttempts = 2;
-        [Browsable(false)]
-        [IgnoreDataMember]
-        protected int RetryAttempts
+        set
         {
-            get
-            {
-                return retryAttempts;
-            }
-            set
-            {
-                if (value == retryAttempts)
-                {
-                    return;
-                }
-                retryAttempts = value;
-                retrySequence.Clear();
-                foreach (var i in Enumerable.Range(1, value))
-                {
-                    retrySequence.Add(TimeSpan.FromSeconds(retryInterval));
-                }
-            }
+            showBoundingBox = value;
         }
+    }
 
-        [NonSerialized]
-        double retryInterval = 5;
-        [DataMember]
-        [Browsable(false)]
-        [IgnoreDataMember]
-        protected double RetryInterval
+    [NonSerialized]
+    int retryAttempts = 2;
+    [Browsable(false)]
+    [IgnoreDataMember]
+    protected int RetryAttempts
+    {
+        get
         {
-            get
-            {
-                return retryInterval;
-            }
-            set
-            {
-                if (value == retryInterval)
-                {
-                    return;
-                }
-                retryInterval = value;
-                retrySequence.Clear();
-                foreach (var i in Enumerable.Range(1, retryAttempts))
-                {
-                    retrySequence.Add(TimeSpan.FromSeconds(value));
-                }
-            }
+            return retryAttempts;
         }
-
-        /// <summary>
-        /// Set the theme used by the application. Target image will be retrieved based on the matching theme.
-        /// </summary>
-        [DataMember]
-        public Argument Theme { get; set; } = new InArgument<string>() { CanChangeType = false, CanChangeMode = true, DefaultValue = string.Empty, Mode = ArgumentMode.DataBound };
-
-        [NonSerialized]
-        private RetryPolicy policy;
-
-        [NonSerialized]
-        private List<TimeSpan> retrySequence;
-
-        [NonSerialized]
-        private IHighlightRectangle highlightRectangle;
-      
-        public ImageControlLocatorComponent() : base("Image Control Locator", "ImageControlLocator")
+        set
         {
-            retrySequence = new List<TimeSpan>();
-            foreach (var i in Enumerable.Range(1, retryAttempts))
+            if (value == retryAttempts)
+            {
+                return;
+            }
+            retryAttempts = value;
+            retrySequence.Clear();
+            foreach (var i in Enumerable.Range(1, value))
             {
                 retrySequence.Add(TimeSpan.FromSeconds(retryInterval));
             }
-            policy = Policy.Handle<ElementNotFoundException>()
-            .WaitAndRetry(retrySequence, (exception, timeSpan, retryCount, context) =>
-            {
-                logger.Error(exception, exception.Message); ;
-                if (retryCount < retrySequence.Count)
-                {
-                    logger.Information("Control lookup  will be attempated again.");
-                }
-            });
-
         }
+    }
 
-        public bool CanProcessControlOfType(IControlIdentity controlIdentity)
+    [NonSerialized]
+    double retryInterval = 5;
+    [DataMember]
+    [Browsable(false)]
+    [IgnoreDataMember]
+    protected double RetryInterval
+    {
+        get
         {
-            return controlIdentity is ImageControlIdentity;
+            return retryInterval;
         }
-
-
-        public async Task<UIControl> FindControlAsync(IControlIdentity controlDetails, UIControl searchRoot)
+        set
         {
-            Guard.Argument(controlDetails).NotNull().Compatible<ImageControlIdentity>();
-
-            ImageControlIdentity controlIdentity = controlDetails as ImageControlIdentity;
-            ConfigureRetryPolicy(controlIdentity);
-
-            var searchArea = searchRoot?.GetApiControl<BoundingBox>();
-            var foundControl = await policy.Execute(async () =>
+            if (value == retryInterval)
             {
-                HighlightElement(searchArea);
-                var boundingBox = await TryFindMatch(controlIdentity, searchArea);
-                //Transform the control bounding box relative to desktop top-left (0,0)
-                if (searchArea != null)
-                {
-                    boundingBox.X += searchArea.X;
-                    boundingBox.Y += searchArea.Y;
-                }
-                return boundingBox;
-            });
-            HighlightElement(foundControl);
-            return await Task.FromResult(new ImageUIControl(controlIdentity, foundControl ?? throw new ElementNotFoundException($"Failed to find any control matching image  {controlDetails}")));
+                return;
+            }
+            retryInterval = value;
+            retrySequence.Clear();
+            foreach (var i in Enumerable.Range(1, retryAttempts))
+            {
+                retrySequence.Add(TimeSpan.FromSeconds(value));
+            }
         }
+    }
 
+    /// <summary>
+    /// Set the theme used by the application. Target image will be retrieved based on the matching theme.
+    /// </summary>
+    [DataMember]
+    public Argument Theme { get; set; } = new InArgument<string>() { CanChangeType = false, CanChangeMode = true, DefaultValue = string.Empty, Mode = ArgumentMode.DataBound };
 
-        public async Task<IEnumerable<UIControl>> FindAllControlsAsync(IControlIdentity controlDetails, UIControl searchRoot)
+    [NonSerialized]
+    private RetryPolicy policy;
+
+    [NonSerialized]
+    private List<TimeSpan> retrySequence;
+
+    [NonSerialized]
+    private IHighlightRectangle highlightRectangle;
+  
+    public ImageControlLocatorComponent() : base("Image Control Locator", "ImageControlLocator")
+    {
+        retrySequence = new List<TimeSpan>();
+        foreach (var i in Enumerable.Range(1, retryAttempts))
         {
-            Guard.Argument(controlDetails).NotNull().Compatible<ImageControlIdentity>();
-
-            ImageControlIdentity controlIdentity = controlDetails as ImageControlIdentity;
-            ConfigureRetryPolicy(controlIdentity);
-            var searchArea = searchRoot?.GetApiControl<BoundingBox>();
-            var foundControls = await policy.Execute(async () =>
-            {
-                HighlightElement(searchArea);
-                return await TryFindAllMatch(controlIdentity, searchArea);
-            });
-            if (!foundControls.Any())
-            {
-                throw new ElementNotFoundException($"Failed to find any control matching image  {controlDetails}");
-            }
-            return await Task.FromResult(foundControls.Select(s => new ImageUIControl(controlDetails, s)));
+            retrySequence.Add(TimeSpan.FromSeconds(retryInterval));
         }
-
-
-        private async Task<BoundingBox> TryFindMatch(ImageControlIdentity controlDetails, BoundingBox searchArea)
+        policy = Policy.Handle<ElementNotFoundException>()
+        .WaitAndRetry(retrySequence, (exception, timeSpan, retryCount, context) =>
         {
-            string templateFile = await GetTemplateFile(controlDetails);
-            var regionOfInterest = CaptureRegionOfInterest(searchArea);
-
-            OpenCvSharp.Point matchingPoint;
-            using (Mat templateImg = Cv2.ImRead(templateFile, ImreadModes.Grayscale))
+            logger.Error(exception, exception.Message); ;
+            if (retryCount < retrySequence.Count)
             {
-                using (Mat sourceImg = Cv2.ImDecode(regionOfInterest, ImreadModes.Grayscale))
-                {
-                    int cols = sourceImg.Cols - templateImg.Cols + 1;
-                    int rows = sourceImg.Rows - templateImg.Rows + 1;
-                    using (Mat resultImg = new Mat(rows, cols, MatType.CV_32F))
-                    {
-                        Cv2.MatchTemplate(sourceImg, templateImg, resultImg, controlDetails.MatchStrategy);
-                        //resultImg.Normalize(0, 1, OpenCvSharp.NormTypes.MinMax);
-                        Cv2.Threshold(resultImg, resultImg, controlDetails.ThreshHold, 1.0, ThresholdTypes.Tozero);
-
-                        if (controlDetails.Index > 1)
-                        {
-                            List<OpenCvSharp.Point> matchingPoints = GetAllMatchingPoints(resultImg, controlDetails.MatchStrategy, controlDetails.ThreshHold);
-                            if (matchingPoints.Count >= controlDetails.Index)
-                            {
-                                matchingPoint = matchingPoints[controlDetails.Index - 1];
-                                return new BoundingBox(matchingPoint.X, matchingPoint.Y, templateImg.Width, templateImg.Height);
-                            }
-
-                            throw new ElementNotFoundException($"Element at index {controlDetails.Index} could not be located");
-                        }
-                        matchingPoint = GetMatchingPoint(resultImg, controlDetails.MatchStrategy, controlDetails.ThreshHold);
-                        return new BoundingBox(matchingPoint.X, matchingPoint.Y, templateImg.Width, templateImg.Height);
-                    }
-                }
+                logger.Information("Control lookup  will be attempated again.");
             }
+        });
 
-        }
+    }
 
-        private async Task<IEnumerable<BoundingBox>> TryFindAllMatch(ImageControlIdentity controlDetails, BoundingBox searchArea)
-        {         
-            string templateFile = await GetTemplateFile(controlDetails);
-            var regionOfInterest = CaptureRegionOfInterest(searchArea);
-            var foundMatches = new List<BoundingBox>();
-            using (Mat templateImg = Cv2.ImRead(templateFile, ImreadModes.Grayscale))
-            {
-                using (Mat sourceImg = Cv2.ImDecode(regionOfInterest, ImreadModes.Grayscale))
-                {
-                    int cols = sourceImg.Cols - templateImg.Cols + 1;
-                    int rows = sourceImg.Rows - templateImg.Rows + 1;
-                    using (Mat resultImg = new Mat(rows, cols, MatType.CV_32F))
-                    {
-                        Cv2.MatchTemplate(sourceImg, templateImg, resultImg, controlDetails.MatchStrategy);
-                        //resultImg.Normalize(0, 1, OpenCvSharp.NormTypes.MinMax);
-                        Cv2.Threshold(resultImg, resultImg, controlDetails.ThreshHold, 1.0, ThresholdTypes.Tozero);
+    public bool CanProcessControlOfType(IControlIdentity controlIdentity)
+    {
+        return controlIdentity is ImageControlIdentity;
+    }
 
-                        List<OpenCvSharp.Point> matchingPoints = GetAllMatchingPoints(resultImg, controlDetails.MatchStrategy, controlDetails.ThreshHold);
-                        foreach (var matchingPoint in matchingPoints)
-                        {
-                            foundMatches.Add(new BoundingBox(matchingPoint.X, matchingPoint.Y, templateImg.Width, templateImg.Height));
-                        }                      
-                    }
-                }
-            }
-            return foundMatches;
-        }
 
-        private async Task<string> GetTemplateFile(ImageControlIdentity controlDetails)
+    public async Task<UIControl> FindControlAsync(IControlIdentity controlDetails, UIControl searchRoot)
+    {
+        Guard.Argument(controlDetails).NotNull().Compatible<ImageControlIdentity>();
+
+        ImageControlIdentity controlIdentity = controlDetails as ImageControlIdentity;
+        ConfigureRetryPolicy(controlIdentity);
+
+        var searchArea = searchRoot?.GetApiControl<BoundingBox>();
+        var foundControl = await policy.Execute(async () =>
         {
-            var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
-            var argumentProcessor = this.EntityManager.GetServiceOfType<IArgumentProcessor>();
-          
-            (short width, short height) = screenCapture.GetScreenResolution();            
-
-            string theme = string.Empty;
-            if (this.Theme.IsConfigured())
-            {
-                theme = await argumentProcessor.GetValueAsync<string>(this.Theme);
-                logger.Information($"Configured theme is {theme}");
-            }
-            var images = controlDetails.GetImages();
-            ImageDescription targetImage;
-            if(!string.IsNullOrEmpty(theme))
-            {
-                targetImage = images.FirstOrDefault(a => a.Theme.Equals(theme) && a.ScreenWidth.Equals(width) && a.ScreenHeight.Equals(height));                   
-            }
-            else
-            {
-                targetImage = images.FirstOrDefault(a => string.IsNullOrEmpty(a.Theme) && a.ScreenWidth.Equals(width) && a.ScreenHeight.Equals(height));
-            }
-            targetImage = targetImage ?? images.FirstOrDefault(a => a.IsDefault);
-           
-            string templateFile = targetImage?.ControlImage ?? throw new ConfigurationException($"No template image could be located for theme : {theme}, " +
-                $"screen width : {width}, screen height : {height} and default image is not configured.");;
-            if (!File.Exists(templateFile))
-            {
-                throw new FileNotFoundException($"{templateFile} doesn't exist.");
-            }
-            return templateFile;
-        }
-
-        private OpenCvSharp.Point GetMatchingPoint(Mat matchData, TemplateMatchModes matchMode, float threshHold)
-        {
-            double minVal, maxVal;
-            OpenCvSharp.Point minLoc, maxLoc;
-            Cv2.MinMaxLoc(matchData, out minVal, out maxVal, out minLoc, out maxLoc);
-
-            switch (matchMode)
-            {
-                case TemplateMatchModes.SqDiff:
-                case TemplateMatchModes.SqDiffNormed:
-                    if (minVal > threshHold)
-                    {
-                        logger.Information("Image match located {@maxLoc} with {maxVal} %", maxLoc, maxVal * 100);
-                        return new OpenCvSharp.Point(minLoc.X, minLoc.Y);
-                    }
-                    else
-                    {
-                        throw new ElementNotFoundException($"Image could not be located against configured threshold of {threshHold}.Best match located has only {maxVal}% accuracy");
-                    }
-                case TemplateMatchModes.CCoeff:
-                case TemplateMatchModes.CCoeffNormed:
-                case TemplateMatchModes.CCorr:
-                case TemplateMatchModes.CCorrNormed:
-                    if (maxVal > threshHold)
-                    {
-                        logger.Information("Image match located {@maxLoc} with {maxVal} %", maxVal, maxLoc);
-                        return new OpenCvSharp.Point(maxLoc.X, maxLoc.Y);
-                    }
-                    else
-                    {
-                        throw new ElementNotFoundException($"Image could not be located against configured threshold of {threshHold}.Best match located has only {maxVal}% accuracy");
-                    }
-                default:
-                    throw new ArgumentException($"Configured MatchMode is not supported by OpenCv for template matching");
-            }
-        }
-
-        private List<OpenCvSharp.Point> GetAllMatchingPoints(Mat matchData, TemplateMatchModes matchMode, float threshHold)
-        {
-            List<OpenCvSharp.Point> matchingPoints = new List<OpenCvSharp.Point>();
-            while (true)
-            {
-                try
-                {
-                    OpenCvSharp.Point matchingPoint = GetMatchingPoint(matchData, matchMode, threshHold);
-                    matchingPoints.Add(matchingPoint);
-                    Rect outRect;
-                    Cv2.FloodFill(matchData, new OpenCvSharp.Point(matchingPoint.X, matchingPoint.Y), new Scalar(0), out outRect, new Scalar(0.1), new Scalar(1.0), FloodFillFlags.FixedRange);
-                }
-                catch
-                {
-                    if (matchingPoints.Count >= 1)
-                        break;
-                    else
-                        throw;
-                }
-
-            }
-            return matchingPoints;
-
-        }
-
-        private byte[] CaptureRegionOfInterest(BoundingBox searchArea)
-        {
-            var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
+            HighlightElement(searchArea);
+            var boundingBox = await TryFindMatch(controlIdentity, searchArea);
+            //Transform the control bounding box relative to desktop top-left (0,0)
             if (searchArea != null)
             {
-                return screenCapture.CaptureArea(searchArea);
+                boundingBox.X += searchArea.X;
+                boundingBox.Y += searchArea.Y;
             }
-            else
-            {
-                return screenCapture.CaptureDesktop();
-            }
-        }
-
-        private void ConfigureRetryPolicy(IControlIdentity controlIdentity)
-        {
-            RetryAttempts = controlIdentity.RetryAttempts;
-            RetryInterval = controlIdentity.RetryInterval;
-        }
-
-        private void HighlightElement(BoundingBox foundControl)
-        {
-
-            if (showBoundingBox && foundControl != null)
-            {
-                if (highlightRectangle == null)
-                {
-                    highlightRectangle = this.EntityManager.GetServiceOfType<IHighlightRectangle>();
-                }
-
-                var boundingBox = new BoundingBox(foundControl.X, foundControl.Y, foundControl.Width, foundControl.Height);
-                if (!boundingBox.Equals(BoundingBox.Empty))
-                {
-                    highlightRectangle.Visible = true;
-
-                    highlightRectangle.Location = boundingBox;
-                    Thread.Sleep(500);
-
-                    highlightRectangle.Visible = false;
-
-                }
-            }
-
-        }
-
-        #region ICoordinateProvider   
-
-        public async Task<(double, double)> GetClickablePoint(IControlIdentity controlDetails)
-        {
-            var bounds = await GetScreenBounds(controlDetails);
-            controlDetails.GetClickablePoint(bounds, out double x, out double y);
-            return await Task.FromResult((x, y));
-        }
-
-        public async Task<BoundingBox> GetScreenBounds(IControlIdentity controlIdentity)
-        {
-            var targetControl = await this.FindControlAsync(controlIdentity, null);
-            var screenBounds = await GetBoundingBox(targetControl);
-            return screenBounds;
-        }
-
-        public async Task<BoundingBox> GetBoundingBox(object control)
-        {
-            if (control is BoundingBox boundingBox)
-            {
-                return await Task.FromResult(new BoundingBox(boundingBox.X, boundingBox.Y, boundingBox.Width, boundingBox.Height));
-            }
-            throw new ArgumentException("control must be of type BoundingBox");
-        }
-
-        #endregion ICoordinateProvider  
+            return boundingBox;
+        });
+        HighlightElement(foundControl);
+        return await Task.FromResult(new ImageUIControl(controlIdentity, foundControl ?? throw new ElementNotFoundException($"Failed to find any control matching image  {controlDetails}")));
     }
+
+
+    public async Task<IEnumerable<UIControl>> FindAllControlsAsync(IControlIdentity controlDetails, UIControl searchRoot)
+    {
+        Guard.Argument(controlDetails).NotNull().Compatible<ImageControlIdentity>();
+
+        ImageControlIdentity controlIdentity = controlDetails as ImageControlIdentity;
+        ConfigureRetryPolicy(controlIdentity);
+        var searchArea = searchRoot?.GetApiControl<BoundingBox>();
+        var foundControls = await policy.Execute(async () =>
+        {
+            HighlightElement(searchArea);
+            return await TryFindAllMatch(controlIdentity, searchArea);
+        });
+        if (!foundControls.Any())
+        {
+            throw new ElementNotFoundException($"Failed to find any control matching image  {controlDetails}");
+        }
+        return await Task.FromResult(foundControls.Select(s => new ImageUIControl(controlDetails, s)));
+    }
+
+
+    private async Task<BoundingBox> TryFindMatch(ImageControlIdentity controlDetails, BoundingBox searchArea)
+    {
+        string templateFile = await GetTemplateFile(controlDetails);
+        var regionOfInterest = CaptureRegionOfInterest(searchArea);
+
+        OpenCvSharp.Point matchingPoint;
+        using (Mat templateImg = Cv2.ImRead(templateFile, ImreadModes.Grayscale))
+        {
+            using (Mat sourceImg = Cv2.ImDecode(regionOfInterest, ImreadModes.Grayscale))
+            {
+                int cols = sourceImg.Cols - templateImg.Cols + 1;
+                int rows = sourceImg.Rows - templateImg.Rows + 1;
+                using (Mat resultImg = new Mat(rows, cols, MatType.CV_32F))
+                {
+                    Cv2.MatchTemplate(sourceImg, templateImg, resultImg, controlDetails.MatchStrategy);
+                    //resultImg.Normalize(0, 1, OpenCvSharp.NormTypes.MinMax);
+                    Cv2.Threshold(resultImg, resultImg, controlDetails.ThreshHold, 1.0, ThresholdTypes.Tozero);
+
+                    if (controlDetails.Index > 1)
+                    {
+                        List<OpenCvSharp.Point> matchingPoints = GetAllMatchingPoints(resultImg, controlDetails.MatchStrategy, controlDetails.ThreshHold);
+                        if (matchingPoints.Count >= controlDetails.Index)
+                        {
+                            matchingPoint = matchingPoints[controlDetails.Index - 1];
+                            return new BoundingBox(matchingPoint.X, matchingPoint.Y, templateImg.Width, templateImg.Height);
+                        }
+
+                        throw new ElementNotFoundException($"Element at index {controlDetails.Index} could not be located");
+                    }
+                    matchingPoint = GetMatchingPoint(resultImg, controlDetails.MatchStrategy, controlDetails.ThreshHold);
+                    return new BoundingBox(matchingPoint.X, matchingPoint.Y, templateImg.Width, templateImg.Height);
+                }
+            }
+        }
+
+    }
+
+    private async Task<IEnumerable<BoundingBox>> TryFindAllMatch(ImageControlIdentity controlDetails, BoundingBox searchArea)
+    {         
+        string templateFile = await GetTemplateFile(controlDetails);
+        var regionOfInterest = CaptureRegionOfInterest(searchArea);
+        var foundMatches = new List<BoundingBox>();
+        using (Mat templateImg = Cv2.ImRead(templateFile, ImreadModes.Grayscale))
+        {
+            using (Mat sourceImg = Cv2.ImDecode(regionOfInterest, ImreadModes.Grayscale))
+            {
+                int cols = sourceImg.Cols - templateImg.Cols + 1;
+                int rows = sourceImg.Rows - templateImg.Rows + 1;
+                using (Mat resultImg = new Mat(rows, cols, MatType.CV_32F))
+                {
+                    Cv2.MatchTemplate(sourceImg, templateImg, resultImg, controlDetails.MatchStrategy);
+                    //resultImg.Normalize(0, 1, OpenCvSharp.NormTypes.MinMax);
+                    Cv2.Threshold(resultImg, resultImg, controlDetails.ThreshHold, 1.0, ThresholdTypes.Tozero);
+
+                    List<OpenCvSharp.Point> matchingPoints = GetAllMatchingPoints(resultImg, controlDetails.MatchStrategy, controlDetails.ThreshHold);
+                    foreach (var matchingPoint in matchingPoints)
+                    {
+                        foundMatches.Add(new BoundingBox(matchingPoint.X, matchingPoint.Y, templateImg.Width, templateImg.Height));
+                    }                      
+                }
+            }
+        }
+        return foundMatches;
+    }
+
+    private async Task<string> GetTemplateFile(ImageControlIdentity controlDetails)
+    {
+        var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
+        var argumentProcessor = this.EntityManager.GetServiceOfType<IArgumentProcessor>();
+      
+        (short width, short height) = screenCapture.GetScreenResolution();            
+
+        string theme = string.Empty;
+        if (this.Theme.IsConfigured())
+        {
+            theme = await argumentProcessor.GetValueAsync<string>(this.Theme);
+            logger.Information($"Configured theme is {theme}");
+        }
+        var images = controlDetails.GetImages();
+        ImageDescription targetImage;
+        if(!string.IsNullOrEmpty(theme))
+        {
+            targetImage = images.FirstOrDefault(a => a.Theme.Equals(theme) && a.ScreenWidth.Equals(width) && a.ScreenHeight.Equals(height));                   
+        }
+        else
+        {
+            targetImage = images.FirstOrDefault(a => string.IsNullOrEmpty(a.Theme) && a.ScreenWidth.Equals(width) && a.ScreenHeight.Equals(height));
+        }
+        targetImage = targetImage ?? images.FirstOrDefault(a => a.IsDefault);
+       
+        string templateFile = targetImage?.ControlImage ?? throw new ConfigurationException($"No template image could be located for theme : {theme}, " +
+            $"screen width : {width}, screen height : {height} and default image is not configured.");;
+        if (!File.Exists(templateFile))
+        {
+            throw new FileNotFoundException($"{templateFile} doesn't exist.");
+        }
+        return templateFile;
+    }
+
+    private OpenCvSharp.Point GetMatchingPoint(Mat matchData, TemplateMatchModes matchMode, float threshHold)
+    {
+        double minVal, maxVal;
+        OpenCvSharp.Point minLoc, maxLoc;
+        Cv2.MinMaxLoc(matchData, out minVal, out maxVal, out minLoc, out maxLoc);
+
+        switch (matchMode)
+        {
+            case TemplateMatchModes.SqDiff:
+            case TemplateMatchModes.SqDiffNormed:
+                if (minVal > threshHold)
+                {
+                    logger.Information("Image match located {@maxLoc} with {maxVal} %", maxLoc, maxVal * 100);
+                    return new OpenCvSharp.Point(minLoc.X, minLoc.Y);
+                }
+                else
+                {
+                    throw new ElementNotFoundException($"Image could not be located against configured threshold of {threshHold}.Best match located has only {maxVal}% accuracy");
+                }
+            case TemplateMatchModes.CCoeff:
+            case TemplateMatchModes.CCoeffNormed:
+            case TemplateMatchModes.CCorr:
+            case TemplateMatchModes.CCorrNormed:
+                if (maxVal > threshHold)
+                {
+                    logger.Information("Image match located {@maxLoc} with {maxVal} %", maxVal, maxLoc);
+                    return new OpenCvSharp.Point(maxLoc.X, maxLoc.Y);
+                }
+                else
+                {
+                    throw new ElementNotFoundException($"Image could not be located against configured threshold of {threshHold}.Best match located has only {maxVal}% accuracy");
+                }
+            default:
+                throw new ArgumentException($"Configured MatchMode is not supported by OpenCv for template matching");
+        }
+    }
+
+    private List<OpenCvSharp.Point> GetAllMatchingPoints(Mat matchData, TemplateMatchModes matchMode, float threshHold)
+    {
+        List<OpenCvSharp.Point> matchingPoints = new List<OpenCvSharp.Point>();
+        while (true)
+        {
+            try
+            {
+                OpenCvSharp.Point matchingPoint = GetMatchingPoint(matchData, matchMode, threshHold);
+                matchingPoints.Add(matchingPoint);
+                Rect outRect;
+                Cv2.FloodFill(matchData, new OpenCvSharp.Point(matchingPoint.X, matchingPoint.Y), new Scalar(0), out outRect, new Scalar(0.1), new Scalar(1.0), FloodFillFlags.FixedRange);
+            }
+            catch
+            {
+                if (matchingPoints.Count >= 1)
+                    break;
+                else
+                    throw;
+            }
+
+        }
+        return matchingPoints;
+
+    }
+
+    private byte[] CaptureRegionOfInterest(BoundingBox searchArea)
+    {
+        var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
+        if (searchArea != null)
+        {
+            return screenCapture.CaptureArea(searchArea);
+        }
+        else
+        {
+            return screenCapture.CaptureDesktop();
+        }
+    }
+
+    private void ConfigureRetryPolicy(IControlIdentity controlIdentity)
+    {
+        RetryAttempts = controlIdentity.RetryAttempts;
+        RetryInterval = controlIdentity.RetryInterval;
+    }
+
+    private void HighlightElement(BoundingBox foundControl)
+    {
+
+        if (showBoundingBox && foundControl != null)
+        {
+            if (highlightRectangle == null)
+            {
+                highlightRectangle = this.EntityManager.GetServiceOfType<IHighlightRectangle>();
+            }
+
+            var boundingBox = new BoundingBox(foundControl.X, foundControl.Y, foundControl.Width, foundControl.Height);
+            if (!boundingBox.Equals(BoundingBox.Empty))
+            {
+                highlightRectangle.Visible = true;
+
+                highlightRectangle.Location = boundingBox;
+                Thread.Sleep(500);
+
+                highlightRectangle.Visible = false;
+
+            }
+        }
+
+    }
+
+    #region ICoordinateProvider   
+
+    ///<inheritdoc/>
+    public async Task<(double, double)> GetClickablePoint(IControlIdentity controlDetails)
+    {
+        var bounds = await GetScreenBounds(controlDetails);
+        controlDetails.GetClickablePoint(bounds, out double x, out double y);
+        return await Task.FromResult((x, y));
+    }
+
+    ///<inheritdoc/>
+    public async Task<BoundingBox> GetScreenBounds(IControlIdentity controlIdentity)
+    {
+        var targetControl = await this.FindControlAsync(controlIdentity, null);
+        var screenBounds = await GetBoundingBox(targetControl);
+        return screenBounds;
+    }
+
+    ///<inheritdoc/>
+    public async Task<BoundingBox> GetBoundingBox(object control)
+    {
+        if (control is BoundingBox boundingBox)
+        {
+            return await Task.FromResult(new BoundingBox(boundingBox.X, boundingBox.Y, boundingBox.Width, boundingBox.Height));
+        }
+        throw new ArgumentException("control must be of type BoundingBox");
+    }
+
+    #endregion ICoordinateProvider  
 }

--- a/src/Pixel.Automation.Image.Matching.Components/ImageUIControl.cs
+++ b/src/Pixel.Automation.Image.Matching.Components/ImageUIControl.cs
@@ -1,32 +1,42 @@
-﻿using Pixel.Automation.Core.Controls;
+﻿using Dawn;
+using Pixel.Automation.Core.Controls;
 using Pixel.Automation.Core.Extensions;
 using Pixel.Automation.Core.Interfaces;
 using System.Threading.Tasks;
 
-namespace Pixel.Automation.Image.Matching.Components
+namespace Pixel.Automation.Image.Matching.Components;
+
+/// <summary>
+/// ImageUI control represents a control image as a control using the bounding box of image on screen.
+/// Bounding box is located using image matching.
+/// </summary>
+public class ImageUIControl : UIControl
 {
-    public class ImageUIControl : UIControl
+    private readonly IControlIdentity controlIdentity;      
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="controlIdentity">Details of the image control</param>
+    /// <param name="imageControl">Bounding box of the image control</param>
+    public ImageUIControl(IControlIdentity controlIdentity, BoundingBox imageControl)
     {
-        private readonly IControlIdentity controlIdentity;
-        private readonly BoundingBox imageControl;
+        this.controlIdentity = Guard.Argument(controlIdentity).NotNull().Value;          
+        this.TargetControl = Guard.Argument(imageControl).NotNull().Value;
+    }
 
-        public ImageUIControl(IControlIdentity controlIdentity, BoundingBox imageControl)
-        {
-            this.controlIdentity = controlIdentity;
-            this.imageControl = imageControl;        
-            this.TargetControl = imageControl;
-        }
+    ///<inheritdoc/>
+    public override async Task<BoundingBox> GetBoundingBoxAsync()
+    {
+        var imageControl = this.TargetControl as BoundingBox;
+        return await Task.FromResult(new BoundingBox(imageControl.X, imageControl.Y, imageControl.Width, imageControl.Height));
+    }
 
-        public override async Task<BoundingBox> GetBoundingBoxAsync()
-        {
-            return await Task.FromResult(new BoundingBox(imageControl.X, imageControl.Y, imageControl.Width, imageControl.Height));
-        }
-
-        public override async Task<(double,double)> GetClickablePointAsync()
-        {
-            var boundingBox = await GetBoundingBoxAsync();
-            controlIdentity.GetClickablePoint(boundingBox, out double x, out double y);
-            return await Task.FromResult((x, y));
-        }
+    ///<inheritdoc/>
+    public override async Task<(double,double)> GetClickablePointAsync()
+    {
+        var boundingBox = await GetBoundingBoxAsync();
+        controlIdentity.GetClickablePoint(boundingBox, out double x, out double y);
+        return (x, y);
     }
 }


### PR DESCRIPTION
**Description**
Image locator fails to find image due to null reference exception when trying to retrieve api control when search scope is configured as desktop.

**Fix**
ImageControlEntity will get the resolution of current screen and create a bounding box with (0, 0, width, height) when specified search scope is desktop instead of passing null.