### PR TITLE
Refresh UI to show new display name after editing a test case or fixture.

### DIFF
--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
@@ -202,6 +202,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                 bool? result = await this.windowManager.ShowDialogAsync(testFixtureEditor);
                 if (result.HasValue && result.Value)
                 {
+                    fixtureVM.Refresh();
                     SaveTestFixture(fixtureVM, false);
                     logger.Information("Edited fixture {0}", fixtureVM.DisplayName);
                 }
@@ -524,6 +525,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                 bool? result = await this.windowManager.ShowDialogAsync(testCaseEditor);
                 if (result.HasValue && result.Value)
                 {
+                    testCaseVM.Refresh();
                     if (testCaseVM.IsOpenForEdit)
                     {
                         testCaseVM.TestCaseEntity.Name = testCaseVM.DisplayName;


### PR DESCRIPTION
**Description**
Editing name of a test case or test fixture applies the  change but the test explorer UI doesn't refresh to show the new display name. This is fixed now.