### PR TITLE
Copy extension to build output on build and reduce dependencies being copied everywhere.

### DIFF
--- a/src/Pixel.Automation.Core.Components/Pixel.Automation.Core.Components.csproj
+++ b/src/Pixel.Automation.Core.Components/Pixel.Automation.Core.Components.csproj
@@ -1,40 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="Properties\**" />
-    <EmbeddedResource Remove="Properties\**" />
-    <None Remove="Properties\**" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="Properties\**" />
+		<EmbeddedResource Remove="Properties\**" />
+		<None Remove="Properties\**" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Dawn.Guard" Version="1.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1">     
-      <PrivateAssets>false</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Polly" Version="7.2.3">     
-      <PrivateAssets>false</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Serilog" Version="2.11.0">     
-      <PrivateAssets>false</PrivateAssets>
-    </PackageReference>  
-  </ItemGroup>
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(AssemblyName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
-      <IncludeAssets>All</IncludeAssets>
-      <Private>false</Private>
-    </ProjectReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Dawn.Guard" Version="1.12.0" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1">
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>		
+		<PackageReference Include="Serilog" Version="2.11.0">
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Polly" Version="7.2.3" />		
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
+			<IncludeAssets>All</IncludeAssets>
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Designer.Views/Pixel.Automation.Designer.Views.csproj
+++ b/src/Pixel.Automation.Designer.Views/Pixel.Automation.Designer.Views.csproj
@@ -10,13 +10,7 @@
 	<PropertyGroup>
 		<OutputPath>..\..\.builds\$(Configuration)\Designer</OutputPath>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<None Remove="Images\OffsetPicker.png" />
-		<None Remove="Images\PrefabIcon.jpg" />
-		<None Remove="Resources\TemplateMapping.xml" />
-	</ItemGroup>
-
+	
 	<ItemGroup>
 		<Content Include="Resources\TemplateMapping.xml">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -72,5 +66,14 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
+
+
+	<Target Name="CopyExtension" AfterTargets="Build">
+		<ItemGroup>
+			<ExtensionFiles Include="..\..\src\Extensions\**\*.*"/>
+		</ItemGroup>
+		<Message Importance="high" Text="Copy extensions to $(BuildDirectory) ========="/>
+		<Copy  SourceFiles="@(ExtensionFiles)"  DestinationFolder="$(OutputPath)\Extensions\%(RecursiveDir)"/>
+	</Target>
 
 </Project>

--- a/src/Pixel.Automation.Editor.Core/Pixel.Automation.Editor.Core.csproj
+++ b/src/Pixel.Automation.Editor.Core/Pixel.Automation.Editor.Core.csproj
@@ -3,9 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
 		<TargetFramework>net6.0-windows</TargetFramework>
-		<UseWPF>true</UseWPF>
-		<ApplicationIcon />
-		<StartupObject />
+		<UseWPF>true</UseWPF>		
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -16,8 +14,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
-		<ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj" />
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
 	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Image.Matching.Components/Pixel.Automation.Image.Matching.Components.csproj
+++ b/src/Pixel.Automation.Image.Matching.Components/Pixel.Automation.Image.Matching.Components.csproj
@@ -1,18 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="OpenCvSharp4" Version="4.6.0.20220608" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.6.0.20220608" />
-    <PackageReference Include="Serilog" Version="2.11.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Serilog" Version="2.11.0" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="OpenCvSharp4" Version="4.6.0.20220608" />
+		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.6.0.20220608" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Image.Scrapper/Pixel.Automation.Image.Scrapper.csproj
+++ b/src/Pixel.Automation.Image.Scrapper/Pixel.Automation.Image.Scrapper.csproj
@@ -1,22 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <ApplicationIcon />
-    <StartupObject />
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<UseWPF>true</UseWPF>
+		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Caliburn.Micro" Version="4.0.210" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Caliburn.Micro" Version="4.0.210" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="System.Drawing.Common" Version="6.0.0" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Editor.Core\Pixel.Automation.Editor.Core.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Image.Matching.Components\Pixel.Automation.Image.Matching.Components.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Editor.Core\Pixel.Automation.Editor.Core.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Image.Matching.Components\Pixel.Automation.Image.Matching.Components.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Input.Devices/Pixel.Automation.Input.Devices.csproj
+++ b/src/Pixel.Automation.Input.Devices/Pixel.Automation.Input.Devices.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(AssemblyName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 
-  
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-  </ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.JAB.Scrapper/Pixel.Automation.JAB.Scrapper.csproj
+++ b/src/Pixel.Automation.JAB.Scrapper/Pixel.Automation.JAB.Scrapper.csproj
@@ -1,40 +1,46 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <UseWindowsForms>true</UseWindowsForms>
-    <ApplicationIcon />
-    <StartupObject />
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<UseWPF>true</UseWPF>
+		<UseWindowsForms>true</UseWindowsForms>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Caliburn.Micro" Version="4.0.210" />
-    <PackageReference Include="MouseKeyHook" Version="5.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Caliburn.Micro" Version="4.0.210" >
+				<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="MouseKeyHook" Version="5.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Editor.Core\Pixel.Automation.Editor.Core.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Java.Access.Bridge.Components\Pixel.Automation.Java.Access.Bridge.Components.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Editor.Core\Pixel.Automation.Editor.Core.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Java.Access.Bridge.Components\Pixel.Automation.Java.Access.Bridge.Components.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="Interop.UIAutomationClient">
-      <HintPath>..\Libs\Interop.UIAutomationClient.dll</HintPath>
-      <Aliases>uiaAutomationClient</Aliases>
-      <EmbedInteropTypes>false</EmbedInteropTypes>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="UIAComWrapper">
-      <HintPath>..\Libs\UIAComWrapper.dll</HintPath>
-      <Aliases>uiaComWrapper</Aliases>
-      <EmbedInteropTypes>false</EmbedInteropTypes>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="WindowsAccessBridgeInterop">
-      <HintPath>..\Libs\WindowsAccessBridgeInterop.dll</HintPath>
-    </Reference>
-  </ItemGroup>
+	<ItemGroup>
+		<Reference Include="Interop.UIAutomationClient">
+			<HintPath>..\Libs\Interop.UIAutomationClient.dll</HintPath>
+			<Aliases>uiaAutomationClient</Aliases>
+			<EmbedInteropTypes>false</EmbedInteropTypes>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UIAComWrapper">
+			<HintPath>..\Libs\UIAComWrapper.dll</HintPath>
+			<Aliases>uiaComWrapper</Aliases>
+			<EmbedInteropTypes>false</EmbedInteropTypes>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="WindowsAccessBridgeInterop">
+			<HintPath>..\Libs\WindowsAccessBridgeInterop.dll</HintPath>
+		</Reference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/Pixel.Automation.Java.Access.Bridge.Components.csproj
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/Pixel.Automation.Java.Access.Bridge.Components.csproj
@@ -1,29 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.11.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Serilog" Version="2.11.0" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="UIAComWrapper">
-      <HintPath>..\Libs\UIAComWrapper.dll</HintPath>
-      <Aliases>uiaComWrapper</Aliases>
-      <EmbedInteropTypes>false</EmbedInteropTypes>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="WindowsAccessBridgeInterop">
-      <HintPath>..\Libs\WindowsAccessBridgeInterop.dll</HintPath>
-      <EmbedInteropTypes>false</EmbedInteropTypes>
-    </Reference>
-  </ItemGroup>
+	<ItemGroup>
+		<Reference Include="UIAComWrapper">
+			<HintPath>..\Libs\UIAComWrapper.dll</HintPath>
+			<Aliases>uiaComWrapper</Aliases>
+			<EmbedInteropTypes>false</EmbedInteropTypes>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="WindowsAccessBridgeInterop">
+			<HintPath>..\Libs\WindowsAccessBridgeInterop.dll</HintPath>
+			<EmbedInteropTypes>false</EmbedInteropTypes>
+		</Reference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Native.Windows/Pixel.Automation.Native.Windows.csproj
+++ b/src/Pixel.Automation.Native.Windows/Pixel.Automation.Native.Windows.csproj
@@ -1,44 +1,46 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <UseWindowsForms>true</UseWindowsForms>
-    <ApplicationIcon />
-    <StartupObject />
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<UseWPF>true</UseWPF>
+		<UseWindowsForms>true</UseWindowsForms>		
+	</PropertyGroup>
 
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Dawn.Guard" Version="1.12.0" />
-    <PackageReference Include="InputSimulatorStandard" Version="1.0.0">
-      <Private>false</Private>
-    </PackageReference>
-    <PackageReference Include="Vanara.Core" Version="3.4.4">
-      <Private>false</Private>
-    </PackageReference>
-    <PackageReference Include="Vanara.PInvoke.Gdi32" Version="3.4.4">
-      <Private>false</Private>
-    </PackageReference>
-    <PackageReference Include="Vanara.PInvoke.Kernel32" Version="3.4.4">
-      <Private>false</Private>
-    </PackageReference>
-    <PackageReference Include="Vanara.PInvoke.Shared" Version="3.4.4">
-      <Private>false</Private>
-    </PackageReference>
-    <PackageReference Include="Vanara.PInvoke.User32" Version="3.4.4">
-      <Private>false</Private>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(AssemblyName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Dawn.Guard" Version="1.12.0" >
+			<Private>false</Private>
+		</PackageReference>
+		<PackageReference Include="InputSimulatorStandard" Version="1.0.0">
+			<Private>false</Private>
+		</PackageReference>
+		<PackageReference Include="Vanara.Core" Version="3.4.4">
+			<Private>false</Private>
+		</PackageReference>
+		<PackageReference Include="Vanara.PInvoke.Gdi32" Version="3.4.4">
+			<Private>false</Private>
+		</PackageReference>
+		<PackageReference Include="Vanara.PInvoke.Kernel32" Version="3.4.4">
+			<Private>false</Private>
+		</PackageReference>
+		<PackageReference Include="Vanara.PInvoke.Shared" Version="3.4.4">
+			<Private>false</Private>
+		</PackageReference>
+		<PackageReference Include="Vanara.PInvoke.User32" Version="3.4.4">
+			<Private>false</Private>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.RunTime/Pixel.Automation.RunTime.csproj
+++ b/src/Pixel.Automation.RunTime/Pixel.Automation.RunTime.csproj
@@ -1,30 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
-  
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="CsvHelper" Version="28.0.0" />
-    <PackageReference Include="Dawn.Guard" Version="1.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Serilog" Version="2.11.0" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>		
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-  </ItemGroup>
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(AssemblyName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Dawn.Guard" Version="1.12.0" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1">
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Serilog" Version="2.11.0">
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="AutoMapper" Version="11.0.1" />
+		<PackageReference Include="CsvHelper" Version="28.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Scripting.Components/Pixel.Automation.Scripting.Components.csproj
+++ b/src/Pixel.Automation.Scripting.Components/Pixel.Automation.Scripting.Components.csproj
@@ -1,27 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Dawn.Guard" Version="1.12.0" />
-    <PackageReference Include="Serilog" Version="2.11.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(AssemblyName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Dawn.Guard" Version="1.12.0" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Serilog" Version="2.11.0" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.UIA.Components/Pixel.Automation.UIA.Components.csproj
+++ b/src/Pixel.Automation.UIA.Components/Pixel.Automation.UIA.Components.csproj
@@ -1,42 +1,46 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <UseWindowsForms>true</UseWindowsForms>
-    <ApplicationIcon />
-    <StartupObject />
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<UseWPF>true</UseWPF>
+		<UseWindowsForms>true</UseWindowsForms>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Dawn.Guard" Version="1.12.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Dawn.Guard" Version="1.12.0" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Reference Include="Interop.UIAutomationClient">
-      <HintPath>..\Libs\Interop.UIAutomationClient.dll</HintPath>
-      <EmbedInteropTypes>false</EmbedInteropTypes>
-      <Aliases>uiaAutomationClient</Aliases>
-      <Private>true</Private>
-    </Reference>
-    <Reference Include="UIAComWrapper">
-      <HintPath>..\Libs\UIAComWrapper.dll</HintPath>
-      <EmbedInteropTypes>false</EmbedInteropTypes>
-      <Aliases>uiaComWrapper</Aliases>
-      <Private>true</Private>
-    </Reference>
-  </ItemGroup>
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(AssemblyName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
+	<ItemGroup>
+		<Reference Include="Interop.UIAutomationClient">
+			<HintPath>..\Libs\Interop.UIAutomationClient.dll</HintPath>
+			<EmbedInteropTypes>false</EmbedInteropTypes>
+			<Aliases>uiaAutomationClient</Aliases>
+			<Private>true</Private>
+		</Reference>
+		<Reference Include="UIAComWrapper">
+			<HintPath>..\Libs\UIAComWrapper.dll</HintPath>
+			<EmbedInteropTypes>false</EmbedInteropTypes>
+			<Aliases>uiaComWrapper</Aliases>
+			<Private>true</Private>
+		</Reference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.UIA.Scrapper/Pixel.Automation.UIA.Scrapper.csproj
+++ b/src/Pixel.Automation.UIA.Scrapper/Pixel.Automation.UIA.Scrapper.csproj
@@ -1,35 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <ApplicationIcon />
-    <StartupObject />
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Caliburn.Micro" Version="4.0.210" />
-    <PackageReference Include="MouseKeyHook" Version="5.6.0" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Editor.Core\Pixel.Automation.Editor.Core.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.UIA.Components\Pixel.Automation.UIA.Components.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Reference Include="Interop.UIAutomationClient">
-      <HintPath>..\Libs\Interop.UIAutomationClient.dll</HintPath>
-      <EmbedInteropTypes>false</EmbedInteropTypes>
-      <Aliases>uiaAutomationClient</Aliases>
-    </Reference>
-    <Reference Include="UIAComWrapper">
-      <HintPath>..\Libs\UIAComWrapper.dll</HintPath>
-      <EmbedInteropTypes>false</EmbedInteropTypes>
-      <Aliases>uiaComWrapper</Aliases>
-    </Reference>
-  </ItemGroup>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<UseWPF>true</UseWPF>
+		<ApplicationIcon />
+		<StartupObject />
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Caliburn.Micro" Version="4.0.210" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="MouseKeyHook" Version="5.6.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Editor.Core\Pixel.Automation.Editor.Core.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.UIA.Components\Pixel.Automation.UIA.Components.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<Reference Include="Interop.UIAutomationClient">
+			<HintPath>..\Libs\Interop.UIAutomationClient.dll</HintPath>
+			<EmbedInteropTypes>false</EmbedInteropTypes>
+			<Aliases>uiaAutomationClient</Aliases>
+		</Reference>
+		<Reference Include="UIAComWrapper">
+			<HintPath>..\Libs\UIAComWrapper.dll</HintPath>
+			<EmbedInteropTypes>false</EmbedInteropTypes>
+			<Aliases>uiaComWrapper</Aliases>
+		</Reference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Web.Common/Pixel.Automation.Web.Common.csproj
+++ b/src/Pixel.Automation.Web.Common/Pixel.Automation.Web.Common.csproj
@@ -1,13 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Web.Playwright.Components/Pixel.Automation.Web.Playwright.Components.csproj
+++ b/src/Pixel.Automation.Web.Playwright.Components/Pixel.Automation.Web.Playwright.Components.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
@@ -7,6 +7,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Dawn.Guard" Version="1.12.0" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>	
+		<PackageReference Include="Serilog" Version="2.11.0">
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Microsoft.Playwright" Version="1.23.0" />
 	</ItemGroup>
 
@@ -17,7 +23,9 @@
 		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
 			<Private>false</Private>
 		</ProjectReference>
-		<ProjectReference Include="..\Pixel.Automation.Web.Common\Pixel.Automation.Web.Common.csproj" />
+		<ProjectReference Include="..\Pixel.Automation.Web.Common\Pixel.Automation.Web.Common.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
 	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Web.Scrapper/Pixel.Automation.Web.Scrapper.csproj
+++ b/src/Pixel.Automation.Web.Scrapper/Pixel.Automation.Web.Scrapper.csproj
@@ -1,31 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-	<TargetFramework>net6.0-windows</TargetFramework>	
-    <ApplicationIcon />
-    <OutputType>Library</OutputType>
-    <StartupObject />
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0-windows</TargetFramework>	
+		<OutputType>Library</OutputType>		
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Caliburn.Micro" Version="4.0.210">
-      <IncludeAssets>compile</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Playwright" Version="1.23.0" />   
-    <PackageReference Include="Serilog" Version="2.11.0">
-      <IncludeAssets>compile</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-	
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\Pixel.Automation.Editor.Core\Pixel.Automation.Editor.Core.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Web.Common\Pixel.Automation.Web.Common.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Web.Selenium.Components\Pixel.Automation.Web.Selenium.Components.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Caliburn.Micro" Version="4.0.210">
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Serilog" Version="2.11.0">
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Playwright" Version="1.23.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Editor.Core\Pixel.Automation.Editor.Core.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Web.Common\Pixel.Automation.Web.Common.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Web.Selenium.Components/Pixel.Automation.Web.Selenium.Components.csproj
+++ b/src/Pixel.Automation.Web.Selenium.Components/Pixel.Automation.Web.Selenium.Components.csproj
@@ -1,40 +1,48 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
 
-    <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(AssemblyName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 
-      
-  <ItemGroup>
-    <PackageReference Include="Dawn.Guard" Version="1.12.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0">
-      <IncludeAssets>compile</IncludeAssets>      
-    </PackageReference>
-    <PackageReference Include="Selenium.Support" Version="4.3.0">     
-    </PackageReference>
-    <PackageReference Include="Selenium.WebDriver" Version="4.3.0">      
-    </PackageReference>
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0">
-      <IncludeAssets>compile</IncludeAssets>      
-    </PackageReference>
-    <PackageReference Include="System.Management" Version="6.0.0" />   
-  </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\Pixel.Automation.Web.Common\Pixel.Automation.Web.Common.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Dawn.Guard" Version="1.12.0" >
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1">
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>	
+		<PackageReference Include="Serilog" Version="2.11.0">
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0">
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="System.Dynamic.Runtime" Version="4.3.0">
+			<IncludeAssets>compile</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Selenium.Support" Version="4.3.0" />	
+		<PackageReference Include="Selenium.WebDriver" Version="4.3.0" />		
+		<PackageReference Include="System.Management" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj">
+			<Private>false</Private>
+		</ProjectReference>		
+		<ProjectReference Include="..\Pixel.Automation.Web.Common\Pixel.Automation.Web.Common.csproj" >
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Automation.Window.Management/Pixel.Automation.Window.Management.csproj
+++ b/src/Pixel.Automation.Window.Management/Pixel.Automation.Window.Management.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>   
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
 
 
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-  </ItemGroup>
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(AssemblyName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>

--- a/src/Pixel.Scripting.Script.Editor/Pixel.Scripting.Script.Editor.csproj
+++ b/src/Pixel.Scripting.Script.Editor/Pixel.Scripting.Script.Editor.csproj
@@ -1,28 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <ApplicationIcon />
-    <StartupObject />     
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<UseWPF>true</UseWPF>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AvalonEdit" Version="6.1.3.50">      
-    </PackageReference>
-    <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />
-    <PackageReference Include="System.Reactive" Version="5.0.0">    
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="AvalonEdit" Version="6.1.3.50">
+		</PackageReference>
+		<PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />
+		<PackageReference Include="System.Reactive" Version="5.0.0">
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">     
-    </ProjectReference>
-    <ProjectReference Include="..\Pixel.Automation.Editor.Controls\Pixel.Automation.Editor.Controls.csproj" />
-    <ProjectReference Include="..\Pixel.Automation.Editor.Core\Pixel.Automation.Editor.Core.csproj">      
-    </ProjectReference>
-    <ProjectReference Include="..\Xceed.Wpf.AvalonDock.Themes.MahApps\Xceed.Wpf.AvalonDock.Themes.MahApps.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
+		<ProjectReference Include="..\Pixel.Automation.Editor.Core\Pixel.Automation.Editor.Core.csproj" />
+		<ProjectReference Include="..\Pixel.Automation.Editor.Controls\Pixel.Automation.Editor.Controls.csproj" />
+		<ProjectReference Include="..\Xceed.Wpf.AvalonDock.Themes.MahApps\Xceed.Wpf.AvalonDock.Themes.MahApps.csproj" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
**Description**
1. Copy chrome extension for browser scraping to build output when the project is built.
2. Lot's of assemblies are copied to bin folder of individual projects. Removed these additional assemblies from being copied everywhere to improve build time.