### PR TITLE
Allow Scraping across tabs and properly dispose Playwright

### DIFF
--- a/src/Extensions/pixel-browser-scrapper/Web.Scrapper.js
+++ b/src/Extensions/pixel-browser-scrapper/Web.Scrapper.js
@@ -19,7 +19,8 @@ function startListening()
     window.addEventListener("mouseover", onMouseOver);
     window.addEventListener("mouseout", onMouseOut);
     window.addEventListener("mousedown", onMouseDown,true);
-    window.addEventListener("click", onClick, true);   
+    window.addEventListener("click", onClick, true);
+    console.log("startListening"); // Scrapper plugin looks for this console message to attach to event handler
 }
 
 function stopListening()
@@ -28,6 +29,7 @@ function stopListening()
     window.removeEventListener("mouseout", onMouseOut);
     window.removeEventListener("mousedown", onMouseDown);
     window.removeEventListener("click", onClick);
+    console.log("stopListening");
 }
 
 


### PR DESCRIPTION
**Description**
1.Currently the scraping of controls  work only for first tab . It is now possible to scrap controls across tab by toggling the extension to start listening again every time a new tab is created. 
2. Additionally, fixed an issue where zombie node process were left after scraping was stopped as we were not disposing Playwright.