### PR TITLE
Assembly->LoadFrom instead of Assembly->LoadFile

### DIFF
--- a/src/Pixel.Automation.Editor.Core/ArgumentTypeProvider.cs
+++ b/src/Pixel.Automation.Editor.Core/ArgumentTypeProvider.cs
@@ -31,7 +31,7 @@ namespace Pixel.Automation.Arguments.Editor
                 {
                     try
                     {
-                        Assembly assembly = Assembly.LoadFile(assemblyPath);                      
+                        Assembly assembly = Assembly.LoadFrom(assemblyPath);                      
                         PopulateAvailableTypesInAssembly(assembly);
                         logger.Information($"Adding types from assembly {assembly.FullName}");
                     }

--- a/src/Pixel.Automation.RunTime/KnownTypeProvider.cs
+++ b/src/Pixel.Automation.RunTime/KnownTypeProvider.cs
@@ -32,7 +32,7 @@ namespace Pixel.Automation.RunTime
             {
                 try
                 {
-                    Assembly assembly = Assembly.LoadFile(Path.Combine(Environment.CurrentDirectory, path));
+                    Assembly assembly = Assembly.LoadFrom(Path.Combine(Environment.CurrentDirectory, path));
                     LoadTypesFromAssembly(assembly);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
**Description**
Assembly->LoadFile loads the specified file into its own and new load context as described at https://github.com/dotnet/runtime/issues/39783. This causes some assemblies to be loaded twice in application as some other parts of application uses Assembly->LoadFrom . Loading same assemblies multiple times results sometimes in type conflict and causes issues.