### PR TITLE
Null reference exception while loading a prefab for execution

### DIFF
--- a/src/Pixel.Scripting.Common.CSharp/WorkspaceManagers/ScriptEditorWorkspaceManager.cs
+++ b/src/Pixel.Scripting.Common.CSharp/WorkspaceManagers/ScriptEditorWorkspaceManager.cs
@@ -127,7 +127,7 @@ namespace Pixel.Scripting.Common.CSharp.WorkspaceManagers
             metaDataResolver = metaDataResolver.WithBaseDirectory(Environment.CurrentDirectory);
             metaDataResolver = metaDataResolver.WithSearchPaths(this.searchPaths);
 
-            this.metaDataReferenceResolver = metaDataReferenceResolver.WithScriptMetaDataResolver(metaDataResolver);
+            this.metaDataReferenceResolver = this.metaDataReferenceResolver?.WithScriptMetaDataResolver(metaDataResolver);
             this.scriptCompilationOptions = this.scriptCompilationOptions?.WithMetadataReferenceResolver(this.metaDataReferenceResolver);
         }
     }


### PR DESCRIPTION
**Description**
As the DesignTimePrefabLoader tries to AddSearchPaths on ScriptEditorFactory, the factory will retrieve the workspacemanager and call AddSearchPaths. However, the workspacemanager for prefab is a new and no project or documents exist yet. The metaDataReferenceResolver stays uninitialized until CreateCompilationOptions() is invoked while adding a new project to workspacemanager. Add a null check on metaDataReferenceResolver during UpdateCompilationOptions()