### PR TITLE
Add missing using statement for type IComponent while generating predicate default script.

### DIFF
--- a/src/Pixel.Automation.Core/Arguments/ArgumentExtensions.cs
+++ b/src/Pixel.Automation.Core/Arguments/ArgumentExtensions.cs
@@ -64,6 +64,7 @@ namespace Pixel.Automation.Core
             }
             else if(argument.GetType().Name.Equals(typeof(PredicateArgument<>).Name))
             {
+                result.Append($"using {typeof(IComponent).Namespace};{Environment.NewLine}");
                 result.Append(GeneratePredicateScript(argument));
                 return result.ToString();
             }

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Arguments/ArgumentExtensionsFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Arguments/ArgumentExtensionsFixture.cs
@@ -58,7 +58,7 @@ namespace Pixel.Automation.Core.Tests.Arguments
         public void ValidateThatInitialScriptCanBeGeneratedForPredicateArgument()
         {
             var argument = new PredicateArgument<int>();
-            var expected = "using System;\r\nbool IsMatch(IComponent current, Int32 argument)\r\n{\r\n    return false;\r\n}\r\nreturn ((Func<IComponent, Int32, bool>)IsMatch);";
+            var expected = "using System;\r\nusing Pixel.Automation.Core.Interfaces;\r\nbool IsMatch(IComponent current, Int32 argument)\r\n{\r\n    return false;\r\n}\r\nreturn ((Func<IComponent, Int32, bool>)IsMatch);";
             var result = argument.GenerateInitialScript();
 
             Assert.AreEqual(expected, result);


### PR DESCRIPTION
**Description**
While generating the default script for predicate arguments, the generated script has missing using statement for namespace for type IComponent. While this can be resolved easily, it would be nice to have this included by default.