### PR TITLE
ShadowDom support for Selenium and fixed FindAllControls implementation

### DIFF
--- a/src/Pixel.Automation.Core/Interfaces/IControlIdentity.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IControlIdentity.cs
@@ -9,89 +9,62 @@ namespace Pixel.Automation.Core.Interfaces
     /// Captures the details of a control that can be used to locate it at runtime
     /// </summary>
     public interface IControlIdentity : ICloneable
-    {      
+    {
         /// <summary>
         /// Identifier of the owner application
         /// </summary>
-        string ApplicationId
-        {
-            get;
-            set;
-        }
+        string ApplicationId { get; set; }       
 
         /// <summary>
         /// Name of the control
         /// </summary>
-        string Name
-        {
-            get;
-            set;
-        }        
-      
+        string Name { get; set; }       
+
         /// <summary>
         /// Number of times to retry if control can't be located in first attempt
         /// </summary>
-        int RetryAttempts
-        {
-            get;
-            set;
-        }
-
+        int RetryAttempts { get; set; }
+       
         /// <summary>
         /// Interval in seconds between each retry attempt
         /// </summary>
-        int RetryInterval
-        {
-            get;
-            set;
-        }
+        int RetryInterval { get; set; }    
 
         /// <summary>
         /// Reference point on control realtive to which mouse operations are performed.       
         /// </summary>
-        Pivots PivotPoint
-        {
-            get;
-            set;
-        }
-
+        Pivots PivotPoint { get; set; }
+      
         /// <summary>
         /// Offset on x-axis from Pivot Point
         /// </summary>
-        double XOffSet
-        {
-            get;
-            set;
-        }
-
+        double XOffSet { get; set; }
+        
         /// <summary>
         /// Offset on y-axis from Pivot Point
         /// </summary>
-        double YOffSet
-        {
-            get;
-            set;
-        }
+        double YOffSet { get; set; }
 
         /// <summary>
         /// Controls how the control lookup will be performed by <see cref="IControlLocator{T}"/>
         /// </summary>
-        LookupType LookupType
-        {
-            get;
-            set;
-        }
+        LookupType LookupType { get; set; }
+
+        /// <summary>
+        /// Configure the scope for searching the control relative to root search context
+        /// </summary>
+        SearchScope SearchScope { get; set; }
 
         /// <summary>
         /// Get the Name of the control
         /// </summary>
         /// <returns></returns>
-        string GetControlName();        
+        string GetControlName();
 
         /// <summary>
         /// For nested navigation
         /// </summary>
-        IControlIdentity  Next
+        IControlIdentity Next
         {
             get; set;
         }

--- a/src/Pixel.Automation.Web.Selenium.Components/Pixel.Automation.Web.Selenium.Components.csproj
+++ b/src/Pixel.Automation.Web.Selenium.Components/Pixel.Automation.Web.Selenium.Components.csproj
@@ -32,7 +32,7 @@
 		<PackageReference Include="System.Dynamic.Runtime" Version="4.3.0">
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Selenium.Support" Version="4.3.0" />	
+		<PackageReference Include="Selenium.Support" Version="4.4.0" />	
 		<PackageReference Include="Selenium.WebDriver" Version="4.4.0" />
 	</ItemGroup>
 

--- a/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/MockControlIdentity.cs
+++ b/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/MockControlIdentity.cs
@@ -16,7 +16,8 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         public double XOffSet { get; set; }
         public double YOffSet { get; set; }
         public LookupType LookupType { get; set; }
-        public IControlIdentity Next { get; set; }
+        public SearchScope SearchScope { get; set; }
+        public IControlIdentity Next { get; set; }      
 
         public object Clone()
         {
@@ -31,7 +32,8 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
                 PivotPoint = this.PivotPoint,
                 XOffSet = this.XOffSet,
                 YOffSet = this.YOffSet,
-                LookupType = this.LookupType
+                LookupType = this.LookupType,
+                SearchScope = this.SearchScope
             };
         }
 

--- a/src/Unit.Tests/Pixel.Automation.Web.Selenium.Components.Tests/WebControlLocatorComponentTests.cs
+++ b/src/Unit.Tests/Pixel.Automation.Web.Selenium.Components.Tests/WebControlLocatorComponentTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using OpenQA.Selenium;
 using Pixel.Automation.Core.Interfaces;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -27,6 +28,7 @@ namespace Pixel.Automation.Web.Selenium.Components.Tests
 
             webDriver.FindElement(Arg.Any<By>()).Returns(controlOne);
 
+            (webDriver as IJavaScriptExecutor).ExecuteScript(Arg.Any<string>(), Arg.Any<object[]>()).Returns(false);
             (webDriver as IJavaScriptExecutor).ExecuteScript(Arg.Any<string>(), Arg.Any<ISearchContext>(), Arg.Any<string>()).Returns(new System.Collections.ObjectModel.ReadOnlyCollection<IWebElement>(new[] { controlOne, controlTwo }));
 
             WebApplication webapplication = new WebApplication()
@@ -393,8 +395,15 @@ namespace Pixel.Automation.Web.Selenium.Components.Tests
             var controlIdentity = new WebControlIdentity()
             {
                 SearchScope = searchScope,
-                Identifier = "sbformq",
-                FindByStrategy = "Id"              
+                Identifier = "form",
+                FindByStrategy = "Id",
+                Index = 2,
+                Next = new WebControlIdentity()
+                {
+                    SearchScope = Core.Enums.SearchScope.Descendants,
+                    Identifier = "input",
+                    FindByStrategy = "Id"                    
+                }                
             };
 
             switch (searchScope)
@@ -403,7 +412,7 @@ namespace Pixel.Automation.Web.Selenium.Components.Tests
                     var locatedControls = await webControlLocator.FindAllControlsAsync(controlIdentity);
                     Assert.IsNotNull(locatedControls);
                     Assert.AreEqual(2, locatedControls.Count());
-                    webDriver.Received(1).FindElements(Arg.Any<By>());
+                    webDriver.Received(2).FindElements(Arg.Any<By>());
                     break;
                 case Core.Enums.SearchScope.Children:
                 case Core.Enums.SearchScope.Ancestor:


### PR DESCRIPTION
**Description**
1. While looking up the control, control locator will check if the current search scope has a shadow root and automatically retrieve shadow root for control lookup. Unfortunately, scraping doesn't support controls within shadow dom.
2. Fixed issue with FindAllControlsAsync implementation as it will find only root element of a control identity. It should start looking from root and end up finding the last configured node instead.