### PR TITLE
Add actors for  Expect* api in Playwright component

### DIFF
--- a/src/Pixel.Automation.Core/Attributes/AllowedTypesAttribute.cs
+++ b/src/Pixel.Automation.Core/Attributes/AllowedTypesAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Pixel.Automation.Core.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+    public class AllowedTypesAttribute : Attribute
+    {
+        public List<Type> Types { get; } = new  List<Type>();
+
+        public AllowedTypesAttribute(params Type[] types)
+        {
+            this.Types.AddRange(types);
+        }
+    }
+}

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IArgumentTypeBrowserFactory.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IArgumentTypeBrowserFactory.cs
@@ -1,4 +1,7 @@
-﻿namespace Pixel.Automation.Editor.Core.Interfaces
+﻿using System;
+using System.Collections.Generic;
+
+namespace Pixel.Automation.Editor.Core.Interfaces
 {
     public interface IArgumentTypeBrowserFactory
     {
@@ -8,6 +11,13 @@
         /// </summary>
         /// <returns></returns>
         IArgumentTypeBrowser CreateArgumentTypeBrowser();
+
+        /// <summary>
+        /// Create an instance of IArgumentTypeBrowser which will show only specified types
+        /// </summary>
+        /// <param name="types"></param>
+        /// <returns></returns>
+        IArgumentTypeBrowser CreateArgumentTypeBrowser(IEnumerable<Type> types);
 
         /// <summary>
         /// Create an instance of IArgumentTypeBrowser where the initial GenericType e.g. List<T>  is already selected and we are showing 

--- a/src/Pixel.Automation.Editor.Core/TypeBrowser/ArgumentTypeBrowserFactory.cs
+++ b/src/Pixel.Automation.Editor.Core/TypeBrowser/ArgumentTypeBrowserFactory.cs
@@ -1,6 +1,9 @@
 ﻿using Dawn;
 using Pixel.Automation.Editor.Core;
 using Pixel.Automation.Editor.Core.Interfaces;
+using Pixel.Automation.Editor.Core.TypeBrowser;
+using System;
+using System.Collections.Generic;
 
 namespace Pixel.Automation.Editor.TypeBrowser
 {
@@ -16,6 +19,11 @@ namespace Pixel.Automation.Editor.TypeBrowser
         public IArgumentTypeBrowser CreateArgumentTypeBrowser()
         {
             return new ArgumentTypeBrowserViewModel(this.typeProvider);
+        }
+
+        public IArgumentTypeBrowser CreateArgumentTypeBrowser(IEnumerable<Type> typesToShow)
+        {
+            return new ArgumentTypeBrowserViewModel(new SimpleArgumentTypeProvider(typesToShow), true);
         }
 
         public IArgumentTypeBrowser CreateArgumentTypeBrowser(TypeDefinition selectedType)

--- a/src/Pixel.Automation.Editor.Core/TypeBrowser/SimpleArgumentTypeProvider.cs
+++ b/src/Pixel.Automation.Editor.Core/TypeBrowser/SimpleArgumentTypeProvider.cs
@@ -1,0 +1,60 @@
+﻿using Dawn;
+using Pixel.Automation.Editor.Core.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Pixel.Automation.Editor.Core.TypeBrowser
+{
+    /// <summary>
+    /// Implementation of <see cref="IArgumentTypeProvider"/> with a fix collection of types passed during initialization.
+    /// </summary>
+    internal class SimpleArgumentTypeProvider : IArgumentTypeProvider
+    {
+        private readonly List<TypeDefinition> knownTypes = new List<TypeDefinition>();
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="types"></param>
+        public SimpleArgumentTypeProvider(IEnumerable<Type> types)
+        {
+            Guard.Argument(types).NotNull().NotEmpty();
+            foreach (var type in types)
+            {
+                this.knownTypes.Add(new TypeDefinition(type));
+            }
+        }
+
+        /// <inheritdoc/>       
+        public IEnumerable<TypeDefinition> GetAllKnownTypes()
+        {
+            return this.knownTypes;
+        }
+
+        /// <inheritdoc/>      
+        public IEnumerable<TypeDefinition> GetCommonTypes()
+        {
+            return Enumerable.Empty<TypeDefinition>();
+        }
+
+        /// <inheritdoc/>      
+        public IEnumerable<TypeDefinition> GetCustomDefinedTypes()
+        {
+            return this.knownTypes;
+        }
+
+        /// <inheritdoc/>      
+        public IArgumentTypeProvider WithAdditionalAssemblyPaths(params string[] assemblyPaths)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>      
+        public IArgumentTypeProvider WithDataModelAssembly(Assembly assembly)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeCheckedActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeCheckedActorComponent.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToBeCheckedActorComponent"/> to ensure that <see cref="ILocator"/> points to a checked input.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Be Checked", "Playwright", "Expect", iconSource: null, description: "Ensures the Locator points to a checked input.", tags: new string[] { "To", "Be", "Checked", "Assert", "Expect" })]
+public class ExpectToBeCheckedActorComponent : PlaywrightActorComponent
+{   
+    [DataMember]
+    [Display(Name = "To Be Checked Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorAssertionsToBeCheckedOptions")]
+    public Argument ToBeCheckedOptions { get; set; } = new InArgument<LocatorAssertionsToBeCheckedOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToBeCheckedActorComponent() : base("Expect To Be Checked", "ExpectToBeChecked")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> points to a checked input.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();  
+        var options = this.ToBeCheckedOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToBeCheckedOptions>(this.ToBeCheckedOptions) : null;
+        await Assertions.Expect(control).ToBeCheckedAsync(options);
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeDisabledActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeDisabledActorComponent.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToBeDisabledActorComponent"/> to ensure that <see cref="ILocator"/> points to a disabled element.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Be Disabled", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to a disabled element.", tags: new string[] { "To", "Be", "Disabled", "Assert", "Expect" })]
+public class ExpectToBeDisabledActorComponent : PlaywrightActorComponent
+{   
+    [DataMember]
+    [Display(Name = "To Be Disabled Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorAssertionsToBeDisabledOptions")]
+    public Argument ToBeDisabledOptions { get; set; } = new InArgument<LocatorAssertionsToBeDisabledOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToBeDisabledActorComponent() : base("Expect To Be Disabled", "ExpectToBeDisabled")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> points to a disabled element.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();  
+        var options = this.ToBeDisabledOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToBeDisabledOptions>(this.ToBeDisabledOptions) : null;
+        await Assertions.Expect(control).ToBeDisabledAsync(options);
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeEditableActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeEditableActorComponent.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToBeEditableActorComponent"/> ensure <see cref="ILocator"/> points to an editable element.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Be Editable", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to an editable element.", tags: new string[] { "To", "Be", "Editable", "Assert", "Expect" })]
+public class ExpectToBeEditableActorComponent : PlaywrightActorComponent
+{   
+    [DataMember]
+    [Display(Name = "To Be Editable Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorAssertionsToBeEditableOptions")]
+    public Argument ToBeEditableOptions { get; set; } = new InArgument<LocatorAssertionsToBeEditableOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToBeEditableActorComponent() : base("Expect To Be Editable", "ExpectToBeEditable")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure <see cref="ILocator"/> points to an editable element.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();  
+        var options = this.ToBeEditableOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToBeEditableOptions>(this.ToBeEditableOptions) : null;
+        await Assertions.Expect(control).ToBeEditableAsync(options);
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeEmptyActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeEmptyActorComponent.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToBeEnabledActorComponent"/> to ensure that <see cref="ILocator"/> point to an empty editable element or to a DOM.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Be Empty", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to an empty editable element or to a DOM", tags: new string[] { "To", "Be", "Empty", "Assert", "Expect" })]
+public class ExpectToBeEmptyActorComponent : PlaywrightActorComponent
+{   
+    [DataMember]
+    [Display(Name = "To Be Empty Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorAssertionsToBeEmptyOptions")]
+    public Argument ToBeEmptyOptions { get; set; } = new InArgument<LocatorAssertionsToBeEmptyOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToBeEmptyActorComponent() : base("Expect To Be Empty", "ExpectToBeEmpty")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> point to an empty editable element or to a DOM.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();  
+        var options = this.ToBeEmptyOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToBeEmptyOptions>(this.ToBeEmptyOptions) : null;
+        await Assertions.Expect(control).ToBeEmptyAsync(options);
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeEnabledActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeEnabledActorComponent.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToBeEnabledActorComponent"/> to ensure that <see cref="ILocator"/> point to a enabled element.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Be Enabled", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to a enabled element.", tags: new string[] { "To", "Be", "Enabled", "Assert", "Expect" })]
+public class ExpectToBeEnabledActorComponent : PlaywrightActorComponent
+{   
+    [DataMember]
+    [Display(Name = "To Be Enabled Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorAssertionsToBeEnabledOptions")]
+    public Argument ToBeEnabledOptions { get; set; } = new InArgument<LocatorAssertionsToBeEnabledOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToBeEnabledActorComponent() : base("Expect To Be Enabled", "ExpectToBeEnabled")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> point to a enabled element.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();  
+        var options = this.ToBeEnabledOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToBeEnabledOptions>(this.ToBeEnabledOptions) : null;
+        await Assertions.Expect(control).ToBeEnabledAsync(options);
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeFocusedActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeFocusedActorComponent.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToBeFocusedActorComponent"/> to ensure that <see cref="ILocator"/> points to a focused DOM node.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Be Focused", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to a focused DOM node.", tags: new string[] { "To", "Be", "Focused", "Assert", "Expect" })]
+public class ExpectToBeFocusedActorComponent : PlaywrightActorComponent
+{   
+    [DataMember]
+    [Display(Name = "To Be Focused Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorAssertionsToBeFocusedOptions")]
+    public Argument ToBeFocusedOptions { get; set; } = new InArgument<LocatorAssertionsToBeFocusedOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToBeFocusedActorComponent() : base("Expect To Be Focused", "ExpectToBeFocused")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> points to a focused DOM node.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();  
+        var options = this.ToBeFocusedOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToBeFocusedOptions>(this.ToBeFocusedOptions) : null;
+        await Assertions.Expect(control).ToBeFocusedAsync(options);
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeHiddenActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeHiddenActorComponent.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToBeHiddenActorComponent"/> to ensure that <see cref="ILocator"/> points to a hidden DOM node.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Be Hidden", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to a hidden DOM node", tags: new string[] { "To", "Be", "Hidden", "Assert", "Expect" })]
+public class ExpectToBeHiddenActorComponent : PlaywrightActorComponent
+{   
+    [DataMember]
+    [Display(Name = "To Be Hidden Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorAssertionsToBeHiddenOptions")]
+    public Argument ToBeHiddenOptions { get; set; } = new InArgument<LocatorAssertionsToBeHiddenOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToBeHiddenActorComponent() : base("Expect To Be Hidden", "ExpectToBeHidden")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> points to a hidden DOM node.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();  
+        var options = this.ToBeHiddenOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToBeHiddenOptions>(this.ToBeHiddenOptions) : null;
+        await Assertions.Expect(control).ToBeHiddenAsync(options);
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeVisibleActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToBeVisibleActorComponent.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToBeVisibleActorComponent"/> to ensure that <see cref="ILocator"/> points to a Visible DOM node.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Be Visible", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to a Visible DOM node", tags: new string[] { "To", "Be", "Visible", "Assert", "Expect" })]
+public class ExpectToBeVisibleActorComponent : PlaywrightActorComponent
+{   
+    [DataMember]
+    [Display(Name = "To Be Visible Options", GroupName = "Configuration", Order = 10, Description = "[Optional] Input argument for LocatorAssertionsToBeVisibleOptions")]
+    public Argument ToBeVisibleOptions { get; set; } = new InArgument<LocatorAssertionsToBeVisibleOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToBeVisibleActorComponent() : base("Expect To Be Visible", "ExpectToBeVisible")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> points to a Visible DOM node.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();  
+        var options = this.ToBeVisibleOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToBeVisibleOptions>(this.ToBeVisibleOptions) : null;
+        await Assertions.Expect(control).ToBeVisibleAsync(options);
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToContainTextActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToContainTextActorComponent.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToContainTextActorComponent"/> to ensure that <see cref="ILocator"/> points to an element that contains the given text.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Contain Text", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to an element points to an element that contains the given text.", tags: new string[] { "To", "Contain", "Text", "Assert", "Expect" })]
+public class ExpectToContainTextActorComponent : PlaywrightActorComponent
+{
+    [DataMember]
+    [Display(Name = "Text", GroupName = "Configuration", Order = 10, Description = "Input argument for expected text")]
+    [AllowedTypes(typeof(string), typeof(Regex), typeof(IEnumerable<string>), typeof(IEnumerable<Regex>))]
+    public Argument Text { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default, CanChangeType = true };
+
+    [DataMember]
+    [Display(Name = "To Contain Text Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorAssertionsToContainTextOptions")]
+    public Argument ToContainTextOptions { get; set; } = new InArgument<LocatorAssertionsToContainTextOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToContainTextActorComponent() : base("Expect To Contain Text", "ExpectToContainText")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> points to an element that contains the given text.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();
+        var options = this.ToContainTextOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToContainTextOptions>(this.ToContainTextOptions) : null;
+        switch (this.Text)
+        {
+            case InArgument<string>:
+                var text = await this.ArgumentProcessor.GetValueAsync<string>(this.Text);
+                await Assertions.Expect(control).ToContainTextAsync(text, options);
+                break;
+            case InArgument<Regex>:
+                var regex = await this.ArgumentProcessor.GetValueAsync<Regex>(this.Text);
+                await Assertions.Expect(control).ToContainTextAsync(regex, options);
+                break;
+            case InArgument<IEnumerable<string>>:
+                var textCollection = await this.ArgumentProcessor.GetValueAsync<IEnumerable<string>>(this.Text);
+                await Assertions.Expect(control).ToContainTextAsync(textCollection, options);
+                break;
+            case InArgument<IEnumerable<Regex>>:
+                var regExCollection = await this.ArgumentProcessor.GetValueAsync<IEnumerable<Regex>>(this.Text);
+                await Assertions.Expect(control).ToContainTextAsync(regExCollection, options);
+                break;
+        }
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveAttributeActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveAttributeActorComponent.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToHaveAttributeActorComponent"/> to ensure that <see cref="ILocator"/> points to an element with given attribute.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Have Attribute", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to an element with given attribute.", tags: new string[] { "To", "Have", "Attribute", "Assert", "Expect" })]
+public class ExpectToHaveAttributeActorComponent : PlaywrightActorComponent
+{
+    [DataMember(IsRequired = true)]
+    [Display(Name = "Attribute Name", GroupName = "Configuration", Order = 10, Description = "Input argument for attribute name")]   
+    public Argument AttributeName { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default };
+
+    [DataMember(IsRequired = true)]
+    [Display(Name = "Attribute Value", GroupName = "Configuration", Order = 20, Description = "Input argument for expected attribute value")]
+    [AllowedTypes(typeof(string), typeof(Regex))]
+    public Argument AttributeValue { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default, CanChangeType = true };
+
+    [DataMember]
+    [Display(Name = "To Have Attribute Options", GroupName = "Configuration", Order = 30, Description = "[Optional] Input argument for LocatorAssertionsToHaveAttributeOptions")]
+    public Argument ToHaveAttributeOptions { get; set; } = new InArgument<LocatorAssertionsToHaveAttributeOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToHaveAttributeActorComponent() : base("Expect To Have Attribute", "ExpectToHaveAttribute")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/>points to an element with given attribute.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();
+        var attributeName = await this.ArgumentProcessor.GetValueAsync<string>(this.AttributeName);
+        var toHaveAttributeOptions = this.ToHaveAttributeOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToHaveAttributeOptions>(this.ToHaveAttributeOptions) : null;
+        switch (this.AttributeValue)
+        {
+            case InArgument<string>:
+                var attributeValue = await this.ArgumentProcessor.GetValueAsync<string>(this.AttributeValue);
+                await Assertions.Expect(control).ToHaveAttributeAsync(attributeName, attributeValue, toHaveAttributeOptions);
+                break;
+            case InArgument<Regex>:
+                var attributeValueRegex = await this.ArgumentProcessor.GetValueAsync<Regex>(this.AttributeValue);
+                await Assertions.Expect(control).ToHaveAttributeAsync(attributeName, attributeValueRegex, toHaveAttributeOptions);
+                break;
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveCSSActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveCSSActorComponent.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToHaveCSSPropertyActorComponent"/> to ensure the <see cref="ILocator"/> resolves to an element with the given computed style.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Have CSS", "Playwright", "Expect", iconSource: null, description: "Ensures the Locator resolves to an element with the given computed CSS style.", tags: new string[] { "To", "Have", "CSS", "Assert", "Expect" })]
+public class ExpectToHaveCSSPropertyActorComponent : PlaywrightActorComponent
+{
+    [DataMember(IsRequired = true)]
+    [Display(Name = "Name", GroupName = "Configuration", Order = 10, Description = "Input argument for name of css property")]
+    public Argument PropertyName { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default };
+
+    [DataMember(IsRequired = true)]
+    [Display(Name = "Value", GroupName = "Configuration", Order = 20, Description = "Input argument for expected value of css property")]
+    [AllowedTypes(typeof(string), typeof(Regex))]
+    public Argument PropertyValue { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default, CanChangeType = true };
+
+    [DataMember]
+    [Display(Name = "CSS Property Options", GroupName = "Configuration", Order = 30, Description = "[Optional] Input argument for LocatorAssertionsToHaveJSPropertyOptions")]
+    public Argument ToHaveCSSPropertyOptions { get; set; } = new InArgument<LocatorAssertionsToHaveCSSOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToHaveCSSPropertyActorComponent() : base("Expect To Have CSS Property", "ExpectToHaveCSSProperty")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure the <see cref="ILocator"/> resolves to an element with the given computed style.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await GetTargetControl();
+        var name = await this.ArgumentProcessor.GetValueAsync<string>(this.PropertyName);    
+        var toHaveCSSPropertyOptions = this.ToHaveCSSPropertyOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToHaveCSSOptions>(this.ToHaveCSSPropertyOptions) : null;
+        
+        switch (this.PropertyValue)
+        {
+            case InArgument<string>:
+                var value = await this.ArgumentProcessor.GetValueAsync<string>(this.PropertyValue);
+                await Assertions.Expect(control).ToHaveCSSAsync(name, value, toHaveCSSPropertyOptions);
+                break;
+            case InArgument<Regex>:
+                var regex = await this.ArgumentProcessor.GetValueAsync<Regex>(this.PropertyValue);
+                await Assertions.Expect(control).ToHaveCSSAsync(name, regex, toHaveCSSPropertyOptions);
+                break;
+        }
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveClassActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveClassActorComponent.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToHaveClassActorComponent"/> to ensure that <see cref="ILocator"/> points to an element with given CSS class.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Have Class", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to an element with given CSS class.", tags: new string[] { "To", "Have", "Class", "Assert", "Expect" })]
+public class ExpectToHaveClassActorComponent : PlaywrightActorComponent
+{
+    [DataMember]
+    [Display(Name = "Class", GroupName = "Configuration", Order = 10, Description = "Input argument for expected class")]
+    [AllowedTypes(typeof(string), typeof(Regex), typeof(IEnumerable<string>), typeof(IEnumerable<Regex>))]
+    public Argument Class { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default, CanChangeType = true };
+
+    [DataMember]
+    [Display(Name = "To Have Class Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorAssertionsToHaveClassOptions")]
+    public Argument ToHaveClassOptions { get; set; } = new InArgument<LocatorAssertionsToHaveClassOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToHaveClassActorComponent() : base("Expect To Have Class", "ExpectToHaveClass")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> points to an element with given CSS class.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();       
+        var options = this.ToHaveClassOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToHaveClassOptions>(this.ToHaveClassOptions) : null;      
+        switch (this.Class)
+        {
+            case InArgument<string>:
+                var Class = await this.ArgumentProcessor.GetValueAsync<string>(this.Class);
+                await Assertions.Expect(control).ToHaveClassAsync(Class, options);
+                break;
+            case InArgument<Regex>:
+                var regex = await this.ArgumentProcessor.GetValueAsync<Regex>(this.Class);
+                await Assertions.Expect(control).ToHaveClassAsync(regex, options);
+                break;
+            case InArgument<IEnumerable<string>>:
+                var ClassCollection = await this.ArgumentProcessor.GetValueAsync<IEnumerable<string>>(this.Class);
+                await Assertions.Expect(control).ToHaveClassAsync(ClassCollection, options);
+                break;
+            case InArgument<IEnumerable<Regex>>:
+                var regExCollection = await this.ArgumentProcessor.GetValueAsync<IEnumerable<Regex>>(this.Class);
+                await Assertions.Expect(control).ToHaveClassAsync(regExCollection, options);
+                break;
+        }
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveCountActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveCountActorComponent.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToHaveCountActorComponent"/> to ensure that <see cref="ILocator"/> resolves to an exact number of DOM nodes.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Have Count", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator resolves to an exact number of DOM nodes.", tags: new string[] { "To", "Have", "Count", "Assert", "Expect" })]
+public class ExpectToHaveCountActorComponent : PlaywrightActorComponent
+{
+    [DataMember]
+    [Display(Name = "Count", GroupName = "Configuration", Order = 10, Description = "Input argument for expected count")]
+    public Argument Count { get; set; } = new InArgument<int>() { Mode = ArgumentMode.Default };
+
+    [DataMember]
+    [Display(Name = "To Have Count Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorAssertionsToHaveCountOptions")]
+    public Argument ToHaveCountOptions { get; set; } = new InArgument<LocatorAssertionsToHaveCountOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToHaveCountActorComponent() : base("Expect To Have Count", "ExpectToHaveCount")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> resolves to an exact number of DOM nodes.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();
+        var count = await this.ArgumentProcessor.GetValueAsync<int>(this.Count);
+        var options = this.ToHaveCountOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToHaveCountOptions>(this.ToHaveCountOptions) : null;
+        await Assertions.Expect(control).ToHaveCountAsync(count, options);
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveIdActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveIdActorComponent.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToHaveIdActorComponent"/> to ensure that <see cref="ILocator"/> points to an element with the given DOM Node.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Have Id", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to an element with the given DOM Node.", tags: new string[] { "To", "Have", "Id", "Assert", "Expect" })]
+public class ExpectToHaveIdActorComponent : PlaywrightActorComponent
+{
+    [DataMember(IsRequired = true)]
+    [Display(Name = "Id", GroupName = "Configuration", Order = 10, Description = "Input argument for Id")]
+    [AllowedTypes(typeof(string), typeof(Regex))]
+    public Argument Identifier { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default , CanChangeType = true };
+
+    [DataMember]
+    [Display(Name = "To Have Id Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for PageAssertionsToHaveURLOptions")]
+    public Argument ToHaveIdOptions { get; set; } = new InArgument<LocatorAssertionsToHaveIdOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToHaveIdActorComponent() : base("Expect To Have Id", "ExpectToHaveId")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> points to an element with the given DOM Node.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();       
+        var toHaveIdOptions = this.ToHaveIdOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToHaveIdOptions>(this.ToHaveIdOptions) : null;
+        switch (this.Identifier)
+        {
+            case InArgument<string>:
+                var identifier = await this.ArgumentProcessor.GetValueAsync<string>(this.Identifier);
+                await Assertions.Expect(control).ToHaveIdAsync(identifier, toHaveIdOptions);
+                break;
+            case InArgument<Regex>:
+                var regex = await this.ArgumentProcessor.GetValueAsync<Regex>(this.Identifier);
+                await Assertions.Expect(control).ToHaveIdAsync(regex, toHaveIdOptions);
+                break;
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveJSPropertyActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveJSPropertyActorComponent.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToHaveJSPropertyActorComponent"/> to ensures that <see cref="ILocator"/> points to an element with given JavaScript property.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Have JS Property", "Playwright", "Expect", iconSource: null, description: "Ensures that ILocator points to an element with given JavaScript property", tags: new string[] { "To", "Have", "JS Property" , "Assert", "Expect" })]
+public class ExpectToHaveJSPropertyActorComponent : PlaywrightActorComponent
+{
+    [DataMember(IsRequired = true)]
+    [Display(Name = "Name", GroupName = "Configuration", Order = 10, Description = "Input argument for name of js property")]
+    public Argument PropertyName { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default };
+
+    [DataMember(IsRequired = true)]
+    [Display(Name = "Value", GroupName = "Configuration", Order = 20, Description = "Input argument for value of js property")]
+    public Argument PropertyValue { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default };
+
+    [DataMember]
+    [Display(Name = "Js Property Options", GroupName = "Configuration", Order = 30, Description = "[Optional] Input argument for LocatorAssertionsToHaveJSPropertyOptions")]
+    public Argument ToHaveJsPropertyOptions { get; set; } = new InArgument<LocatorAssertionsToHaveJSPropertyOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToHaveJSPropertyActorComponent() : base("Expect To Have JS Property", "ExpectToHaveJSProperty")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensures that <see cref="ILocator"/> points to an element with given JavaScript property
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await GetTargetControl();
+        var name = await this.ArgumentProcessor.GetValueAsync<string>(this.PropertyName);
+        var value = await this.ArgumentProcessor.GetValueAsync<string>(this.PropertyValue);
+        var toHaveJsPropertyOptions = this.ToHaveJsPropertyOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToHaveJSPropertyOptions>(this.ToHaveJsPropertyOptions) : null;
+        await Assertions.Expect(control).ToHaveJSPropertyAsync(name, value, toHaveJsPropertyOptions);
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveTextActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveTextActorComponent.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToHaveTextActorComponent"/> to ensure that <see cref="ILocator"/> points to an element with the given text.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Have Text", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to an element with the given text.", tags: new string[] { "To", "Have", "Text", "Assert", "Expect" })]
+public class ExpectToHaveTextActorComponent : PlaywrightActorComponent
+{
+    [DataMember]
+    [Display(Name = "Text", GroupName = "Configuration", Order = 10, Description = "Input argument for expected Text")]
+    [AllowedTypes(typeof(string), typeof(Regex), typeof(IEnumerable<string>), typeof(IEnumerable<Regex>))]
+    public Argument Text { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default, CanChangeType = true };
+
+    [DataMember]
+    [Display(Name = "To Have Text Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorAssertionsToHaveTextOptions")]
+    public Argument ToHaveTextOptions { get; set; } = new InArgument<LocatorAssertionsToHaveTextOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToHaveTextActorComponent() : base("Expect To Have Text", "ExpectToHaveText")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> points to an element with the given text.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();       
+        var options = this.ToHaveTextOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToHaveTextOptions>(this.ToHaveTextOptions) : null;      
+        switch (this.Text)
+        {
+            case InArgument<string>:
+                var text = await this.ArgumentProcessor.GetValueAsync<string>(this.Text);
+                await Assertions.Expect(control).ToHaveTextAsync(text, options);
+                break;
+            case InArgument<Regex>:
+                var regex = await this.ArgumentProcessor.GetValueAsync<Regex>(this.Text);
+                await Assertions.Expect(control).ToHaveTextAsync(regex, options);
+                break;
+            case InArgument<IEnumerable<string>>:
+                var textCollection = await this.ArgumentProcessor.GetValueAsync<IEnumerable<string>>(this.Text);
+                await Assertions.Expect(control).ToHaveTextAsync(textCollection, options);
+                break;
+            case InArgument<IEnumerable<Regex>>:
+                var regExCollection = await this.ArgumentProcessor.GetValueAsync<IEnumerable<Regex>>(this.Text);
+                await Assertions.Expect(control).ToHaveTextAsync(regExCollection, options);
+                break;
+        }
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveTitleActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveTitleActorComponent.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToHaveTitleActorComponent"/> to ensure the page has the given title.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Have Title", "Playwright", "Expect", iconSource: null, description: "Ensures the page has the given title.", tags: new string[] { "To", "Have", "Title", "Assert", "Expect" })]
+public class ExpectToHaveTitleActorComponent : PlaywrightActorComponent
+{
+    [DataMember(IsRequired = true)]
+    [Display(Name = "Title", GroupName = "Configuration", Order = 10, Description = "Input argument for title to look for")]
+    [AllowedTypes(typeof(string), typeof(Regex))]
+    public Argument Title { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default, CanChangeType = true };  
+
+    [DataMember]
+    [Display(Name = "Title Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for PageAssertionsToHaveTitleOptions")]
+    public Argument ToHaveTitleOptions { get; set; } = new InArgument<PageAssertionsToHaveTitleOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToHaveTitleActorComponent() : base("Expect To Have Title", "ExpectToHaveTitle")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure the page has the given title.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {        
+        var toHaveTitleOptions = this.ToHaveTitleOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<PageAssertionsToHaveTitleOptions>(this.ToHaveTitleOptions) : null;
+
+        switch (this.Title)
+        {
+            case InArgument<string>:
+                var title =  await this.ArgumentProcessor.GetValueAsync<string>(this.Title);
+                await Assertions.Expect(this.ApplicationDetails.ActivePage).ToHaveTitleAsync(title, toHaveTitleOptions);
+                break;
+            case InArgument<Regex>:
+                var regex = await this.ArgumentProcessor.GetValueAsync<Regex>(this.Title);
+                await Assertions.Expect(this.ApplicationDetails.ActivePage).ToHaveTitleAsync(regex, toHaveTitleOptions);
+                break;
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveUrlActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveUrlActorComponent.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToHaveUrlActorComponent"/> to ensure the page is navigated to the given URL..
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Have Url", "Playwright", "Expect", iconSource: null, description: "Check a checkbox or a radio button", tags: new string[] { "To", "Have", "Url", "Assert", "Expect" })]
+public class ExpectToHaveUrlActorComponent : PlaywrightActorComponent
+{
+    [DataMember(IsRequired = true)]
+    [Display(Name = "Url", GroupName = "Configuration", Order = 10, Description = "Input argument for url to look for")]
+    [AllowedTypes(typeof(string), typeof(Regex))]
+    public Argument Url { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default , CanChangeType = true };
+  
+    [DataMember]
+    [Display(Name = "To Have Url Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for PageAssertionsToHaveURLOptions")]
+    public Argument ToHaveUrlOptions { get; set; } = new InArgument<PageAssertionsToHaveURLOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToHaveUrlActorComponent() : base("Expect To Have Url", "ExpectToHaveUrl")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensures the page is navigated to the given URL.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {       
+        var toHaveUrlOptions = this.ToHaveUrlOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<PageAssertionsToHaveURLOptions>(this.ToHaveUrlOptions) : null;
+        
+        switch (this.Url)
+        {
+            case InArgument<string>:
+                var title = await this.ArgumentProcessor.GetValueAsync<string>(this.Url);
+                await Assertions.Expect(this.ApplicationDetails.ActivePage).ToHaveURLAsync(title, toHaveUrlOptions);
+                break;
+            case InArgument<Regex>:
+                var regex = await this.ArgumentProcessor.GetValueAsync<Regex>(this.Url);
+                await Assertions.Expect(this.ApplicationDetails.ActivePage).ToHaveURLAsync(regex, toHaveUrlOptions);
+                break;
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveValueActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveValueActorComponent.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToHaveValueActorComponent"/> to ensure that <see cref="ILocator"/> points to an element with the given input value.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Have Value", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to an element with the given input value.", tags: new string[] { "To", "Have", "Value", "Assert", "Expect" })]
+public class ExpectToHaveValueActorComponent : PlaywrightActorComponent
+{
+    [DataMember]
+    [Display(Name = "Value", GroupName = "Configuration", Order = 10, Description = "Input argument for expected Value")]
+    [AllowedTypes(typeof(string), typeof(Regex))]
+    public Argument Value { get; set; } = new InArgument<string>() { Mode = ArgumentMode.Default, CanChangeType = true };
+
+    [DataMember]
+    [Display(Name = "To Have Value Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorAssertionsToHaveValueOptions")]
+    public Argument ToHaveValueOptions { get; set; } = new InArgument<LocatorAssertionsToHaveValueOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToHaveValueActorComponent() : base("Expect To Have Value", "ExpectToHaveValue")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> points to an element with the given input value..
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();       
+        var options = this.ToHaveValueOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToHaveValueOptions>(this.ToHaveValueOptions) : null;      
+        switch (this.Value)
+        {
+            case InArgument<string>:
+                var value = await this.ArgumentProcessor.GetValueAsync<string>(this.Value);
+                await Assertions.Expect(control).ToHaveValueAsync(value, options);
+                break;
+            case InArgument<Regex>:
+                var regex = await this.ArgumentProcessor.GetValueAsync<Regex>(this.Value);
+                await Assertions.Expect(control).ToHaveValueAsync(regex, options);
+                break;           
+        }
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveValuesActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Asssertions/ExpectToHaveValuesActorComponent.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Playwright;
+using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Pixel.Automation.Web.Playwright.Components;
+
+/// <summary>
+/// Use <see cref="ExpectToHaveValuesActorComponent"/> to ensure that <see cref="ILocator"/> points to multi-select/combobox (i.e. a <c>select</c>
+/// with the <c>multiple</c> attribute) and the specified values are selected.
+/// </summary>
+[DataContract]
+[Serializable]
+[ToolBoxItem("To Have Values", "Playwright", "Expect", iconSource: null, description: "Ensures the ILocator points to multi-select/combobox (i.e. a <c>select</c> with the <c>multiple</c> attribute) and the specified values are selected" , tags: new string[] { "To", "Have", "Values", "Assert", "Expect" })]
+public class ExpectToHaveValuesActorComponent : PlaywrightActorComponent
+{
+    [DataMember]
+    [Display(Name = "Values", GroupName = "Configuration", Order = 10, Description = "Input argument for expected Values")]
+    [AllowedTypes(typeof(IEnumerable<string>), typeof(IEnumerable<Regex>))]
+    public Argument Values { get; set; } = new InArgument<IEnumerable<string>>() { Mode = ArgumentMode.DataBound, CanChangeType = true };
+
+    [DataMember]
+    [Display(Name = "To Have Value Options", GroupName = "Configuration", Order = 20, Description = "[Optional] Input argument for LocatorAssertionsToHaveValuesOptions")]
+    public Argument ToHaveValuesOptions { get; set; } = new InArgument<LocatorAssertionsToHaveValuesOptions>() { AllowedModes = ArgumentMode.DataBound | ArgumentMode.Scripted, Mode = ArgumentMode.DataBound };
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public ExpectToHaveValuesActorComponent() : base("Expect To Have Values", "ExpectToHaveValues")
+    {
+
+    }
+
+    /// <summary>
+    /// Ensure that <see cref="ILocator"/> points to multi-select/combobox (i.e. a <c>select</c> with the <c>multiple</c> attribute) and the specified values are selected.
+    /// </summary>
+    /// <returns></returns>
+    public override async Task ActAsync()
+    {
+        var control = await this.GetTargetControl();       
+        var options = this.ToHaveValuesOptions.IsConfigured() ? await this.ArgumentProcessor.GetValueAsync<LocatorAssertionsToHaveValuesOptions>(this.ToHaveValuesOptions) : null;      
+        switch (this.Values)
+        {
+            case InArgument<IEnumerable<string>>:
+                var values = await this.ArgumentProcessor.GetValueAsync<IEnumerable<string>>(this.Values);
+                await Assertions.Expect(control).ToHaveValuesAsync(values, options);
+                break;
+            case InArgument<IEnumerable<Regex>>:
+                var valuesRegex = await this.ArgumentProcessor.GetValueAsync<IEnumerable<Regex>>(this.Values);
+                await Assertions.Expect(control).ToHaveValuesAsync(valuesRegex, options);
+                break;           
+        }
+    }
+}
+

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/SelectOptionsActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/SelectOptionsActorComponent.cs
@@ -31,7 +31,8 @@ public class SelectOptionsActorComponent : PlaywrightActorComponent
     /// </summary>
     [DataMember]
     [Display(Name = "Values", GroupName = "Configuration", Order = 20, Description = "one or more values to select")]
-    public Argument Values { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound };
+    [AllowedTypes(typeof(string), typeof(IEnumerable<string>), typeof(SelectOptionValue), typeof(IEnumerable<SelectOptionValue>), typeof(IElementHandle), typeof(IEnumerable<IElementHandle>))]
+    public Argument Values { get; set; } = new InArgument<string>() { Mode = ArgumentMode.DataBound, CanChangeType = true };
 
 
     /// <summary>

--- a/src/Pixel.Automation.Web.Playwright.Components/Pixel.Automation.Web.Playwright.Components.csproj
+++ b/src/Pixel.Automation.Web.Playwright.Components/Pixel.Automation.Web.Playwright.Components.csproj
@@ -11,7 +11,7 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Dawn.Guard" Version="1.12.0" >
+		<PackageReference Include="Dawn.Guard" Version="1.12.0">
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>	
 		<PackageReference Include="Serilog" Version="2.11.0">
@@ -27,7 +27,7 @@
 		<ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
 			<Private>false</Private>
 		</ProjectReference>
-		<ProjectReference Include="..\Pixel.Automation.Web.Common\Pixel.Automation.Web.Common.csproj" >
+		<ProjectReference Include="..\Pixel.Automation.Web.Common\Pixel.Automation.Web.Common.csproj">
 			<Private>false</Private>
 		</ProjectReference>
 	</ItemGroup>


### PR DESCRIPTION
**Description**
1. Added actor components in Playwright to support the Expect api provided by Playwright. 
2. It is possible now to decorate an argument with AllowedTypesAttribute which will allow selecting only predefined types in the argument browser while trying to change the argument type.