### PR TITLE
Application screens for grouping controls

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Application/ApplicationDescriptionViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Application/ApplicationDescriptionViewModel.cs
@@ -5,6 +5,7 @@ using Pixel.Automation.Core;
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.Models;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Pixel.Automation.AppExplorer.ViewModels.Application
 {
@@ -67,12 +68,20 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Application
         }
 
         /// <summary>
-        /// Identifier of the controls belonging to this application
+        /// Collection of screens for application used to group controls
         /// </summary>
-        public List<string> AvailableControls
+        public IEnumerable<string> ScreensCollection
+        {
+            get => AvailableControls.Keys.Select(s => s);
+        }
+
+        /// <summary>
+        /// Control identifier collection for a given application screen
+        /// </summary>
+        public Dictionary<string, List<string>> AvailableControls
         {
             get => applicationDescription.AvailableControls;
-        }
+        }     
 
         /// <summary>
         /// Identifier of the prefabs belonging to this application
@@ -80,8 +89,8 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Application
         public List<string> AvailablePrefabs
         {
             get => applicationDescription.AvailablePrefabs;
-        }
- 
+        }       
+
         /// <summary>
         /// Controls belonging to the application
         /// </summary>
@@ -102,14 +111,42 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Application
         }       
 
         /// <summary>
+        /// Add a new screen to the application
+        /// </summary>
+        /// <param name="screenName"></param>
+        public void AddScreen(string screenName)
+        {
+            if(!this.ScreensCollection.Contains(screenName))
+            {
+                this.applicationDescription.AvailableControls.Add(screenName, new List<string>());
+                OnPropertyChanged(nameof(ScreensCollection));
+            }
+        }
+
+        /// <summary>
+        /// Remove an existing screen from the application.
+        /// </summary>
+        /// <param name="screenName"></param>
+        public void DeleteScreen(string screenName)
+        {
+            if (this.ScreensCollection.Contains(screenName))
+            {
+                this.applicationDescription.AvailableControls.Remove(screenName);
+                OnPropertyChanged(nameof(ScreensCollection));
+            }
+        }
+
+        /// <summary>
         /// Add a new control to the application.
         /// </summary>
         /// <param name="controlDescription"></param>
-        public void AddControl(ControlDescriptionViewModel controlDescription)
+        public void AddControl(ControlDescriptionViewModel controlDescription, string screenName)
         {
-            if (!this.AvailableControls.Contains(controlDescription.ControlId))
+            AddScreen(screenName);
+            var controlCollection = this.applicationDescription.AvailableControls[screenName];
+            if (!controlCollection.Contains(controlDescription.ControlId))
             {
-                this.AvailableControls.Add(controlDescription.ControlId);
+                controlCollection.Add(controlDescription.ControlId);
             }
             if (!this.ControlsCollection.Contains(controlDescription))
             {
@@ -121,12 +158,17 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Application
         /// Remove an existing control from the application
         /// </summary>
         /// <param name="controlDescription"></param>
-        public void DeleteControl(ControlDescriptionViewModel controlDescription)
+        public void DeleteControl(ControlDescriptionViewModel controlDescription, string screenName)
         {
-            if (this.AvailableControls.Contains(controlDescription.ControlId))
+            if(this.applicationDescription.AvailableControls.ContainsKey(screenName))
             {
-                this.AvailableControls.Remove(controlDescription.ControlId);
-            }
+                var controlCollection = this.applicationDescription.AvailableControls[screenName];
+                if (controlCollection.Contains(controlDescription.ControlId))
+                {
+                    controlCollection.Remove(controlDescription.ControlId);
+                }
+            }          
+            
             if (this.ControlsCollection.Contains(controlDescription))
             {
                 this.ControlsCollection.Remove(controlDescription);

--- a/src/Pixel.Automation.AppExplorer.ViewModels/Application/ApplicationExplorerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Application/ApplicationExplorerViewModel.cs
@@ -28,6 +28,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Application
         private readonly IEventAggregator eventAggregator;
         private readonly ITypeProvider typeProvider;
         private readonly IApplicationDataManager applicationDataManager;
+        private readonly IWindowManager windowManager;
 
         /// <summary>
         /// Child views that are dependent on the selected application such as control explorer and prefab explorer
@@ -92,12 +93,13 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Application
         /// <param name="typeProvider"></param>
         /// <param name="childView"></param>
         public ApplicationExplorerViewModel(IEventAggregator eventAggregator, IApplicationDataManager applicationDataManager,
-            ITypeProvider typeProvider, IEnumerable<IApplicationAware> childView)
+            ITypeProvider typeProvider, IEnumerable<IApplicationAware> childView, IWindowManager windowManager)
         {
             this.DisplayName = "Application Repository";
-            this.eventAggregator = eventAggregator;
-            this.typeProvider = typeProvider;
-            this.applicationDataManager = applicationDataManager;
+            this.eventAggregator = Guard.Argument(eventAggregator).NotNull().Value; ;
+            this.typeProvider = Guard.Argument(typeProvider).NotNull().Value; ;
+            this.applicationDataManager = Guard.Argument(applicationDataManager).NotNull().Value;
+            this.windowManager = Guard.Argument(windowManager).NotNull().Value;
             this.ChildViews.AddRange(childView);
             this.SelectedView = this.ChildViews[0];
 
@@ -180,7 +182,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Application
                 this.eventAggregator.PublishOnUIThreadAsync(new RepositoryApplicationOpenedEventArgs(string.Empty, string.Empty));
             }
             NotifyOfPropertyChange(nameof(IsApplicationOpen));
-        }
+        }       
 
         public async Task AddApplication(KnownApplication knownApplication)
         {
@@ -190,6 +192,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Application
 
             ApplicationDescription newApplication = new ApplicationDescription(application);
             var applicationDescriptionViewModel = new ApplicationDescriptionViewModel(newApplication);
+            applicationDescriptionViewModel.AddScreen("Home");
             if (string.IsNullOrEmpty(applicationDescriptionViewModel.ApplicationName))
             {
                 applicationDescriptionViewModel.ApplicationName = $"{this.Applications.Count() + 1}";
@@ -218,6 +221,8 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Application
             this.Applications.Remove(applicationDescriptionViewModel);
             this.Applications.Add(applicationDescriptionViewModel);
         }
+
+
 
         private void InitializeKnownApplications()
         {

--- a/src/Pixel.Automation.AppExplorer.ViewModels/Application/ApplicationScreenViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Application/ApplicationScreenViewModel.cs
@@ -1,0 +1,71 @@
+﻿using Dawn;
+using Pixel.Automation.Editor.Core;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.AppExplorer.ViewModels.Application
+{
+    public class ApplicationScreenViewModel : SmartScreen
+    {
+        private readonly ApplicationDescriptionViewModel applicationDescriptionViewModel;
+
+        private string screenName;
+
+        public string ScreenName
+        {
+            get => screenName;
+            set
+            {
+                screenName = value;
+                ValidateScreenName(value);
+                NotifyOfPropertyChange(() => ScreenName);
+            }
+        }
+
+        public ApplicationScreenViewModel(ApplicationDescriptionViewModel applicationDescriptionViewModel)
+        {
+            this.DisplayName = "Create New Application Screen";
+            this.applicationDescriptionViewModel = Guard.Argument(applicationDescriptionViewModel).NotNull();
+        }
+
+        public async Task CreateNewScreen()
+        {
+            if(this.CanCreateScreen)
+            {
+                this.applicationDescriptionViewModel.AddScreen(this.ScreenName);
+                await this.TryCloseAsync(true);               
+            }           
+        }
+
+        public bool CanCreateScreen
+        {
+            get
+            {
+                return !this.HasErrors && !string.IsNullOrEmpty(this.ScreenName) && !!IsNameAvailable(this.ScreenName);
+            }         
+        }
+
+        private void ValidateScreenName(string screenName)
+        {
+            ClearErrors(nameof(ScreenName));
+            ValidateRequiredProperty(nameof(ScreenName), screenName);
+            ValidatePattern("^([A-Za-z]|){3,}$", nameof(ScreenName), screenName, "Name must contain only alphabets and should be atleast 3 characters in length.");
+            if (!IsNameAvailable(screenName))
+            {
+                this.AddOrAppendErrors(nameof(ScreenName), $"Screen already exists with name {ScreenName}");
+            }
+
+        }
+
+        private bool IsNameAvailable(string screenName)
+        {
+            return !this.applicationDescriptionViewModel.ScreensCollection.Any(a => a.Equals(screenName));
+        }
+
+        public async void Cancel()
+        {
+            await this.TryCloseAsync(false);
+        }
+
+    }
+}

--- a/src/Pixel.Automation.AppExplorer.Views/Application/ApplicationScreenView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Application/ApplicationScreenView.xaml
@@ -1,0 +1,34 @@
+﻿<Controls:MetroWindow x:Class="Pixel.Automation.AppExplorer.Views.Application.ApplicationScreenView"
+                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                      xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+                      ResizeMode="NoResize" SizeToContent="WidthAndHeight"
+             WindowStartupLocation="CenterScreen"  ShowCloseButton="False"
+             IsMinButtonEnabled="False" Title="Add New Screen" GlowBrush="{DynamicResource AccentColorBrush}">
+    <Controls:MetroWindow.Resources>
+        <ResourceDictionary>
+            <Thickness x:Key="ControlMargin">10 10 10 10</Thickness>
+        </ResourceDictionary>
+    </Controls:MetroWindow.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+        </Grid.RowDefinitions>
+        <DockPanel LastChildFill="True" MinWidth="320" Grid.Row="0" Margin="10,20,10,20">
+            <Label Content="Name" MinWidth="80" DockPanel.Dock="Left" VerticalAlignment="Center" ></Label>
+            <TextBox DockPanel.Dock="Right" VerticalAlignment="Center"
+                         Text="{Binding ScreenName,ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
+                         Controls:TextBoxHelper.Watermark="Screen Name"
+                         Controls:TextBoxHelper.UseFloatingWatermark="True"
+                         Controls:TextBoxHelper.IsWaitingForData="True"                                   
+                         ToolTip="Screen Name" />
+        </DockPanel>
+        <DockPanel LastChildFill="False"  Grid.Row="1">
+            <Border DockPanel.Dock="Top" BorderThickness="1" Height="1" HorizontalAlignment="Stretch" 
+                    Width="{Binding Path=Width,RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type DockPanel}}}" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+            <Button x:Name="Cancel" Content="CANCEL" Width="100" DockPanel.Dock="Right"  Margin="{StaticResource ControlMargin}" Style="{DynamicResource MahApps.Styles.Button.Square}"/>
+            <Button x:Name="CreateNewScreen" Content="CREATE" DockPanel.Dock="Right" Width="100" Margin="0,10,0,10"  Style="{DynamicResource MahApps.Styles.Button.Square.Accent}"/>
+        </DockPanel>
+    </Grid>
+</Controls:MetroWindow>

--- a/src/Pixel.Automation.AppExplorer.Views/Application/ApplicationScreenView.xaml.cs
+++ b/src/Pixel.Automation.AppExplorer.Views/Application/ApplicationScreenView.xaml.cs
@@ -1,0 +1,13 @@
+﻿namespace Pixel.Automation.AppExplorer.Views.Application
+{
+    /// <summary>
+    /// Interaction logic for ApplicationScreenView.xaml
+    /// </summary>
+    public partial class ApplicationScreenView
+    {
+        public ApplicationScreenView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml
@@ -13,23 +13,6 @@
 
     <UserControl.Resources>
 
-
-        <Style x:Key="BackButton" TargetType="Button">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate>
-                        <StackPanel Orientation="Horizontal">
-                            <Rectangle Fill="{DynamicResource MahApps.Brushes.Accent}" Width="28" Height="28">
-                                <Rectangle.OpacityMask>
-                                    <VisualBrush Visual="{iconPacks:FontAwesome Kind=ArrowAltCircleLeftRegular}" Stretch="Fill" />
-                                </Rectangle.OpacityMask>
-                            </Rectangle>
-                        </StackPanel>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-
         <Style x:Key="ControlLabel" TargetType="{x:Type TextBox}">
             <Setter Property="IsReadOnly" Value="True"></Setter>
             <Setter Property="HorizontalAlignment" Value="Center"></Setter>
@@ -132,15 +115,34 @@
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="*"></RowDefinition>
         </Grid.RowDefinitions>
-        <StackPanel Orientation="Horizontal" Grid.Row="0">
-            <TextBox Name="Filter" Margin="6,1,0,1" Text="{Binding FilterText,UpdateSourceTrigger=PropertyChanged}" controls:TextBoxHelper.ClearTextButton="True"                      
+        <DockPanel Grid.Row="0">
+            <!-- SearchBox and Back button on left-->
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" DockPanel.Dock="Left">
+                <TextBox Name="Filter" Margin="6,1,0,1" Text="{Binding FilterText,UpdateSourceTrigger=PropertyChanged}" controls:TextBoxHelper.ClearTextButton="True"                      
                              controls:TextBoxHelper.UseFloatingWatermark="False"                     
                              controls:TextBoxHelper.Watermark="Search"   Grid.Column="0" HorizontalAlignment="Left"
                                  Width="250"/>
-            <Separator Width="1" Margin="10,0,0,0" BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
-            <Button x:Name="BackButton" HorizontalAlignment="Right" cal:Message.Attach="[Event Click] = [Action GoBack()]"  Margin="0,0,10,0" Style="{StaticResource BackButton}">
-            </Button>
-        </StackPanel>
+                <Separator Width="1" Margin="10,0,0,0" BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+                <Button x:Name="BackButton" Margin="0,0,2,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"                                          
+                                            Height="30" Width="30" ToolTip="Go back to application view"                                                                                      
+                                            cal:Message.Attach="[Event Click] = [Action GoBack()]"
+                                            Style="{StaticResource EditControlButtonStyle}"
+                                            Content="{iconPacks:FontAwesome ArrowAltCircleLeftRegular, Width=28, Height=28}"/>
+            </StackPanel>
+            <Separator Width="1" Margin="10,0,10,0" BorderThickness="2" BorderBrush="{DynamicResource MahApps.Brushes.Accent}" DockPanel.Dock="Left"/>
+            <!-- Screen management on right-->
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" DockPanel.Dock="Left">
+                <ComboBox x:Name="Screens" SelectedItem="{Binding SelectedScreen}" MinWidth="180" Style="{DynamicResource MahApps.Styles.ComboBox}"/>
+                <Separator Width="1" Margin="10,0,0,0" BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+                <Button x:Name="AddScreenButton" Margin="0,0,2,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"                                          
+                                            Height="30" Width="30" ToolTip="Create a new application screen"                                                                                    
+                                            cal:Message.Attach="[Event Click] = [Action CreateScreen()]"
+                                            Style="{StaticResource EditControlButtonStyle}"
+                                            Content="{iconPacks:Material PlusCircleOutline, Width=28, Height=28}"/>
+            </StackPanel>
+            
+        </DockPanel>        
+        
         <ListBox  x:Name="Controls" Grid.Row="1" SelectedItem="{Binding SelectedControl}" dd:DragDrop.IsDragSource="True" 
                           ItemTemplate="{StaticResource ControlItemTemplate}"
                           Width="{Binding Path=Width, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}"

--- a/src/Pixel.Automation.Core/Models/ApplicationDescription.cs
+++ b/src/Pixel.Automation.Core/Models/ApplicationDescription.cs
@@ -43,10 +43,10 @@ namespace Pixel.Automation.Core.Models
         public IApplication ApplicationDetails { get; set; }
 
         /// <summary>
-        /// Identifier of the controls belonging to this application
+        /// Control identifier collection for a given application screen
         /// </summary>
         [DataMember(Order = 30)]
-        public List<string> AvailableControls { get; private set; } = new List<string>();
+        public Dictionary<string, List<string>> AvailableControls { get; private set; } = new ();
 
         /// <summary>
         /// Identifier of the prefabs belonging to this application

--- a/src/Pixel.Persistence.Services.Client/ApplicationDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/ApplicationDataManager.cs
@@ -272,17 +272,49 @@ namespace Pixel.Persistence.Services.Client
            }
         }
 
+        /// <summary>
+        /// Get all the controls belonging to application
+        /// </summary>
+        /// <param name="applicationDescription"></param>
+        /// <returns></returns>
         public IEnumerable<ControlDescription> GetAllControls(ApplicationDescription applicationDescription)
         {
-            foreach (var controlId in applicationDescription.AvailableControls)
+            foreach(var screen in applicationDescription.AvailableControls)
             {
-                string controlFile = Path.Combine(applicationSettings.ApplicationDirectory, applicationDescription.ApplicationId, Constants.ControlsDirectory, controlId, $"{controlId}.dat");
-
-                if (File.Exists(controlFile))
+                foreach(var controlId in screen.Value)
                 {
-                    ControlDescription controlDescription = serializer.Deserialize<ControlDescription>(controlFile);
-                    yield return controlDescription;
-                }
+                    string controlFile = Path.Combine(applicationSettings.ApplicationDirectory, applicationDescription.ApplicationId, Constants.ControlsDirectory, controlId, $"{controlId}.dat");
+
+                    if (File.Exists(controlFile))
+                    {
+                        ControlDescription controlDescription = serializer.Deserialize<ControlDescription>(controlFile);
+                        yield return controlDescription;
+                    }
+                }              
+            }
+            yield break;
+        }
+
+        /// <summary>
+        /// Get all the controls for a given application screen
+        /// </summary>
+        /// <param name="applicationDescription"></param>
+        /// <param name="screenName"></param>
+        /// <returns></returns>
+        public IEnumerable<ControlDescription> GetControlsForScreen(ApplicationDescription applicationDescription, string screenName)
+        {
+            if(applicationDescription.AvailableControls.ContainsKey(screenName))
+            {
+                foreach (var controlId in applicationDescription.AvailableControls[screenName])
+                {
+                    string controlFile = Path.Combine(applicationSettings.ApplicationDirectory, applicationDescription.ApplicationId, Constants.ControlsDirectory, controlId, $"{controlId}.dat");
+
+                    if (File.Exists(controlFile))
+                    {
+                        ControlDescription controlDescription = serializer.Deserialize<ControlDescription>(controlFile);
+                        yield return controlDescription;
+                    }
+                }               
             }
             yield break;
         }

--- a/src/Pixel.Persistence.Services.Client/Interfaces/IApplicationDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/IApplicationDataManager.cs
@@ -40,6 +40,13 @@ namespace Pixel.Persistence.Services.Client
         /// <returns></returns>
         IEnumerable<ControlDescription> GetAllControls(ApplicationDescription applicationDescription);
 
+        /// <summary>
+        /// Load all the control files from disk for a given screen of a given application
+        /// </summary>
+        /// <param name="applicationDescription"></param>
+        /// <param name="screenName"></param>
+        /// <returns></returns>
+        IEnumerable<ControlDescription> GetControlsForScreen(ApplicationDescription applicationDescription, string screenName);
 
         /// <summary>
         /// Add or update a control file

--- a/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Application/ApplicationDescriptionViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Application/ApplicationDescriptionViewModelFixture.cs
@@ -5,6 +5,7 @@ using Pixel.Automation.AppExplorer.ViewModels.Prefab;
 using Pixel.Automation.Core.Controls;
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.Models;
+using System.Linq;
 
 namespace Pixel.Automation.AppExplorer.ViewModels.Tests
 {
@@ -56,15 +57,19 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
             };
 
             var control = new Control.ControlDescriptionViewModel(new ControlDescription());
-            applicationDescriptionViewModel.AddControl(control);
+            applicationDescriptionViewModel.AddControl(control, "Home");
                     
-            Assert.AreEqual(1, applicationDescriptionViewModel.AvailableControls.Count);           
+            Assert.AreEqual(1, applicationDescriptionViewModel.AvailableControls["Home"].Count);           
             Assert.AreEqual(1, applicationDescriptionViewModel.ControlsCollection.Count);
+            Assert.AreEqual(1, applicationDescriptionViewModel.ScreensCollection.Count());
 
-            applicationDescriptionViewModel.DeleteControl(control);
+            applicationDescriptionViewModel.DeleteControl(control, "Home");
 
-            Assert.AreEqual(0, applicationDescriptionViewModel.AvailableControls.Count);
+            Assert.AreEqual(0, applicationDescriptionViewModel.AvailableControls["Home"].Count);
             Assert.AreEqual(0, applicationDescriptionViewModel.ControlsCollection.Count);
+
+            applicationDescriptionViewModel.DeleteScreen("Home");
+            Assert.AreEqual(0, applicationDescriptionViewModel.ScreensCollection.Count());
 
         }
 

--- a/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Application/ApplicationExplorerViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Application/ApplicationExplorerViewModelFixture.cs
@@ -22,6 +22,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         private ITypeProvider typeProvider;
         private IApplicationDataManager applicationDataManager;
         private IApplicationAware childScreen;
+        private IWindowManager windowManager;
     
         [OneTimeSetUp]
         public void OneTimeSetup()
@@ -30,6 +31,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
             typeProvider = Substitute.For<ITypeProvider>();
             applicationDataManager = Substitute.For<IApplicationDataManager>();
             childScreen = Substitute.For<IApplicationAware>();
+            windowManager = Substitute.For<IWindowManager>();
 
             var application = CreateApplicationDescription();
             applicationDataManager.GetAllApplications().Returns(new[] { application });
@@ -50,7 +52,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public void ValidateThatApplicationExplorerViewModelCanBeCorrectlyInitialized()
         {
-            var applicationExplorerViewModel = new ApplicationExplorerViewModel(eventAggregator, applicationDataManager, typeProvider, new[] { childScreen });
+            var applicationExplorerViewModel = new ApplicationExplorerViewModel(eventAggregator, applicationDataManager, typeProvider, new[] { childScreen }, windowManager);
 
             Assert.AreEqual(1, applicationExplorerViewModel.Applications.Count);
             Assert.AreEqual(1, applicationExplorerViewModel.KnownApplications.Count);
@@ -67,7 +69,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public void ValidateThatCanOpenChildView()
         {
-            var applicationExplorerViewModel = new ApplicationExplorerViewModel(eventAggregator, applicationDataManager, typeProvider, new[] { childScreen });
+            var applicationExplorerViewModel = new ApplicationExplorerViewModel(eventAggregator, applicationDataManager, typeProvider, new[] { childScreen }, windowManager);
             var applicationDescription = applicationExplorerViewModel.Applications.First();
             applicationExplorerViewModel.OpenApplication(applicationDescription);
 
@@ -83,7 +85,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public void ValidateThatCanGoBackToParentView()
         {
-            var applicationExplorerViewModel = new ApplicationExplorerViewModel(eventAggregator, applicationDataManager, typeProvider, new[] { childScreen });
+            var applicationExplorerViewModel = new ApplicationExplorerViewModel(eventAggregator, applicationDataManager, typeProvider, new[] { childScreen }, windowManager);
             var applicationDescription = applicationExplorerViewModel.Applications.First();
             
             applicationExplorerViewModel.OpenApplication(applicationDescription);
@@ -99,7 +101,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public async Task ValidateThatNewApplicationCanBeAdded()
         {
-            var applicationExplorerViewModel = new ApplicationExplorerViewModel(eventAggregator, applicationDataManager, typeProvider, new[] { childScreen });
+            var applicationExplorerViewModel = new ApplicationExplorerViewModel(eventAggregator, applicationDataManager, typeProvider, new[] { childScreen }, windowManager);
             var knownApplication = applicationExplorerViewModel.KnownApplications.First();
 
             await applicationExplorerViewModel.AddApplication(knownApplication);
@@ -114,7 +116,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         [Test]
         public void ValidateThatCanToggleRename()
         {
-            var applicationExplorerViewModel = new ApplicationExplorerViewModel(eventAggregator, applicationDataManager, typeProvider, new[] { childScreen });
+            var applicationExplorerViewModel = new ApplicationExplorerViewModel(eventAggregator, applicationDataManager, typeProvider, new[] { childScreen }, windowManager);
             var applicationDescription = applicationExplorerViewModel.Applications.First();
 
             applicationExplorerViewModel.SelectedApplication = applicationDescription;

--- a/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Control/ControlExplorerViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Control/ControlExplorerViewModelFixture.cs
@@ -39,7 +39,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
             controlEditorFactory.CreateControlEditor(Arg.Any<IControlIdentity>()).Returns(controlEditor);
                       
             var controlDescription = CreateControl("SaveButton");
-            applicationDataManager.GetAllControls(Arg.Any<ApplicationDescription>()).Returns(new [] { controlDescription });
+            applicationDataManager.GetControlsForScreen(Arg.Any<ApplicationDescription>(), Arg.Any<string>()).Returns(new [] { controlDescription });
             this.applicationDataManager.AddOrUpdateControlImageAsync(Arg.Any<ControlDescription>(), Arg.Any<Stream>()).Returns(Path.GetRandomFileName());
         }
 
@@ -243,11 +243,14 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
             IApplication applicationDetails = Substitute.For<IApplication>();
             applicationDetails.ApplicationName.Returns("NotePad");
             applicationDetails.ApplicationId.Returns("application-id");
-            return new ApplicationDescription(applicationDetails)
+            var applicationDescription = new ApplicationDescription(applicationDetails)
             {
                 ApplicationName = "NotePad",
                 ApplicationDetails = applicationDetails
             };
+            var controls = applicationDataManager.GetControlsForScreen(applicationDescription, "Home");
+            applicationDescription.AvailableControls.Add("Home", new System.Collections.Generic.List<string>(controls.Select(s => s.ControlId)));
+            return applicationDescription;
         }        
     }
 }


### PR DESCRIPTION
Applications can have a largs number of controls. Loading all the controls for application at a given time will slow down application and might not be optimal as user will usually work on a selected application screen. It is possible now to define screens for an application. Controls can be associated with these screen. Control explorer exposes a drop down now to select screen. Only controls belonging to selected screen will be loaded.