### PR TITLE
Add support for simple assertions on control like visibility , enabled, etc

### DIFF
--- a/Pixel.Automation.sln
+++ b/Pixel.Automation.sln
@@ -154,6 +154,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Automation.Window.Man
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Automation.Editor.Image.Capture", "src\Pixel.Automation.Editor.Image.Capture\Pixel.Automation.Editor.Image.Capture.csproj", "{9A86AD46-64EA-47B6-B029-6541E6A0253A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pixel.Automation.Assertions.Components", "src\Pixel.Automation.Assertions.Components\Pixel.Automation.Assertions.Components.csproj", "{D7AC21DE-DDF5-4C4E-A487-98C62693F1A9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -388,6 +390,10 @@ Global
 		{9A86AD46-64EA-47B6-B029-6541E6A0253A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9A86AD46-64EA-47B6-B029-6541E6A0253A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9A86AD46-64EA-47B6-B029-6541E6A0253A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7AC21DE-DDF5-4C4E-A487-98C62693F1A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7AC21DE-DDF5-4C4E-A487-98C62693F1A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7AC21DE-DDF5-4C4E-A487-98C62693F1A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7AC21DE-DDF5-4C4E-A487-98C62693F1A9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -455,6 +461,7 @@ Global
 		{5AF13BBB-1CE1-4B16-9FE5-B157879D2642} = {242744A0-4C9B-4B89-9AC0-4188D186D4D2}
 		{EEDB10ED-9889-4336-A68F-55429FCF2F24} = {242744A0-4C9B-4B89-9AC0-4188D186D4D2}
 		{9A86AD46-64EA-47B6-B029-6541E6A0253A} = {94422BB0-2426-4FA2-B9C4-29F94A3CAD7F}
+		{D7AC21DE-DDF5-4C4E-A487-98C62693F1A9} = {2B0C7388-18D7-4E3C-8BDF-B7A414520615}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DEAA90E2-A175-4FAA-99F1-30B64D8D3125}

--- a/src/Pixel.Automation.Assertions.Components/AssertIsCheckActorComponent.cs
+++ b/src/Pixel.Automation.Assertions.Components/AssertIsCheckActorComponent.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions;
+using Pixel.Automation.Core.Attributes;
+using Pixel.Automation.Core.Controls;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Assertions.Components;
+
+/// <summary>
+/// Assert that a <see cref="UIControl"/> is checked.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("Is Checked", "Assertions", iconSource: null, description: "Assert that a UIControl is checked", tags: new string[] { "Checked", "Assert" })]
+public class AssertIsCheckedActorComponent : AssertableControlActorComponent
+{
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    public AssertIsCheckedActorComponent() : base("Assert Is Checked", "AssertIsChecked")
+    {
+
+    }
+
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();
+        bool isChecked = await control.IsCheckedAsync();
+        isChecked.Should().BeTrue();
+    }
+}

--- a/src/Pixel.Automation.Assertions.Components/AssertIsDisabledActorComponent.cs
+++ b/src/Pixel.Automation.Assertions.Components/AssertIsDisabledActorComponent.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions;
+using Pixel.Automation.Core.Attributes;
+using Pixel.Automation.Core.Controls;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Assertions.Components;
+
+/// <summary>
+/// Assert that a <see cref="UIControl"/> is enabled.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("Is Disabled", "Assertions", iconSource: null, description: "Assert that a UIControl is disabled", tags: new string[] { "Disabled", "Assert" })]
+public class AssertIsDisabledActorComponent : AssertableControlActorComponent
+{
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    public AssertIsDisabledActorComponent() : base("Assert Is Disabled", "AssertIsDisabled")
+    {
+
+    }
+
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();
+        bool isDisabled = await control.IsDisabledAsync();
+        isDisabled.Should().BeTrue();
+    }
+}

--- a/src/Pixel.Automation.Assertions.Components/AssertIsEnabledActorComponent.cs
+++ b/src/Pixel.Automation.Assertions.Components/AssertIsEnabledActorComponent.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions;
+using Pixel.Automation.Core.Attributes;
+using Pixel.Automation.Core.Controls;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Assertions.Components;
+
+/// <summary>
+/// Assert that a <see cref="UIControl"/> is enabled.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("Is Enabled", "Assertions", iconSource: null, description: "Assert that a UIControl is enabled", tags: new string[] { "Enabled", "Assert" })]
+public class AssertIsEnabledActorComponent : AssertableControlActorComponent
+{
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    public AssertIsEnabledActorComponent() : base("Assert Is Enabled", "AssertIsEnabled")
+    {
+
+    }
+
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();
+        bool isEnabled = await control.IsEnabledAsync();
+        isEnabled.Should().BeTrue();
+    }
+}

--- a/src/Pixel.Automation.Assertions.Components/AssertIsHiddenActorComponent.cs
+++ b/src/Pixel.Automation.Assertions.Components/AssertIsHiddenActorComponent.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions;
+using Pixel.Automation.Core.Attributes;
+using Pixel.Automation.Core.Controls;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Assertions.Components;
+
+/// <summary>
+/// Assert that a <see cref="UIControl"/> is visible
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("Is Hidden", "Assertions", iconSource: null, description: "Assert that a UIControl is hidden", tags: new string[] { "Hidden", "Assert" })]
+public class AssertIsHiddenActorComponent : AssertableControlActorComponent
+{
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    public AssertIsHiddenActorComponent() : base("Assert Is Hidden", "AssertIsHidden")
+    {
+
+    }
+
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();
+        bool isHidden = await control.IsHiddenAsync();
+        isHidden.Should().BeTrue();
+    }
+}

--- a/src/Pixel.Automation.Assertions.Components/AssertIsVisibleActorComponent.cs
+++ b/src/Pixel.Automation.Assertions.Components/AssertIsVisibleActorComponent.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions;
+using Pixel.Automation.Core.Attributes;
+using Pixel.Automation.Core.Controls;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Assertions.Components;
+
+/// <summary>
+/// Assert that a <see cref="UIControl"/> is visible
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("Is Visible", "Assertions", iconSource: null, description: "Assert that a UIControl is visible", tags: new string[] { "Visible", "Assert" })]
+public class AssertIsVisibleActorComponent : AssertableControlActorComponent
+{
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    public AssertIsVisibleActorComponent() : base("Assert Is Visible", "AssertIsVisible")
+    {
+
+    }
+
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();
+        bool isVisible = await control.IsVisibleAsync();
+        isVisible.Should().BeTrue();
+    }        
+}

--- a/src/Pixel.Automation.Assertions.Components/AssertableControlActorComponent.cs
+++ b/src/Pixel.Automation.Assertions.Components/AssertableControlActorComponent.cs
@@ -1,0 +1,80 @@
+﻿using Pixel.Automation.Core;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Components;
+using Pixel.Automation.Core.Controls;
+using Pixel.Automation.Core.Exceptions;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Assertions.Components;
+
+/// <summary>
+/// Base actor class to assert states of a <see cref="UIControl"/>
+/// </summary>
+public abstract class AssertableControlActorComponent : ActorComponent
+{
+    /// <summary>
+    /// Target control that needs to be interacted with. This is an optional component. If the actor is an immediate child of a <see cref="ControlEntity"/>,
+    /// target control will be automatically retrieved from parent ControlEntity. If the target control was previously looked up by any means , it can be specified as an 
+    /// argument instead.
+    /// </summary>
+    [DataMember]
+    [Display(Name = "Target Control", GroupName = "Control Details", Order = 10, Description = "[Optional] Target control that needs to be interacted with")]
+    public Argument TargetControl { get; set; } = new InArgument<UIControl>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+
+    /// <summary>
+    /// Parent control entity that provides the target control.
+    /// </summary>
+    [Browsable(false)]
+    public ControlEntity ControlEntity
+    {
+        get
+        {
+            return this.Parent as ControlEntity;
+
+        }
+    }
+
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="tag"></param>
+    public AssertableControlActorComponent(string name = "", string tag = "") : base(name, tag)
+    {
+
+    }
+
+    /// <summary>
+    /// Get the UIControl identified using the control details
+    /// </summary>
+    /// <returns></returns>
+    protected async Task<UIControl> GetTargetControl()
+    {
+        UIControl targetControl;
+        if (this.TargetControl.IsConfigured())
+        {
+            targetControl = await ArgumentProcessor.GetValueAsync<UIControl>(this.TargetControl);
+        }
+        else
+        {
+            ThrowIfMissingControlEntity();
+            targetControl = await this.ControlEntity.GetControl();
+        }
+        return targetControl;
+    }
+
+    /// <summary>
+    /// Throw <see cref="ConfigurationException"/> if ControlEntity is missing.
+    /// </summary>
+    protected void ThrowIfMissingControlEntity()
+    {
+        if (this.ControlEntity == null)
+        {
+            throw new ConfigurationException($"Component with id : {this.Id} must be child of ControlEntity");
+        }
+    }
+
+}

--- a/src/Pixel.Automation.Assertions.Components/Pixel.Automation.Assertions.Components.csproj
+++ b/src/Pixel.Automation.Assertions.Components/Pixel.Automation.Assertions.Components.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>		
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="6.7.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\Pixel.Automation.Core.Components\Pixel.Automation.Core.Components.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
+
+</Project>

--- a/src/Pixel.Automation.Core/Controls/UIControl.cs
+++ b/src/Pixel.Automation.Core/Controls/UIControl.cs
@@ -41,5 +41,35 @@ namespace Pixel.Automation.Core.Controls
         /// </summary>
         /// <returns></returns>
         public abstract Task<(double,double)> GetClickablePointAsync();
+
+        /// <summary>
+        /// Check if a UI Control is visible
+        /// </summary>
+        /// <returns></returns>
+        public abstract Task<bool> IsVisibleAsync();
+
+        /// <summary>
+        /// Check if a UI Control is visible
+        /// </summary>
+        /// <returns></returns>
+        public abstract Task<bool> IsHiddenAsync();
+
+        /// <summary>
+        /// Check if a UI Control is enabled
+        /// </summary>
+        /// <returns></returns>
+        public abstract Task<bool> IsEnabledAsync();
+
+        /// <summary>
+        /// Check if a UI Control is disabled
+        /// </summary>
+        /// <returns></returns>
+        public abstract Task<bool> IsDisabledAsync();
+
+        /// <summary>
+        /// Check if a control has checked state
+        /// </summary>
+        /// <returns></returns>
+        public abstract Task<bool> IsCheckedAsync();
     }
 }

--- a/src/Pixel.Automation.Designer.Views/Pixel.Automation.Designer.Views.csproj
+++ b/src/Pixel.Automation.Designer.Views/Pixel.Automation.Designer.Views.csproj
@@ -39,7 +39,7 @@
 		<ProjectReference Include="..\Pixel.Automation.AppExplorer.Views\Pixel.Automation.AppExplorer.Views.csproj" />
 		<ProjectReference Include="..\Xceed.Wpf.AvalonDock.Themes.MahApps\Xceed.Wpf.AvalonDock.Themes.MahApps.csproj" />
 
-
+		<ProjectReference Include="..\Pixel.Automation.Assertions.Components\Pixel.Automation.Assertions.Components.csproj" />
 		<ProjectReference Include="..\Pixel.Automation.Input.Devices.Components\Pixel.Automation.Input.Devices.Components.csproj" />
 		<ProjectReference Include="..\Pixel.Automation.Image.Matching.Components\Pixel.Automation.Image.Matching.Components.csproj" />
 		<ProjectReference Include="..\Pixel.Automation.Java.Access.Bridge.Components\Pixel.Automation.Java.Access.Bridge.Components.csproj" />

--- a/src/Pixel.Automation.Designer.Views/appsettings.json
+++ b/src/Pixel.Automation.Designer.Views/appsettings.json
@@ -40,7 +40,8 @@
     ],
     "defaultScriptReferences": [
       ".\\\\Pixel.Automation.Core.dll",
-      ".\\\\Pixel.Automation.Core.Components.dll"
+      ".\\\\Pixel.Automation.Core.Components.dll",
+      ".\\\\FluentAssertions.dll"
     ],
     "whiteListedReferences": [
       "Microsoft.CSharp",
@@ -58,7 +59,8 @@
       "System.Runtime",
       "System.Text.RegularExpressions",
       "System.Threading",
-      "System.Threading.Tasks"
+      "System.Threading.Tasks",
+      "FluentAssertions"
     ]
   }
 }

--- a/src/Pixel.Automation.Image.Matching.Components/ImageUIControl.cs
+++ b/src/Pixel.Automation.Image.Matching.Components/ImageUIControl.cs
@@ -39,4 +39,34 @@ public class ImageUIControl : UIControl
         controlIdentity.GetClickablePoint(boundingBox, out double x, out double y);
         return (x, y);
     }
+
+    ///<inheritdoc/>
+    public override Task<bool> IsDisabledAsync()
+    {
+        throw new System.NotSupportedException("Image control doesn't support determinig if a control is disabled.");
+    }
+
+    ///<inheritdoc/>
+    public override Task<bool> IsEnabledAsync()
+    {
+        throw new System.NotSupportedException("Image control doesn't support determining if a control is enabled.");
+    }
+
+    ///<inheritdoc/>
+    public override Task<bool> IsHiddenAsync()
+    {
+        return Task.FromResult(false);
+    }
+
+    ///<inheritdoc/>
+    public override Task<bool> IsVisibleAsync()
+    {      
+        return Task.FromResult(true);
+    }
+
+    ///<inheritdoc/>
+    public override Task<bool> IsCheckedAsync()
+    {
+        throw new System.NotSupportedException("Image control doesn't support determining if a control is checked.");
+    }
 }

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/JavaUIControl.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/JavaUIControl.cs
@@ -11,6 +11,11 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
         private readonly IControlIdentity controlIdentity;
         private readonly AccessibleContextNode controlNode;
 
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="controlIdentity"></param>
+        /// <param name="controlNode"></param>
         public JavaUIControl(IControlIdentity controlIdentity, AccessibleContextNode controlNode)
         {
             this.controlIdentity = controlIdentity;
@@ -18,17 +23,50 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
             this.TargetControl = controlNode;
         }
 
+        ///<inheritdoc/>
         public override async Task<BoundingBox> GetBoundingBoxAsync()
         {
             var boundingBox = this.controlNode.GetScreenRectangle().Value;
             return await Task.FromResult(new BoundingBox(boundingBox.X, boundingBox.Y, boundingBox.Width, boundingBox.Height));
         }
 
+        ///<inheritdoc/>
         public override async Task<(double, double)> GetClickablePointAsync()
         {
             var boundingBox = await GetBoundingBoxAsync();
             controlIdentity.GetClickablePoint(boundingBox, out double x, out double y);
             return await Task.FromResult((x, y));
         }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsDisabledAsync()
+        {
+            return Task.FromResult(!this.controlNode.GetInfo().states.Contains("enabled"));
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsEnabledAsync()
+        {
+            return Task.FromResult(this.controlNode.GetInfo().states.Contains("enabled"));
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsHiddenAsync()
+        {
+            return Task.FromResult(!this.controlNode.GetInfo().states.Contains("visible"));
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsVisibleAsync()
+        {
+            return Task.FromResult(this.controlNode.GetInfo().states.Contains("visible"));
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsCheckedAsync()
+        {
+            return Task.FromResult(this.controlNode.GetInfo().states.Contains("checked"));
+        }
+
     }
 }

--- a/src/Pixel.Automation.Test.Runner/appsettings.json
+++ b/src/Pixel.Automation.Test.Runner/appsettings.json
@@ -19,7 +19,8 @@
   "defaultCodeReferences": [],
   "defaultScriptReferences": [
     ".\\\\Pixel.Automation.Core.dll",
-    ".\\\\Pixel.Automation.Core.Components.dll"
+    ".\\\\Pixel.Automation.Core.Components.dll",
+    ".\\\\FluentAssertions.dll"
   ],
   "whiteListedReferences": [
     "Microsoft.CSharp",
@@ -37,6 +38,7 @@
     "System.Runtime",
     "System.Text.RegularExpressions",
     "System.Threading",
-    "System.Threading.Tasks"
+    "System.Threading.Tasks",
+    "FluentAssertions"
   ]
 }

--- a/src/Pixel.Automation.UIA.Components/WinUIControl.cs
+++ b/src/Pixel.Automation.UIA.Components/WinUIControl.cs
@@ -8,12 +8,16 @@ using uiaComWrapper::System.Windows.Automation;
 namespace Pixel.Automation.UIA.Components
 {
     public class WinUIControl : UIControl
-    {     
-       
+    {            
         private readonly IControlIdentity controlIdentity;
         private readonly AutomationElement automationElement;
         public static UIControl RootControl { get; private set; } = new WinUIControl(null, AutomationElement.RootElement);
 
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="controlIdentity"></param>
+        /// <param name="automationElement"></param>
         public WinUIControl(IControlIdentity controlIdentity, AutomationElement automationElement)
         {          
             this.controlIdentity = controlIdentity;
@@ -21,17 +25,54 @@ namespace Pixel.Automation.UIA.Components
             this.TargetControl = automationElement;
         }
 
+        ///<inheritdoc/>
         public override async Task<BoundingBox> GetBoundingBoxAsync()
         {
             var boundingBox = this.automationElement.Current.BoundingRectangle;
             return await Task.FromResult(new BoundingBox((int)boundingBox.Left, (int)boundingBox.Top, (int)boundingBox.Width, (int)boundingBox.Height));
         }
 
+        ///<inheritdoc/>
         public override async Task<(double,double)> GetClickablePointAsync()
         {
             var boundingBox = await GetBoundingBoxAsync();
             controlIdentity.GetClickablePoint(boundingBox, out double x, out double y);
             return await Task.FromResult((x, y));
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsVisibleAsync()
+        {
+            return Task.FromResult(!this.automationElement.Current.IsOffscreen);
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsHiddenAsync()
+        {
+            return Task.FromResult(this.automationElement.Current.IsOffscreen);
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsEnabledAsync()
+        {
+            return Task.FromResult(this.automationElement.Current.IsEnabled);
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsDisabledAsync()
+        {
+            return Task.FromResult(!this.automationElement.Current.IsEnabled);
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsCheckedAsync()
+        {
+           if(this.automationElement.TryGetCurrentPattern(TogglePattern.Pattern, out object pattern))
+           {
+                bool isChecked = (pattern as TogglePattern).Current.ToggleState.Equals(ToggleState.On);
+                return Task.FromResult(isChecked);
+           }
+           return Task.FromResult(false);
         }
     }
 }

--- a/src/Pixel.Automation.Web.Playwright.Components/WebUIControl.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/WebUIControl.cs
@@ -3,6 +3,7 @@ using Microsoft.Playwright;
 using Pixel.Automation.Core.Controls;
 using Pixel.Automation.Core.Extensions;
 using Pixel.Automation.Core.Interfaces;
+using System.Runtime.InteropServices;
 
 namespace Pixel.Automation.Web.Playwright.Components
 {
@@ -11,7 +12,6 @@ namespace Pixel.Automation.Web.Playwright.Components
         private readonly ICoordinateProvider coordinateProvider;
         private readonly IControlIdentity controlIdentity;
         private readonly ILocator locator;
-
 
         /// <summary>
         /// Constructor
@@ -31,27 +31,53 @@ namespace Pixel.Automation.Web.Playwright.Components
             this.TargetControl = locator;
         }
 
-
-        /// <summary>
-        /// Get the bounding box
-        /// </summary>
-        /// <returns></returns>
+        ///<inheritdoc/>
         public override async Task<BoundingBox> GetBoundingBoxAsync()
         {           
             var boundingBox = await coordinateProvider.GetBoundingBox(locator);
             return boundingBox;
         }
 
-        /// <summary>
-        /// Get the clickable point
-        /// </summary>
-        /// <param name="x"></param>
-        /// <param name="y"></param>
+        ///<inheritdoc/>
         public override async Task<(double, double)> GetClickablePointAsync()
         {
             var boundingBox = await GetBoundingBoxAsync();
             controlIdentity.GetClickablePoint(boundingBox, out double x, out double y);
             return await Task.FromResult((x, y));
         }
+
+        ///<inheritdoc/>
+        public override async Task<bool> IsDisabledAsync()
+        {
+            return await this.locator.IsDisabledAsync();
+        }
+
+        ///<inheritdoc/>
+        public override async Task<bool> IsEnabledAsync()
+        {
+            return await this.locator.IsEnabledAsync();
+        }
+
+        ///<inheritdoc/>
+        public override async Task<bool> IsHiddenAsync()
+        {
+            return await this.locator.IsHiddenAsync();
+        }
+
+        ///<inheritdoc/>
+        public override async Task<bool> IsVisibleAsync()
+        {
+            return await this.locator.IsVisibleAsync();
+        }
+
+        ///<inheritdoc/>
+        public override async Task<bool> IsCheckedAsync()
+        {
+            return await this.locator.IsCheckedAsync(new LocatorIsCheckedOptions() 
+            { 
+                Timeout = this.controlIdentity.RetryInterval * this.controlIdentity.RetryAttempts 
+            });
+        }
+
     }
 }

--- a/src/Pixel.Automation.Web.Selenium.Components/WebUIControl.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/WebUIControl.cs
@@ -3,7 +3,6 @@ using OpenQA.Selenium;
 using Pixel.Automation.Core.Controls;
 using Pixel.Automation.Core.Extensions;
 using Pixel.Automation.Core.Interfaces;
-using System.Threading.Tasks;
 
 namespace Pixel.Automation.Web.Selenium.Components
 {
@@ -15,7 +14,6 @@ namespace Pixel.Automation.Web.Selenium.Components
         private readonly ICoordinateProvider coordinateProvider; 
         private readonly IControlIdentity controlIdentity;
         private readonly IWebElement webElement;
-
 
         /// <summary>
         /// Constructor
@@ -35,11 +33,7 @@ namespace Pixel.Automation.Web.Selenium.Components
             this.TargetControl = webElement;
         }
 
-
-        /// <summary>
-        /// Get the bounding box of wrapped <see cref="IWebElement"/>
-        /// </summary>
-        /// <returns></returns>
+        ///<inheritdoc/>
         public override async Task<BoundingBox> GetBoundingBoxAsync()
         {
             //webdriver imlementation for location doesn't consider browser window titlebar space resulting in to incorrect y-coodrinate.
@@ -50,16 +44,42 @@ namespace Pixel.Automation.Web.Selenium.Components
             return boundingBox;
         }
 
-        /// <summary>
-        /// Get the clickable point of wrapped <see cref="IWebElement"/>
-        /// </summary>
-        /// <param name="x"></param>
-        /// <param name="y"></param>
+        ///<inheritdoc/>
         public override async Task<(double, double)> GetClickablePointAsync()
         {
             var boundingBox = await GetBoundingBoxAsync();
             controlIdentity.GetClickablePoint(boundingBox, out double x, out double y);
             return await Task.FromResult((x, y));
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsDisabledAsync()
+        {
+            return Task.FromResult(!this.webElement.Enabled);
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsEnabledAsync()
+        {
+            return Task.FromResult(this.webElement.Enabled);
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsHiddenAsync()
+        {
+            return Task.FromResult(!this.webElement.Displayed);
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsVisibleAsync()
+        {
+            return Task.FromResult(this.webElement.Displayed);
+        }
+
+        ///<inheritdoc/>
+        public override Task<bool> IsCheckedAsync()
+        {
+            return Task.FromResult(this.webElement.Selected);
         }
     }
 }

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/UIControlFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/UIControlFixture.cs
@@ -29,6 +29,31 @@ namespace Pixel.Automation.Core.Tests.Models
         {
             return await Task.FromResult((0, 0));
         }
+
+        public override Task<bool> IsCheckedAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<bool> IsDisabledAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<bool> IsEnabledAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<bool> IsHiddenAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<bool> IsVisibleAsync()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     class UIControlFixture


### PR DESCRIPTION
**Description**
1. Add support for asserting simple states of control like visibility, enabled, checked, etc.
2. Load FluentAssertions library by default for script engine so that assertions can be used from scripts. This still needs some additional work to include the namespace by default however. The using statement needs to be manually added at the moment.