### PR TITLE
Allowed Modes for Argument for better control

### DIFF
--- a/src/Pixel.Automation.Core.Components/Entities/ControlEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Entities/ControlEntity.cs
@@ -39,6 +39,7 @@ namespace Pixel.Automation.Core.Components
         [Browsable(true)]
         public virtual Argument SearchRoot { get; set; } = new InArgument<UIControl>()
         {
+            AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted,
             Mode = ArgumentMode.DataBound,
             CanChangeType = false
         };
@@ -107,11 +108,20 @@ namespace Pixel.Automation.Core.Components
         [Description("Bind to current Iteration when used inside loop")]
         public Argument Index { get; set; } = new InArgument<int>() { DefaultValue = 0, CanChangeType = false, Mode = ArgumentMode.Default };
 
+        private Argument filter;
         [DataMember]
         [Browsable(false)]
         [Display(Name = "Filter Script", GroupName = "Search Strategy", Order = 40)]
         [Description("When using FindAll LookupMode, provide a script to Filter the result")]
-        public virtual Argument Filter { get; set; }
+        public virtual Argument Filter
+        {
+            get => filter;
+            set
+            {
+                filter = value;
+                OnPropertyChanged();
+            }
+        }
 
         [DataMember]
         [Display(Name = "Enable Caching", GroupName = "Caching", Order = 50,

--- a/src/Pixel.Automation.Core.Components/Loops/ForEachLoopEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Loops/ForEachLoopEntity.cs
@@ -36,7 +36,7 @@ namespace Pixel.Automation.Core.Components.Loops
             }
         }
 
-        private Argument targetCollection = new InArgument<IEnumerable<object>>() { Mode = ArgumentMode.DataBound, CanChangeType = true, CanChangeMode = true };
+        private Argument targetCollection = new InArgument<IEnumerable<object>>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted , Mode = ArgumentMode.DataBound, CanChangeType = true };
         [DataMember]       
         [Description("Target collection which needs to be looped over all its items")]
         [Display(Name = "Collection", GroupName = "Input", Order = 20)]
@@ -50,7 +50,7 @@ namespace Pixel.Automation.Core.Components.Loops
             }
         }
 
-        private Argument current = new OutArgument<object>() { Mode = ArgumentMode.DataBound, CanChangeType = true, CanChangeMode = false };
+        private Argument current = new OutArgument<object>() { Mode = ArgumentMode.DataBound, CanChangeType = true };
         [DataMember]            
         [Description("Current object being iterated")]
         [Display(Name = "Item", GroupName = "Input", Order = 10)]

--- a/src/Pixel.Automation.Core.Components/Sequences/TryCatchSequence.cs
+++ b/src/Pixel.Automation.Core.Components/Sequences/TryCatchSequence.cs
@@ -23,7 +23,7 @@ namespace Pixel.Automation.Core.Components.Sequences
         [DataMember]
         [Display(Name = "Exception", GroupName = "Exception  Handling", Order = 10)]
         [Description("Exception encountered during processing of try block")]
-        public Argument Exception { get; set; } = new OutArgument<Exception>() { CanChangeType = false, Mode = ArgumentMode.DataBound, CanChangeMode = false };
+        public Argument Exception { get; set; } = new OutArgument<Exception>() { CanChangeType = false, Mode = ArgumentMode.DataBound};
 
         public TryCatchSequence() : base("Try Catch", "TryCatchSequence")
         {

--- a/src/Pixel.Automation.Core/Arguments/InArgument.cs
+++ b/src/Pixel.Automation.Core/Arguments/InArgument.cs
@@ -18,8 +18,8 @@ namespace Pixel.Automation.Core.Arguments
     public class InArgument<T> : Argument, IDefaultValueProvider<T>
     {
 
-        T defaultValue;
-        [DataMember(IsRequired = false)]
+        T defaultValue = default(T);
+        [DataMember(IsRequired = false, Order = 30)]
         /// <summary>
         /// Default value of the argument
         /// </summary>
@@ -56,7 +56,7 @@ namespace Pixel.Automation.Core.Arguments
         /// </summary>
         public InArgument()
         {
-            this.Mode = ArgumentMode.Default;
+           
         }
 
         /// <summary>
@@ -87,9 +87,9 @@ namespace Pixel.Automation.Core.Arguments
             InArgument<T> clone = new InArgument<T>()
             {
                 Mode = this.Mode,
+                AllowedModes = this.AllowedModes,
                 DefaultValue = this.DefaultValue,
-                PropertyPath = this.PropertyPath,
-                CanChangeMode = this.CanChangeMode,
+                PropertyPath = this.PropertyPath,               
                 CanChangeType = this.CanChangeType,
                 ScriptFile = this.ScriptFile
             };

--- a/src/Pixel.Automation.Core/Arguments/OutArgument.cs
+++ b/src/Pixel.Automation.Core/Arguments/OutArgument.cs
@@ -16,6 +16,7 @@ namespace Pixel.Automation.Core.Arguments
         /// </summary>
         public OutArgument()
         {
+            this.AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted;
             this.Mode = ArgumentMode.DataBound;
         }
        
@@ -31,8 +32,8 @@ namespace Pixel.Automation.Core.Arguments
             OutArgument<T> clone = new OutArgument<T>()
             {
                 Mode = this.Mode,
-                PropertyPath = this.PropertyPath,              
-                CanChangeMode = this.CanChangeMode,
+                AllowedModes = this.AllowedModes,
+                PropertyPath = this.PropertyPath,                     
                 CanChangeType = this.CanChangeType,
                 ScriptFile = this.ScriptFile
             };

--- a/src/Pixel.Automation.Core/Arguments/PredicateArgument.cs
+++ b/src/Pixel.Automation.Core/Arguments/PredicateArgument.cs
@@ -17,9 +17,9 @@ namespace Pixel.Automation.Core.Arguments
         /// </summary>
         public PredicateArgument()
         {
-            this.Mode = ArgumentMode.Scripted;
-            this.CanChangeType = true;
-            this.CanChangeMode = false;
+            this.AllowedModes = ArgumentMode.Scripted;
+            this.Mode = ArgumentMode.Scripted;         
+            this.CanChangeType = false;            
         }
 
         /// <inheritdoc/>
@@ -34,7 +34,7 @@ namespace Pixel.Automation.Core.Arguments
             PredicateArgument<T> clone = new PredicateArgument<T>()
             {
                 Mode = this.Mode,            
-                CanChangeMode = this.CanChangeMode,
+                AllowedModes = this.AllowedModes,
                 CanChangeType = this.CanChangeType,
                 ScriptFile = this.ScriptFile
             };

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/ArgumentEditor.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/ArgumentEditor.cs
@@ -3,7 +3,6 @@ using Microsoft.Win32;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Arguments;
 using Pixel.Automation.Core.Interfaces;
-using Pixel.Automation.Editor.Core.Helpers;
 using Pixel.Automation.Editor.Core.Interfaces;
 using Pixel.Scripting.Editor.Core.Contracts;
 using Serilog;
@@ -162,7 +161,7 @@ namespace Pixel.Automation.Editor.Controls.Arguments
         public async void ChangeArgumentType(object sender, RoutedEventArgs e)
         {
             //Using outside automation process such as Application in ApplicationRepository
-            if (this.OwnerComponent?.EntityManager == null)
+            if (this.OwnerComponent?.EntityManager == null || !this.Argument.CanChangeType)
             {
                 return;
             }
@@ -181,8 +180,7 @@ namespace Pixel.Automation.Editor.Controls.Arguments
                 if (this.Argument.GetType().Name.StartsWith("OutArgument"))
                 {
                     Argument typedArgumentInstance = typeBrowserWindow.CreateOutArgumentForSelectedType();
-                    typedArgumentInstance.Mode = this.Argument.Mode;
-                    typedArgumentInstance.CanChangeMode = this.Argument.CanChangeMode;
+                    typedArgumentInstance.Mode = this.Argument.Mode;              
                     typedArgumentInstance.CanChangeType = this.Argument.CanChangeType;
                     this.Argument = typedArgumentInstance;
                 }
@@ -191,7 +189,6 @@ namespace Pixel.Automation.Editor.Controls.Arguments
                 {
                     Argument typedArgumentInstance = typeBrowserWindow.CreateInArgumentForSelectedType();
                     typedArgumentInstance.Mode = this.Argument.Mode;
-                    typedArgumentInstance.CanChangeMode = this.Argument.CanChangeMode;
                     typedArgumentInstance.CanChangeType = this.Argument.CanChangeType;
                     this.Argument = typedArgumentInstance;
                 }

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/InArgumentEditor.xaml.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/InArgumentEditor.xaml.cs
@@ -37,7 +37,7 @@ namespace Pixel.Automation.Editor.Controls.Arguments
 
         public void ChangeArgumentMode(object sender, RoutedEventArgs e)
         {
-            if (this.OwnerComponent?.EntityManager == null)
+            if (this.OwnerComponent?.EntityManager == null || !this.Argument.CanChangeMode)
             {
                 return;
             }
@@ -45,15 +45,38 @@ namespace Pixel.Automation.Editor.Controls.Arguments
             switch (this.Argument.Mode)
             {
                 case ArgumentMode.Default:
-                    this.Argument.Mode = ArgumentMode.DataBound;
-                    LoadAvailableProperties();
+                    if(this.Argument.AllowedModes.HasFlag(ArgumentMode.DataBound))
+                    {
+                        this.Argument.Mode = ArgumentMode.DataBound;
+                        LoadAvailableProperties();
+                    }
+                    else if(this.Argument.AllowedModes.HasFlag(ArgumentMode.Scripted))
+                    {
+                        this.Argument.Mode = ArgumentMode.Scripted;
+                        InitializeScriptName();
+                    }
                     break;
                 case ArgumentMode.DataBound:
-                    this.Argument.Mode = ArgumentMode.Scripted;
-                    InitializeScriptName();
+                    if(this.Argument.AllowedModes.HasFlag(ArgumentMode.Scripted))
+                    {
+                        this.Argument.Mode = ArgumentMode.Scripted;
+                        InitializeScriptName();
+                    }
+                    else if (this.Argument.AllowedModes.HasFlag(ArgumentMode.Default))
+                    {
+                        this.Argument.Mode = ArgumentMode.Default;
+                    }
                     break;
                 case ArgumentMode.Scripted:
-                    this.Argument.Mode = ArgumentMode.Default;
+                    if (this.Argument.AllowedModes.HasFlag(ArgumentMode.Default))
+                    {
+                        this.Argument.Mode = ArgumentMode.Default;
+                    }
+                    else if (this.Argument.AllowedModes.HasFlag(ArgumentMode.DataBound))
+                    {
+                        this.Argument.Mode = ArgumentMode.DataBound;
+                        LoadAvailableProperties();
+                    }
                     break;
             }
         }

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/OutArgumentEditor.xaml.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/OutArgumentEditor.xaml.cs
@@ -37,16 +37,16 @@ namespace Pixel.Automation.Editor.Controls.Arguments
 
         public void ChangeArgumentMode(object sender, RoutedEventArgs e)
         {
-            if (this.OwnerComponent?.EntityManager == null)
+            if (this.OwnerComponent?.EntityManager == null || !this.Argument.CanChangeMode)
             {
                 return;
             }
-            if (this.Argument.Mode == ArgumentMode.DataBound)
+            if (this.Argument.Mode == ArgumentMode.DataBound && this.Argument.AllowedModes.HasFlag(ArgumentMode.Scripted))
             {
                 this.Argument.Mode = ArgumentMode.Scripted;
                 InitializeScriptName();
             }
-            else if (this.Argument.Mode == ArgumentMode.Scripted)
+            else if (this.Argument.Mode == ArgumentMode.Scripted && this.Argument.AllowedModes.HasFlag(ArgumentMode.DataBound))
             {                
                 this.Argument.Mode = ArgumentMode.DataBound;
                 LoadAvailableProperties();

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/ArgumentUserControl.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/ArgumentUserControl.cs
@@ -115,7 +115,7 @@ namespace Pixel.Automation.Editor.Controls.Arguments
         public async void ChangeArgumentType(object sender, RoutedEventArgs e)
         {
             //Using outside automation process such as Application in ApplicationRepository
-            if (this.OwnerComponent?.EntityManager == null)
+            if (this.OwnerComponent?.EntityManager == null || !this.Argument.CanChangeType)
             {
                 return;
             }
@@ -134,8 +134,7 @@ namespace Pixel.Automation.Editor.Controls.Arguments
                 if (this.Argument.GetType().Name.StartsWith("OutArgument"))
                 {
                     Argument typedArgumentInstance = typeBrowserWindow.CreateOutArgumentForSelectedType();
-                    typedArgumentInstance.Mode = this.Argument.Mode;
-                    typedArgumentInstance.CanChangeMode = this.Argument.CanChangeMode;
+                    typedArgumentInstance.Mode = this.Argument.Mode;                   
                     typedArgumentInstance.CanChangeType = this.Argument.CanChangeType;
                     this.Argument = typedArgumentInstance;
                 }
@@ -143,13 +142,11 @@ namespace Pixel.Automation.Editor.Controls.Arguments
                 if (this.Argument.GetType().Name.StartsWith("InArgument"))
                 {
                     Argument typedArgumentInstance = typeBrowserWindow.CreateInArgumentForSelectedType();
-                    typedArgumentInstance.Mode = this.Argument.Mode;
-                    typedArgumentInstance.CanChangeMode = this.Argument.CanChangeMode;
+                    typedArgumentInstance.Mode = this.Argument.Mode;                   
                     typedArgumentInstance.CanChangeType = this.Argument.CanChangeType;
                     this.Argument = typedArgumentInstance;
                 }               
             }
-
         }
 
         /// <summary>

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/InArgumentUserControl.xaml.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/InArgumentUserControl.xaml.cs
@@ -29,26 +29,49 @@ namespace Pixel.Automation.Editor.Controls.Arguments
 
         public void ChangeArgumentMode(object sender, RoutedEventArgs e)
         {
-            if (this.OwnerComponent?.EntityManager == null)
+            if (this.OwnerComponent?.EntityManager == null || !this.Argument.CanChangeMode)
+            {
                 return;
-
+            }
+            //Set argument mode to next mode based on current mode i.e. rotate from Default -> DataBound -> Scripted -> Default....
             switch (this.Argument.Mode)
             {
                 case ArgumentMode.Default:
-                    this.Argument.Mode = ArgumentMode.DataBound;
-                    LoadAvailableProperties();
+                    if (this.Argument.AllowedModes.HasFlag(ArgumentMode.DataBound))
+                    {
+                        this.Argument.Mode = ArgumentMode.DataBound;
+                        LoadAvailableProperties();
+                    }
+                    else if (this.Argument.AllowedModes.HasFlag(ArgumentMode.Scripted))
+                    {
+                        this.Argument.Mode = ArgumentMode.Scripted;
+                        InitializeScriptName();
+                    }
                     break;
                 case ArgumentMode.DataBound:
-                    this.Argument.Mode = ArgumentMode.Scripted;
-                    InitializeScriptName();
+                    if (this.Argument.AllowedModes.HasFlag(ArgumentMode.Scripted))
+                    {
+                        this.Argument.Mode = ArgumentMode.Scripted;
+                        InitializeScriptName();
+                    }
+                    else if (this.Argument.AllowedModes.HasFlag(ArgumentMode.Default))
+                    {
+                        this.Argument.Mode = ArgumentMode.Default;
+                    }
                     break;
-                case ArgumentMode.Scripted:                   
-                    this.Argument.Mode = ArgumentMode.Default;
+                case ArgumentMode.Scripted:
+                    if (this.Argument.AllowedModes.HasFlag(ArgumentMode.Default))
+                    {
+                        this.Argument.Mode = ArgumentMode.Default;
+                    }
+                    else if (this.Argument.AllowedModes.HasFlag(ArgumentMode.DataBound))
+                    {
+                        this.Argument.Mode = ArgumentMode.DataBound;
+                        LoadAvailableProperties();
+                    }
                     break;
-            }            
-
+            }
         }
-
-      
+        
     }
 }

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/OutArgumentUserControl.xaml.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/OutArgumentUserControl.xaml.cs
@@ -25,21 +25,20 @@ namespace Pixel.Automation.Editor.Controls.Arguments
 
         public void ChangeArgumentMode(object sender, RoutedEventArgs e)
         {
-            if (this.OwnerComponent?.EntityManager == null)
+            if (this.OwnerComponent?.EntityManager == null || !this.Argument.CanChangeMode)
             {
                 return;
             }
-            if (this.Argument.Mode == ArgumentMode.DataBound)
+            if (this.Argument.Mode == ArgumentMode.DataBound && this.Argument.AllowedModes.HasFlag(ArgumentMode.Scripted))
             {
                 this.Argument.Mode = ArgumentMode.Scripted;
                 InitializeScriptName();
             }
-            else if (this.Argument.Mode == ArgumentMode.Scripted)
-            {                        
+            else if (this.Argument.Mode == ArgumentMode.Scripted && this.Argument.AllowedModes.HasFlag(ArgumentMode.DataBound))
+            {
                 this.Argument.Mode = ArgumentMode.DataBound;
                 LoadAvailableProperties();
             }
-
         }        
 
     }

--- a/src/Pixel.Automation.Image.Matching.Components/ImageControlEntity.cs
+++ b/src/Pixel.Automation.Image.Matching.Components/ImageControlEntity.cs
@@ -76,7 +76,7 @@ public class ImageControlEntity : ControlEntity
     [DataMember]
     [Display(Name = "Target window", GroupName = "Search Strategy", Order = 10)]    
     [Description("Target application window within which image lookup will be restricted")]     
-    public Argument TargetWindow { get; set; } = new InArgument<ApplicationWindow>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+    public Argument TargetWindow { get; set; } = new InArgument<ApplicationWindow>() { Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// A custom bounding box can be provided when search scope is set to custom. Image lookup is constrained within this bounding box.
@@ -84,14 +84,14 @@ public class ImageControlEntity : ControlEntity
     [DataMember]
     [Display(Name = "Area on screen", GroupName = "Search Strategy", Order = 15)]
     [Description("Target window within which image lookup will be restricted")]    
-    public Argument AreaOnScreen { get; set; } = new InArgument<BoundingBox>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+    public Argument AreaOnScreen { get; set; } = new InArgument<BoundingBox>() { Mode = ArgumentMode.DataBound };
 
     ///<inheritdoc/>
     protected override void InitializeFilter()
     {
         if (this.Filter == null)
         {
-            this.Filter = new PredicateArgument<BoundingBox>() { CanChangeMode = false, CanChangeType = false };
+            this.Filter = new PredicateArgument<BoundingBox>() { CanChangeType = false };
         }
     }
 

--- a/src/Pixel.Automation.Image.Matching.Components/ImageControlLocatorComponent.cs
+++ b/src/Pixel.Automation.Image.Matching.Components/ImageControlLocatorComponent.cs
@@ -102,7 +102,7 @@ public class ImageControlLocatorComponent : ServiceComponent, IControlLocator, I
     /// Set the theme used by the application. Target image will be retrieved based on the matching theme.
     /// </summary>
     [DataMember]
-    public Argument Theme { get; set; } = new InArgument<string>() { CanChangeType = false, CanChangeMode = true, DefaultValue = string.Empty, Mode = ArgumentMode.DataBound };
+    public Argument Theme { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound, DefaultValue = string.Empty };
 
     [NonSerialized]
     private AsyncRetryPolicy policy;

--- a/src/Pixel.Automation.Input.Devices.Components/Mouse/DragDropActorComponent.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/Mouse/DragDropActorComponent.cs
@@ -75,14 +75,14 @@ namespace Pixel.Automation.Input.Devices.Components
         /// </summary>
         [DataMember]
         [Display(Name = "Drag Source", GroupName = "Control Details", Order = 30, Description = "Control to drag")]
-        public Argument SourceControl { get; set; } = new InArgument<UIControl>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+        public Argument SourceControl { get; set; } = new InArgument<UIControl>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
         /// <summary>
         /// Drop target control
         /// </summary>
         [DataMember]
         [Display(Name = "Drop Target", GroupName = "Control Details", Order = 40, Description = "Target control to drop to")]
-        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Pixel.Automation.Input.Devices.Components
         /// </summary>
         [DataMember]
         [Display(Name = "Drag Start", GroupName = "Point", Order = 50, Description = "Represents the coordinates which acts as drag start point")]     
-        public Argument DragStartPoint { get; set; } = new InArgument<ScreenCoordinate>() { DefaultValue = new ScreenCoordinate(0, 0), CanChangeType = false };
+        public Argument DragStartPoint { get; set; } = new InArgument<ScreenCoordinate>() { DefaultValue = new ScreenCoordinate(0, 0) };
 
         /// <summary>
         /// Drop point co-ordinates

--- a/src/Pixel.Automation.Input.Devices.Components/Mouse/MouseClickActorComponent.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/Mouse/MouseClickActorComponent.cs
@@ -84,7 +84,7 @@ namespace Pixel.Automation.Input.Devices.Components
         /// </summary>
         [DataMember]
         [Display(Name = "Target Control", GroupName = "Control Details", Order = 50, Description = "[Optional] Target control that needs to be clicked.")]  
-        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
         /// <summary>
         /// MouseClickActorComponent can be used to click at an arbitrary co-ordinates instead of a target control. Click At argument can be used to spcify an arbitrary co-ordinates
@@ -92,7 +92,7 @@ namespace Pixel.Automation.Input.Devices.Components
         /// </summary>
         [DataMember]
         [Display(Name = "Click At", GroupName = "Point", Order = 50, Description = "[Optional] Co-ordinates at which click needs to be performed if there is no target control.")]
-        public Argument ClickAt { get; set; } = new InArgument<ScreenCoordinate>() { DefaultValue = new ScreenCoordinate(), CanChangeType = false };
+        public Argument ClickAt { get; set; } = new InArgument<ScreenCoordinate>() { DefaultValue = new ScreenCoordinate()};
 
         /// <summary>
         /// Default constructor

--- a/src/Pixel.Automation.Input.Devices.Components/Mouse/MouseOverActorComponent.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/Mouse/MouseOverActorComponent.cs
@@ -64,14 +64,14 @@ namespace Pixel.Automation.Input.Devices.Components
         /// </summary>
         [DataMember]
         [Display(Name = "Target Control", GroupName = "Control Details", Order = 30, Description = "[Optional] Target control where cursor needs to be moved.")]
-        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
         /// <summary>
         /// An arbitrary co-ordinates where the cursor position should be moved.
         /// </summary>
         [DataMember]
         [Display(Name = "Move To", GroupName = "Point", Order = 40, Description = "[Optional] Arbitrary co-ordinates where mouse cursor should be moved to.")]
-        public Argument MoveTo { get; set; } = new InArgument<ScreenCoordinate>() { DefaultValue = new ScreenCoordinate(100, 100), CanChangeType = false };
+        public Argument MoveTo { get; set; } = new InArgument<ScreenCoordinate>() { DefaultValue = new ScreenCoordinate(100, 100) };
 
         /// <summary>
         /// Default constructor

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/JABActorComponent.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/JABActorComponent.cs
@@ -25,7 +25,7 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
         /// </summary>
         [DataMember]
         [Display(Name = "Target Control", GroupName = "Control Details", Order = 10, Description = "[Optional] Specify a JavaUIControl to be interacted with.")]
-        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
               
         /// <summary>
         /// Parent Control entity component if any

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/JavaControlEntity.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/JavaControlEntity.cs
@@ -20,7 +20,7 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
         {
             if (this.Filter == null)
             {
-                this.Filter = new PredicateArgument<AccessibleContextNode>() { CanChangeMode = false, CanChangeType = false };
+                this.Filter = new PredicateArgument<AccessibleContextNode>();
             }
         }
 

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/MoveActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/MoveActorComponent.cs
@@ -27,7 +27,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         /// </summary>
         [DataMember]
         [Display(Name = "Position", GroupName = "Configuration", Order = 10, Description = "New position co-ordinates of the control")]
-        public Argument Position { get; set; } = new InArgument<ScreenCoordinate>() { CanChangeMode = true, CanChangeType = false, DefaultValue = new ScreenCoordinate(), Mode = ArgumentMode.Default };
+        public Argument Position { get; set; } = new InArgument<ScreenCoordinate>() { Mode = ArgumentMode.Default, DefaultValue = new ScreenCoordinate()};
 
        /// <summary>
        /// Default constructor

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/ResizeActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/ResizeActorComponent.cs
@@ -26,14 +26,14 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         /// </summary>
         [DataMember]
         [Display(Name = "Width", GroupName = "Configuration", Order = 10, Description = "New value of width")]
-        public Argument Width { get; set; } = new InArgument<double>() { CanChangeMode = true, CanChangeType = false, DefaultValue = 0.0, Mode = ArgumentMode.Default };
+        public Argument Width { get; set; } = new InArgument<double>() { Mode = ArgumentMode.Default,  DefaultValue = 0.0 };
 
         /// <summary>
         /// New value of the height
         /// </summary>
         [DataMember]
         [Display(Name = "Height", GroupName = "Configuration", Order = 20, Description = "New value of height")]
-        public Argument Height { get; set; } = new InArgument<double>() { CanChangeMode = true, CanChangeType = false, DefaultValue = 0.0, Mode = ArgumentMode.Default };
+        public Argument Height { get; set; } = new InArgument<double>() { Mode = ArgumentMode.Default, DefaultValue = 0.0};
 
         /// <summary>
         /// Default constructor

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/RotateActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/RotateActorComponent.cs
@@ -27,7 +27,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         [DataMember]
         [Display(Name = "Rotate By", GroupName = "Configuration", Order = 10, Description = "The number of degrees to rotate the element." +
             "A positive number rotates clockwise; a negative number rotates counterclockwise.")]
-        public Argument RotateBy { get; set; } = new InArgument<double>() { CanChangeMode = true, CanChangeType = false, DefaultValue = 0.0, Mode = ArgumentMode.Default };
+        public Argument RotateBy { get; set; } = new InArgument<double>() { CanChangeType = false, DefaultValue = 0.0, Mode = ArgumentMode.Default };
 
         /// <summary>
         /// Default constructor

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/UIAActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/UIAActorComponent.cs
@@ -27,7 +27,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         /// </summary>
         [DataMember]
         [Display(Name ="Target Control", GroupName = "Control Details", Order = 10, Description = "[Optional] Target control that needs to be interacted with")]         
-        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
         
         /// <summary>

--- a/src/Pixel.Automation.UIA.Components/WinControlEntity.cs
+++ b/src/Pixel.Automation.UIA.Components/WinControlEntity.cs
@@ -21,7 +21,7 @@ namespace Pixel.Automation.UIA.Components
         {
             if (this.Filter == null)
             {
-                this.Filter = new PredicateArgument<AutomationElement>() { CanChangeMode = false, CanChangeType = false };
+                this.Filter = new PredicateArgument<AutomationElement>();
             }
         }
 

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/CheckActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/CheckActorComponent.cs
@@ -23,7 +23,7 @@ public class CheckActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Check Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorCheckOptions")]
-    public Argument CheckOptions { get; set; } = new InArgument<LocatorCheckOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument CheckOptions { get; set; } = new InArgument<LocatorCheckOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
    
     /// <summary>

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/ClickActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/ClickActorComponent.cs
@@ -22,7 +22,7 @@ public class ClickActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Click Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorClickOptions")]
-    public Argument ClickOptions { get; set; } = new InArgument<LocatorClickOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument ClickOptions { get; set; } = new InArgument<LocatorClickOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Constructor

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/DispatchEventAggregator.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/DispatchEventAggregator.cs
@@ -23,7 +23,7 @@ public class DispatchEventActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "DispatchEvent", GroupName = "Configuration", Order = 10, Description = "event to dispatch")]
-    public Argument DispatchEvent { get; set; } = new InArgument<string>() { CanChangeType = false, Mode = ArgumentMode.Default, DefaultValue = String.Empty };
+    public Argument DispatchEvent { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default, DefaultValue = String.Empty };
 
 
     /// <summary>
@@ -31,7 +31,7 @@ public class DispatchEventActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Dispatch Event Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorDispatchEventOptions")]
-    public Argument DispatchEventOptions { get; set; } = new InArgument<LocatorDispatchEventOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument DispatchEventOptions { get; set; } = new InArgument<LocatorDispatchEventOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Constructor

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/DoubleClickActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/DoubleClickActorComponent.cs
@@ -23,7 +23,7 @@ public class DoubleClickActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Double Click Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorDblClickOptions")]
-    public Argument DblClickOptions { get; set; } = new InArgument<LocatorDblClickOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument DblClickOptions { get; set; } = new InArgument<LocatorDblClickOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Constructor

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/DragToActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/DragToActorComponent.cs
@@ -22,14 +22,14 @@ public class DragToActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Target", GroupName = "Configuration", Order = 10, Description = "Input argument for drop target locator")]
-    public Argument Target { get; set; } = new InArgument<ILocator>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument Target { get; set; } = new InArgument<ILocator>() {  Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Optional input argument for <see cref="LocatorDragToOptions"/> that can be used to customize the drag operation
     /// </summary>
     [DataMember]
     [Display(Name = "Drag To Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorDragToOptions")]
-    public Argument DragToOptions { get; set; } = new InArgument<LocatorDragToOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument DragToOptions { get; set; } = new InArgument<LocatorDragToOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Constructor

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/EvaluateScriptActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/EvaluateScriptActorComponent.cs
@@ -21,14 +21,14 @@ public class EvaluateScriptActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "JavaScript", GroupName = "Configuration", Order = 10, Description = "Input argument to provide javascript to be evaluated.")]     
-    public Argument Script { get; set; } = new InArgument<string>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument Script { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Input argument to provide additional arguments to be passed to javascript.   
     /// </summary>
     [DataMember]
     [Display(Name = "Arguments", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for additional arguments to be passed to javascript")]      
-    public Argument Arguments { get; set; } = new InArgument<object>() { Mode = ArgumentMode.DataBound };
+    public Argument Arguments { get; set; } = new InArgument<object>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Output argument to store the result of the evaluate javascript operation

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/FillActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/FillActorComponent.cs
@@ -23,14 +23,14 @@ public class FillActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember(IsRequired = true)]
     [Display(Name = "Input", GroupName = "Configuration", Order = 10, Description = "Input value to fill")]
-    public Argument Input { get; set; } = new InArgument<string>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument Input { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Optional input argument for <see cref="LocatorFillOptions"/> that can be used to customize the fill operation
     /// </summary>
     [DataMember]
     [Display(Name = "Offset", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorFillOptions")]
-    public Argument FillOptions { get; set; } = new InArgument<LocatorFillOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument FillOptions { get; set; } = new InArgument<LocatorFillOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Constructor

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/FocusActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/FocusActorComponent.cs
@@ -23,7 +23,7 @@ public class FocusActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Focus Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorFocusOptions")]
-    public Argument FocusOptions { get; set; } = new InArgument<LocatorFocusOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument FocusOptions { get; set; } = new InArgument<LocatorFocusOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Constructor

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/GetAttributeActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/GetAttributeActorComponent.cs
@@ -27,14 +27,14 @@ public class GetAttributeActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Get Attribute Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorGetAttributeOptions")]
-    public Argument GetAttributeOptions { get; set; } = new InArgument<LocatorGetAttributeOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument GetAttributeOptions { get; set; } = new InArgument<LocatorGetAttributeOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Output argument to store the attribute value of element
     /// </summary>
     [DataMember]
     [Display(Name = "Result", GroupName = "Output", Order = 20, Description = "Output argument to store the retrieved attribute value")]
-    public Argument Result { get; set; } = new OutArgument<string>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument Result { get; set; } = new OutArgument<string>() { Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Constructor

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/HoverActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/HoverActorComponent.cs
@@ -23,7 +23,7 @@ public class HoverActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Hover Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorHoverOptions")]      
-    public Argument HoverOptions { get; set; } = new InArgument<LocatorHoverOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument HoverOptions { get; set; } = new InArgument<LocatorHoverOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Constructor

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/PlaywrightActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/PlaywrightActorComponent.cs
@@ -18,7 +18,7 @@ public abstract class PlaywrightActorComponent : ActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Target Control", GroupName = "Control Details", Order = 10, Description = "[Optional] Input argument to provide a WebUIControl.")]
-    public Argument TargetControl { get; set; } = new InArgument<UIControl>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+    public Argument TargetControl { get; set; } = new InArgument<UIControl>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Owner application that is interacted with

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/PressActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/PressActorComponent.cs
@@ -23,14 +23,14 @@ public class PressActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember(IsRequired = true)]
     [Display(Name = "Keys", GroupName = "Configuration", Order = 10, Description = "Input argument to provide keys to press")]
-    public Argument Keys { get; set; } = new InArgument<string>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument Keys { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Optional input argument for <see cref="LocatorPressOptions"/> that can be used to customize the Press operation
     /// </summary>
     [DataMember]
     [Display(Name = "Press Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorpressOptions")]
-    public Argument PressOptions { get; set; } = new InArgument<LocatorPressOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument PressOptions { get; set; } = new InArgument<LocatorPressOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Constructor

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/SelectOptionsActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/SelectOptionsActorComponent.cs
@@ -23,7 +23,7 @@ public class SelectOptionsActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Select Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorSelectOptionOptions")]
-    public Argument SelectOptions { get; set; } = new InArgument<LocatorSelectOptionOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument SelectOptions { get; set; } = new InArgument<LocatorSelectOptionOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
 
     /// <summary>
@@ -31,7 +31,7 @@ public class SelectOptionsActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Values", GroupName = "Configuration", Order = 20, Description = "one or more values to select")]
-    public Argument Values { get; set; } = new InArgument<string>() { CanChangeType = true, Mode = ArgumentMode.DataBound };
+    public Argument Values { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound };
 
 
     /// <summary>

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/SetInputFileActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/SetInputFileActorComponent.cs
@@ -23,7 +23,7 @@ public class SetInputFileActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Input Files", GroupName = "Configuration", Order = 10, Description = "Input argument for input files for upload")]
-    public Argument InputFiles { get; set; } = new InArgument<string>() { CanChangeType = true, Mode = ArgumentMode.DataBound };
+    public Argument InputFiles { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound };
 
 
     /// <summary>
@@ -31,7 +31,7 @@ public class SetInputFileActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Input Files Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorSetInputFilesOptions")]
-    public Argument SetInputFilesOptions { get; set; } = new InArgument<LocatorSetInputFilesOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument SetInputFilesOptions { get; set; } = new InArgument<LocatorSetInputFilesOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
 
     /// <summary>

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/TapActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/TapActorComponent.cs
@@ -22,7 +22,7 @@ public class TapActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Tap Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorTapOptions")]
-    public Argument TapOptions { get; set; } = new InArgument<LocatorTapOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument TapOptions { get; set; } = new InArgument<LocatorTapOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
     /// <summary>
     /// Cosntructor

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/TypeActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/TypeActorComponent.cs
@@ -23,7 +23,7 @@ public class TypeActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember(IsRequired = true)]
     [Display(Name = "Input", GroupName = "Configuration", Order = 10, Description = "Input argument for text to type")]
-    public Argument Input { get; set; } = new InArgument<string>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument Input { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound };
 
 
     /// <summary>
@@ -31,7 +31,7 @@ public class TypeActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Type Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorTypeOptions")]
-    public Argument TypeOptions { get; set; } = new InArgument<LocatorTypeOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument TypeOptions { get; set; } = new InArgument<LocatorTypeOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
 
     /// <summary>

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/UncheckActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/UncheckActorComponent.cs
@@ -23,7 +23,7 @@ public class UncheckActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "UnCheck Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorUncheckOptions")]
-    public Argument UnCheckOptions { get; set; } = new InArgument<LocatorUncheckOptions>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+    public Argument UnCheckOptions { get; set; } = new InArgument<LocatorUncheckOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
 
     /// <summary>

--- a/src/Pixel.Automation.Web.Playwright.Components/WebControlEntity.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/WebControlEntity.cs
@@ -17,7 +17,7 @@ namespace Pixel.Automation.Web.Playwright.Components
         {
             if (this.Filter == null)
             {
-                this.Filter = new PredicateArgument<ILocator>() { CanChangeMode = false, CanChangeType = false };
+                this.Filter = new PredicateArgument<ILocator>();
             }
         }
 

--- a/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/DragDropActorComponent.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/DragDropActorComponent.cs
@@ -29,7 +29,7 @@ namespace Pixel.Automation.Web.Selenium.Components
         [DataMember]
         [Display(Name = "Drag Source", GroupName = "Control Details", Order = 10)]
         [Description("Drag source control")]
-        public Argument SourceControl { get; set; } = new InArgument<UIControl>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+        public Argument SourceControl { get; set; } = new InArgument<UIControl>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
         /// <summary>
         /// Drop target control
@@ -37,7 +37,7 @@ namespace Pixel.Automation.Web.Selenium.Components
         [DataMember]
         [Display(Name = "Drop Target", GroupName = "Control Details", Order = 10)]
         [Description("Drop target control")]
-        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
         /// <summary>
         /// Default constructor

--- a/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/HoverActorComponent.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/HoverActorComponent.cs
@@ -28,7 +28,7 @@ namespace Pixel.Automation.Web.Selenium.Components
         /// </summary>
         [DataMember]
         [Display(Name = "Offset", GroupName = "Configuration", Order = 20, Description = "[Optional] Specify an offset relative to center of the control for hover position")]      
-        public Argument Offset { get; set; } = new InArgument<ScreenCoordinate>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+        public Argument Offset { get; set; } = new InArgument<ScreenCoordinate>() { Mode = ArgumentMode.DataBound, DefaultValue = new ScreenCoordinate() };
 
         /// <summary>
         /// Default constructor

--- a/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/MoveActorComponent.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/MoveActorComponent.cs
@@ -26,7 +26,7 @@ namespace Pixel.Automation.Web.Selenium.Components
         /// </summary>
         [DataMember]
         [Display(Name = "OffSet", GroupName = "Configuration", Order = 10, Description = "New position co-ordinates of the control")]
-        public Argument OffSet { get; set; } = new InArgument<ScreenCoordinate>() { CanChangeMode = true, CanChangeType = false, DefaultValue = new ScreenCoordinate(), Mode = ArgumentMode.Default };
+        public Argument OffSet { get; set; } = new InArgument<ScreenCoordinate>() { Mode = ArgumentMode.Default, DefaultValue = new ScreenCoordinate()};
 
         /// <summary>
         /// Default constructor

--- a/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/ScriptExecutorActorComponent.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/ScriptExecutorActorComponent.cs
@@ -3,12 +3,8 @@ using Pixel.Automation.Core.Arguments;
 using Pixel.Automation.Core.Attributes;
 using Pixel.Automation.Core.Interfaces;
 using Serilog;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
-using System.Threading.Tasks;
 
 namespace Pixel.Automation.Web.Selenium.Components.ActorComponents
 {
@@ -27,7 +23,7 @@ namespace Pixel.Automation.Web.Selenium.Components.ActorComponents
         /// </summary>
         [DataMember]
         [Display(Name = "JavaScript", GroupName = "Configuration", Order = 20, Description = "javascript to be executed")]     
-        public Argument Script { get; set; } = new InArgument<string>() { CanChangeType = false, Mode = ArgumentMode.DataBound };
+        public Argument Script { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound };
 
         /// <summary>
         /// Specify additional arguments to be passed to javascript. These arguments can be accessed inside javascript using arguments[n].
@@ -35,7 +31,7 @@ namespace Pixel.Automation.Web.Selenium.Components.ActorComponents
         /// </summary>
         [DataMember]
         [Display(Name = "Arguments", GroupName = "Configuration", Order = 30, Description = "[Optional] Additional arguments to be passed to javascript")]      
-        public Argument Arguments { get; set; } = new InArgument<object[]>() { Mode = ArgumentMode.Scripted };
+        public Argument Arguments { get; set; } = new InArgument<object[]>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.Scripted };
 
         /// <summary>
         /// Result argument will store the returned value from javascript execution

--- a/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/SeleniumActorComponent.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/SeleniumActorComponent.cs
@@ -54,7 +54,7 @@ namespace Pixel.Automation.Web.Selenium.Components
         /// </summary>
         [DataMember]
         [Display(Name = "Target Control", GroupName = "Control Details", Order = 10, Description = "[Optional] Specify a WebUIControl to be interacted with.")]       
-        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+        public Argument TargetControl { get; set; } = new InArgument<UIControl>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound, CanChangeType = false };
 
         /// <summary>
         /// Parent Control entity component if any

--- a/src/Pixel.Automation.Web.Selenium.Components/WebControlEntity.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/WebControlEntity.cs
@@ -4,9 +4,6 @@ using Pixel.Automation.Core.Components;
 using Pixel.Automation.Core.Controls;
 using Pixel.Automation.Core.Enums;
 using Serilog;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Pixel.Automation.Web.Selenium.Components
 {
@@ -24,7 +21,7 @@ namespace Pixel.Automation.Web.Selenium.Components
         {
             if (this.Filter == null)
             {
-                this.Filter = new PredicateArgument<IWebElement>() { CanChangeMode = false, CanChangeType = false };
+                this.Filter = new PredicateArgument<IWebElement>();
             }
         }
 

--- a/src/Pixel.Automation.Window.Management.Components/FindChildWindowActorComponent.cs
+++ b/src/Pixel.Automation.Window.Management.Components/FindChildWindowActorComponent.cs
@@ -32,7 +32,7 @@ namespace Pixel.Automation.Window.Management.Components
         [DisplayName("Parent Window")]
         [Description("Parent Window whose child window needs to be located")]
         [Category("Input")]
-        public InArgument<ApplicationWindow> ParentWindow { get; set; } = new InArgument<ApplicationWindow>() { Mode = ArgumentMode.DataBound };
+        public InArgument<ApplicationWindow> ParentWindow { get; set; } = new InArgument<ApplicationWindow>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
         private LookupMode lookupMode = LookupMode.FindSingle;
         [DataMember]
@@ -79,7 +79,7 @@ namespace Pixel.Automation.Window.Management.Components
                         this.SetDispalyAttribute(nameof(Index), true);
                         break;
                     case FilterMode.Custom:
-                        this.Filter = new PredicateArgument<ApplicationWindow>() { CanChangeMode = false, CanChangeType = false };
+                        this.Filter = new PredicateArgument<ApplicationWindow>() { CanChangeType = false };
                         this.SetDispalyAttribute(nameof(Filter), true);
                         this.SetDispalyAttribute(nameof(Index), false);
                         break;

--- a/src/Pixel.Automation.Window.Management.Components/FindDesktopWindowActorComponent.cs
+++ b/src/Pixel.Automation.Window.Management.Components/FindDesktopWindowActorComponent.cs
@@ -73,7 +73,7 @@ namespace Pixel.Automation.Window.Management.Components
                         this.SetDispalyAttribute(nameof(Index), true);
                         break;
                     case FilterMode.Custom:
-                        this.Filter = new PredicateArgument<ApplicationWindow>() { CanChangeMode = false, CanChangeType = false };
+                        this.Filter = new PredicateArgument<ApplicationWindow>();
                         this.SetDispalyAttribute(nameof(Filter), true);
                         this.SetDispalyAttribute(nameof(Index), false);
                         break;
@@ -90,7 +90,7 @@ namespace Pixel.Automation.Window.Management.Components
         [DataMember]
         [Display(Name = "Index", GroupName = "Search Strategy", Order = 40)]
         [Description("Bind to current Iteration when used inside loop")]
-        public Argument Index { get; set; } = new InArgument<int>() { DefaultValue = 0, CanChangeType = false, Mode = ArgumentMode.Default };
+        public Argument Index { get; set; } = new InArgument<int>() {  Mode = ArgumentMode.Default, DefaultValue = 0 };
 
         [DataMember]
         [Display(Name = "Filter Script", GroupName = "Search Strategy", Order = 40)]

--- a/src/Pixel.Automation.Window.Management.Components/FindWindowFromHandleActorComponent.cs
+++ b/src/Pixel.Automation.Window.Management.Components/FindWindowFromHandleActorComponent.cs
@@ -18,7 +18,7 @@ namespace Pixel.Automation.Window.Management.Components
         [DataMember]
         [Description("Handle window to be located")]
         [DisplayName("Window Handle")]
-        public Argument WindowHandle { get; set; } = new InArgument<IntPtr>() { DefaultValue = IntPtr.Zero, Mode = ArgumentMode.Default, CanChangeType = false, CanChangeMode = true };
+        public Argument WindowHandle { get; set; } = new InArgument<IntPtr>() { Mode = ArgumentMode.Default, DefaultValue = IntPtr.Zero };
 
         [DataMember]
         [DisplayName("Found Window")]

--- a/src/Pixel.Automation.Window.Management.Components/FindWindowFromProcessIdActorComponent.cs
+++ b/src/Pixel.Automation.Window.Management.Components/FindWindowFromProcessIdActorComponent.cs
@@ -18,7 +18,7 @@ namespace Pixel.Automation.Window.Management.Components
         [DataMember]
         [Description("ProcessId of window to be located")]
         [DisplayName("Process Id")]
-        public Argument ProcessId { get; set; } = new InArgument<int>() { DefaultValue = 0, Mode = ArgumentMode.Default, CanChangeType = false, CanChangeMode = true };
+        public Argument ProcessId { get; set; } = new InArgument<int>() { Mode = ArgumentMode.Default, DefaultValue = 0 };
 
         [DataMember]
         [DisplayName("Found Window")]

--- a/src/Pixel.Automation.Window.Management.Components/ResizeWindowActorComponent.cs
+++ b/src/Pixel.Automation.Window.Management.Components/ResizeWindowActorComponent.cs
@@ -19,13 +19,13 @@ namespace Pixel.Automation.Window.Management.Components
         [DataMember]
         [DisplayName("Target Window")]
         [Category("Input")]
-        public Argument ApplicationWindow { get; set; } = new InArgument<ApplicationWindow>() { Mode = ArgumentMode.DataBound };
+        public Argument ApplicationWindow { get; set; } = new InArgument<ApplicationWindow>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
         [DataMember]
         [DisplayName("Window dimension")]
         [Category("Input")]
         [Description("New dimension i.e. width and height of window")]
-        public Argument Dimension { get; set; } = new InArgument<Dimension>() { DefaultValue = Core.Devices.Dimension.ZeroExtents };
+        public Argument Dimension { get; set; } = new InArgument<Dimension>() { DefaultValue = new Dimension(0, 0) };
 
         public ResizeWindowActorComponent() : base("Resize Window", "ResizeWindow")
         {

--- a/src/Pixel.Automation.Window.Management.Components/SetForegroundWindowActorComponent.cs
+++ b/src/Pixel.Automation.Window.Management.Components/SetForegroundWindowActorComponent.cs
@@ -18,7 +18,7 @@ namespace Pixel.Automation.Window.Management.Components
         [DataMember]
         [DisplayName("Target Window")]
         [Category("Input")]
-        public Argument ApplicationWindow { get; set; } = new InArgument<ApplicationWindow>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+        public Argument ApplicationWindow { get; set; } = new InArgument<ApplicationWindow>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
         public SetForegroundWindowActorComponent() : base("Set Foreground Window", "SetForegroundWindow")
         {

--- a/src/Pixel.Automation.Window.Management.Components/SetWindowPositionActorComponent.cs
+++ b/src/Pixel.Automation.Window.Management.Components/SetWindowPositionActorComponent.cs
@@ -22,7 +22,7 @@ namespace Pixel.Automation.Window.Management.Components
         [DataMember]
         [DisplayName("Target Window")]
         [Category("Input")]
-        public Argument ApplicationWindow { get; set; } = new InArgument<ApplicationWindow>() { Mode = ArgumentMode.DataBound };
+        public Argument ApplicationWindow { get; set; } = new InArgument<ApplicationWindow>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
         [DataMember]
         [DisplayName("Position")]

--- a/src/Pixel.Automation.Window.Management.Components/SetWindowStateActorComponent.cs
+++ b/src/Pixel.Automation.Window.Management.Components/SetWindowStateActorComponent.cs
@@ -19,7 +19,7 @@ namespace Pixel.Automation.Window.Management.Components
         [DataMember]
         [DisplayName("Target Window")]
         [Category("Input")]
-        public Argument ApplicationWindow { get; set; } = new InArgument<ApplicationWindow>() { Mode = ArgumentMode.DataBound, CanChangeType = false };
+        public Argument ApplicationWindow { get; set; } = new InArgument<ApplicationWindow>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
 
         [DataMember]
         [DisplayName("Desired State")]

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Arguments/ArgumentFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Arguments/ArgumentFixture.cs
@@ -2,8 +2,6 @@
 using Pixel.Automation.Core.Arguments;
 using Pixel.Automation.Test.Helpers;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Pixel.Automation.Core.Tests.Arguments
 {
@@ -13,6 +11,7 @@ namespace Pixel.Automation.Core.Tests.Arguments
         public DummyArgument()
         {
             this.Mode = ArgumentMode.DataBound;
+            this.AllowedModes = ArgumentMode.Default | ArgumentMode.DataBound | ArgumentMode.Scripted;
         }
 
         public override object Clone()
@@ -31,7 +30,7 @@ namespace Pixel.Automation.Core.Tests.Arguments
         [Test]
         public void ValidateThatArugmentCanBeInitializedInDataBoundMode()
         {
-            var argument = new DummyArgument<Person>() { PropertyPath = "Age", CanChangeMode = true, CanChangeType =false };
+            var argument = new DummyArgument<Person>() { PropertyPath = "Age", CanChangeType =false };
             Assert.AreEqual(ArgumentMode.DataBound, argument.Mode);
             Assert.IsTrue(argument.CanChangeMode);
             Assert.IsFalse(argument.CanChangeType);
@@ -39,7 +38,10 @@ namespace Pixel.Automation.Core.Tests.Arguments
             Assert.AreEqual("Age", argument.PropertyPath);
             Assert.AreEqual("Person", argument.ArgumentType);
             Assert.IsTrue(argument.IsConfigured());
-                       
+            Assert.IsTrue(argument.AllowedModes.HasFlag(ArgumentMode.Default));
+            Assert.IsTrue(argument.AllowedModes.HasFlag(ArgumentMode.DataBound));
+            Assert.IsTrue(argument.AllowedModes.HasFlag(ArgumentMode.Scripted));
+
         }
 
         [Test]
@@ -53,6 +55,22 @@ namespace Pixel.Automation.Core.Tests.Arguments
             Assert.IsTrue(string.IsNullOrEmpty(argument.PropertyPath));
             Assert.AreEqual("Int32", argument.ArgumentType);
             Assert.IsTrue(argument.IsConfigured());
+        }
+
+        [Test]
+        public void ValidateThatOnlyAllowedModesCanBeSetAsArgumentMode()
+        {
+            var argument = new DummyArgument<int>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.Scripted, ScriptFile = "Script.csx" };
+           
+            Assert.IsFalse(argument.AllowedModes.HasFlag(ArgumentMode.Default));
+            Assert.IsTrue(argument.AllowedModes.HasFlag(ArgumentMode.DataBound));
+            Assert.IsTrue(argument.AllowedModes.HasFlag(ArgumentMode.Scripted));
+            Assert.AreEqual(ArgumentMode.Scripted, argument.Mode);
+
+            argument.Mode = ArgumentMode.Default;
+       
+            Assert.AreNotEqual(ArgumentMode.Default, argument.Mode);
+            Assert.AreEqual(ArgumentMode.Scripted, argument.Mode);
 
         }
     }

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Arguments/InArgumentFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Arguments/InArgumentFixture.cs
@@ -1,9 +1,6 @@
 ﻿using NUnit.Framework;
 using Pixel.Automation.Core.Arguments;
 using Pixel.Automation.Test.Helpers;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Pixel.Automation.Core.Tests.Arguments
 {
@@ -18,7 +15,12 @@ namespace Pixel.Automation.Core.Tests.Arguments
             Assert.AreEqual(26, inArgument.DefaultValue);         
             Assert.IsTrue(inArgument.IsConfigured());
             Assert.AreEqual(26, inArgument.GetDefaultValue());
-            Assert.AreEqual(typeof(int), inArgument.GetArgumentType());            
+            Assert.IsFalse(inArgument.CanChangeType);
+            Assert.IsTrue(inArgument.CanChangeMode);
+            Assert.AreEqual(typeof(int), inArgument.GetArgumentType());
+            Assert.IsTrue(inArgument.AllowedModes.HasFlag(ArgumentMode.Default));
+            Assert.IsTrue(inArgument.AllowedModes.HasFlag(ArgumentMode.DataBound));
+            Assert.IsTrue(inArgument.AllowedModes.HasFlag(ArgumentMode.Scripted));
         }
 
         [Test]

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Arguments/OutArgumentFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Arguments/OutArgumentFixture.cs
@@ -24,7 +24,12 @@ namespace Pixel.Automation.Core.Tests.Arguments
             Assert.AreEqual(ArgumentMode.DataBound, outArgument.Mode);
             Assert.AreEqual("Age", outArgument.PropertyPath);
             Assert.AreEqual(typeof(Person), outArgument.GetArgumentType());
+            Assert.IsFalse(outArgument.CanChangeType);
+            Assert.IsTrue(outArgument.CanChangeMode);
             Assert.IsTrue(outArgument.IsConfigured());
+            Assert.IsFalse(outArgument.AllowedModes.HasFlag(ArgumentMode.Default));
+            Assert.IsTrue(outArgument.AllowedModes.HasFlag(ArgumentMode.DataBound));
+            Assert.IsTrue(outArgument.AllowedModes.HasFlag(ArgumentMode.Scripted));
         }
 
         [Test]

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Arguments/PredicateArgumentFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Arguments/PredicateArgumentFixture.cs
@@ -12,9 +12,12 @@ namespace Pixel.Automation.Core.Tests.Arguments
             
             Assert.AreEqual(ArgumentMode.Scripted, predicateArgument.Mode);
             Assert.AreEqual("PredicateScript.csx", predicateArgument.ScriptFile);
-            Assert.IsTrue(predicateArgument.CanChangeType);
+            Assert.IsFalse(predicateArgument.CanChangeType);
             Assert.IsFalse(predicateArgument.CanChangeMode);
             Assert.AreEqual(typeof(int), predicateArgument.GetArgumentType());
+            Assert.IsFalse(predicateArgument.AllowedModes.HasFlag(ArgumentMode.Default));
+            Assert.IsFalse(predicateArgument.AllowedModes.HasFlag(ArgumentMode.DataBound));
+            Assert.IsTrue(predicateArgument.AllowedModes.HasFlag(ArgumentMode.Scripted));
         }
 
         [Test]

--- a/src/Unit.Tests/Pixel.Automation.RunTime.Tests/Arguments/SetArgumentValueTests.cs
+++ b/src/Unit.Tests/Pixel.Automation.RunTime.Tests/Arguments/SetArgumentValueTests.cs
@@ -32,23 +32,7 @@ namespace Pixel.Automation.RunTime.Tests
 
             Assert.ThrowsAsync<InvalidOperationException>(async () => await argumentProcessor.SetValueAsync<bool>(argument, false));
             await Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Validate that InvalidOperationException is thrown since SetValue operation is not applicable for a OutArgument<T>
-        /// which doesn't have a default value. Only InArgument<T> have default value which can be retrieved only using GetValue operation
-        /// </summary>
-        [Test]
-        public async Task ShouldThrowExceptionIfArgumentIsConfiguredForDefaultMode()
-        {
-            ArgumentProcessor argumentProcessor = new ArgumentProcessor();
-            argumentProcessor.Initialize(defaultScriptEngine, new object());
-            var argument = new OutArgument<int>() { Mode = ArgumentMode.Default };
-
-            Assert.ThrowsAsync<InvalidOperationException>(async () => await argumentProcessor.SetValueAsync<int>(argument, 10));
-            await Task.CompletedTask;
-           
-        }
+        }       
 
         /// <summary>
         /// Several OutArgument<T> on components can not be configured as user might not be intersted in storing these values.


### PR DESCRIPTION
**Description**
Add AllowedModes property on Arguments to control different ArgumentModes that can be configured for Argument. 
"CanChangeMode" property allowed only to decide whether it was possible to change argument mode or not . However, it did not offer flexibility to configure what modes are allowed to be configured.