### PR TITLE
Remove ToString() overrides from actor components

### DIFF
--- a/src/Pixel.Automation.Core.Components/Applications/AttachApplicationActorComponent.cs
+++ b/src/Pixel.Automation.Core.Components/Applications/AttachApplicationActorComponent.cs
@@ -138,9 +138,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             await Task.CompletedTask;
         }
 
-        public override string ToString()
-        {
-            return "Attach Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Core.Components/Applications/CloseApplicationActorComponent.cs
+++ b/src/Pixel.Automation.Core.Components/Applications/CloseApplicationActorComponent.cs
@@ -46,11 +46,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             await applicationEntity.CloseAsync();
         }
 
-        public override string ToString()
-        {
-            return "Close Application Actor";
-        }
-
-       
     }
 }

--- a/src/Pixel.Automation.Core.Components/Applications/LaunchApplicationActorComponent.cs
+++ b/src/Pixel.Automation.Core.Components/Applications/LaunchApplicationActorComponent.cs
@@ -44,9 +44,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             await this.ApplicationEntity.LaunchAsync();
         }
 
-        public override string ToString()
-        {
-            return "Launch Application Actor";
-        }        
     }
 }

--- a/src/Pixel.Automation.Input.Devices.Components/Keyboard/HotKeyActorComponent.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/Keyboard/HotKeyActorComponent.cs
@@ -67,9 +67,5 @@ namespace Pixel.Automation.Input.Devices.Components
             return IsValid && base.ValidateComponent();
         }
 
-        public override string ToString()
-        {
-            return "Hot Key Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Input.Devices.Components/Keyboard/KeyPressActorComponent.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/Keyboard/KeyPressActorComponent.cs
@@ -97,9 +97,5 @@ namespace Pixel.Automation.Input.Devices.Components
             return IsValid && base.ValidateComponent();
         }
 
-        public override string ToString()
-        {
-            return "Key Press Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Input.Devices.Components/Keyboard/TypeTextActorComponent.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/Keyboard/TypeTextActorComponent.cs
@@ -46,9 +46,5 @@ namespace Pixel.Automation.Input.Devices.Components
             await Task.CompletedTask;
         }
 
-        public override string ToString()
-        {
-            return "Type Text Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Input.Devices.Components/Mouse/DragDropActorComponent.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/Mouse/DragDropActorComponent.cs
@@ -102,7 +102,7 @@ namespace Pixel.Automation.Input.Devices.Components
         /// <summary>
         /// Default constructor
         /// </summary>
-        public DragDropActorComponent() : base("Mouse Drag", "MouseDrag")
+        public DragDropActorComponent() : base("Drag Drop", "DragDrop")
         {
             
         }
@@ -165,10 +165,5 @@ namespace Pixel.Automation.Input.Devices.Components
             return IsValid && base.ValidateComponent();
         }
 
-
-        public override string ToString()
-        {
-            return "Drag Drop Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Input.Devices.Components/Mouse/MouseClickActorComponent.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/Mouse/MouseClickActorComponent.cs
@@ -187,9 +187,5 @@ namespace Pixel.Automation.Input.Devices.Components
             return IsValid && base.ValidateComponent();
         }
 
-        public override string ToString()
-        {
-            return "Mouse Click Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Input.Devices.Components/Mouse/MouseMoveByActorComponent.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/Mouse/MouseMoveByActorComponent.cs
@@ -37,7 +37,7 @@ namespace Pixel.Automation.Input.Devices.Components
         /// <summary>
         /// Default constructor
         /// </summary>
-        public MouseMoveByActorComponent() : base("Move By", "MoveBy")
+        public MouseMoveByActorComponent() : base("Mouse Move By", "MouseMoveBy")
         {
         }
 
@@ -53,9 +53,5 @@ namespace Pixel.Automation.Input.Devices.Components
             await Task.CompletedTask;
         }
 
-        public override string ToString()
-        {
-            return "Mouse Move By Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Input.Devices.Components/Mouse/MouseOverActorComponent.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/Mouse/MouseOverActorComponent.cs
@@ -124,9 +124,5 @@ namespace Pixel.Automation.Input.Devices.Components
             return IsValid && base.ValidateComponent();
         }
 
-        public override string ToString()
-        {
-            return "Mouse Over Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Input.Devices.Components/Mouse/ScrollActorComponent.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/Mouse/ScrollActorComponent.cs
@@ -68,9 +68,5 @@ namespace Pixel.Automation.Input.Devices.Components
             await Task.CompletedTask;
         }
 
-        public override string ToString()
-        {
-            return "Scroll Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/ClickActorComponent.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/ClickActorComponent.cs
@@ -57,9 +57,5 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
             throw new InvalidOperationException($"Control: {this.TargetControl} doesn't support cAccessibleTextInterface.");
         }
 
-        public override string ToString()
-        {
-            return "Click Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/GetTextActorComponent.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/GetTextActorComponent.cs
@@ -65,12 +65,6 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
             throw new InvalidOperationException($"Control: {this.TargetControl} doesn't support cAccessibleTextInterface.");
         }
 
-
-        public override string ToString()
-        {
-            return "Get Text Actor";
-        }
-
         //private static string MakePrintable(string text)
         //{
         //    var sb = new StringBuilder();

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/GetValueActorComponent.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/GetValueActorComponent.cs
@@ -55,9 +55,5 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
             throw new InvalidOperationException($"Control: {this.TargetControl} doesn't support cAccessibleValueInterface.");
         }
 
-        public override string ToString()
-        {
-            return "Get Value Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/SelectListItemActorComponent.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/SelectListItemActorComponent.cs
@@ -122,9 +122,5 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
             //targetControl.AccessBridge.Functions.AddAccessibleSelectionFromContext(targetControl.JvmId, targetControl.AccessibleContextHandle, targetIndex);
         }
 
-        public override string ToString()
-        {
-            return "Select List Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/SetTextActorComponent.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/SetTextActorComponent.cs
@@ -51,9 +51,5 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
             throw new InvalidOperationException($"Control doesn't support cAccessibleTextInterface.");
         }
 
-        public override string ToString()
-        {
-            return "Set Text Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/ToggleStateActorComponent.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/ToggleStateActorComponent.cs
@@ -60,9 +60,5 @@ namespace Pixel.Automation.Java.Access.Bridge.Components.ActorComponents
             throw new InvalidOperationException($"Control doesn't support cAccessibleTextInterface.");
         }
 
-        public override string ToString()
-        {
-            return "Toggle State Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Scripting.Components/ExecuteInlineScriptActorComponent.cs
+++ b/src/Pixel.Automation.Scripting.Components/ExecuteInlineScriptActorComponent.cs
@@ -32,7 +32,7 @@ namespace Pixel.Automation.Scripting.Components
             }
         }
 
-        public ExecuteInlineScriptActorComponent() : base("Script", "ExecuteInlineScript")
+        public ExecuteInlineScriptActorComponent() : base("Execute Inline Script", "ExecuteInlineScript")
         {           
         }
 

--- a/src/Pixel.Automation.Scripting.Components/ExecuteScriptActorComponent.cs
+++ b/src/Pixel.Automation.Scripting.Components/ExecuteScriptActorComponent.cs
@@ -15,7 +15,7 @@ namespace Pixel.Automation.Scripting.Components
     [Serializable]
     [Scriptable("ScriptFile")]
     [Initializer(typeof(ScriptFileInitializer))]
-    [ToolBoxItem("Execute [Editor]", "Scripting", iconSource: null, description: "Execute any provided script", tags: new string[] { "Scripted Action", "Scripting" })]   
+    [ToolBoxItem("Execute [File]", "Scripting", iconSource: null, description: "Execute any provided script", tags: new string[] { "Scripted Action", "Scripting" })]   
     public class ExecuteScriptActorComponent : ActorComponent
     {
         protected string scriptFile;
@@ -32,7 +32,7 @@ namespace Pixel.Automation.Scripting.Components
             }
         }
 
-        public ExecuteScriptActorComponent() : base("Script", "ExecuteScript")
+        public ExecuteScriptActorComponent() : base("Execute Script", "ExecuteScript")
         {
 
         }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/CollapseActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/CollapseActorComponent.cs
@@ -42,10 +42,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             logger.Information("Control was collapsed.");
         }
 
-        public override string ToString()
-        {
-            return "Collapse Actor";
-        }
-
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/ExpandActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/ExpandActorComponent.cs
@@ -43,9 +43,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             logger.Information("Control was expanded.");
         }
 
-        public override string ToString()
-        {
-            return "Expand Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/GetValueActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/GetValueActorComponent.cs
@@ -48,9 +48,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             logger.Information("Value of control was retrieved.");
         }
 
-        public override string ToString()
-        {
-            return "Get Value Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/InvokeActionComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/InvokeActionComponent.cs
@@ -22,7 +22,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         /// <summary>
         /// Default constructor
         /// </summary>
-        public InvokeActorComponent():base("Invoke","Invoke")
+        public InvokeActorComponent():base("Invoke", "Invoke")
         {
 
         }
@@ -37,9 +37,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             logger.Information("Invoke performed on control.");
         }
 
-        public override string ToString()
-        {
-            return "Invoke Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/MoveActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/MoveActorComponent.cs
@@ -49,9 +49,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             logger.Information($"Control was moved to position : ({newPosition.XCoordinate}, {newPosition.YCoordinate})");
         }
 
-        public override string ToString()
-        {
-            return "Move Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/ResizeActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/ResizeActorComponent.cs
@@ -55,10 +55,6 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             control.ResizeTo(width, height);
             logger.Information($"Control was resized to ({width}, {height})");
         }
-
-        public override string ToString()
-        {
-            return "Resize Actor";
-        }
+               
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/RotateActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/RotateActorComponent.cs
@@ -32,7 +32,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         /// <summary>
         /// Default constructor
         /// </summary>
-        public RotateActorComponent() : base("Rotate","Rotate")
+        public RotateActorComponent() : base("Rotate", "Rotate")
         {
 
         }
@@ -49,9 +49,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             logger.Information($"Control was rotated by {rotateBy} degrees.");
         }
 
-        public override string ToString()
-        {
-            return "Rotate Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/ScrollToElementActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/ScrollToElementActorComponent.cs
@@ -22,7 +22,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         /// <summary>
         /// Default constructor
         /// </summary>
-        public ScrollToActorComponent() : base("Scroll To", "ScrollTo")
+        public ScrollToActorComponent() : base("Scroll To Element", "ScrollToElement")
         {
 
         }
@@ -38,9 +38,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             logger.Information("Control was scrolled in to view.");
         }
 
-        public override string ToString()
-        {
-            return "Scroll To Control Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/ScrollViewActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/ScrollViewActorComponent.cs
@@ -40,7 +40,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         /// <summary>
         /// Default constructor
         /// </summary>
-        public ScrollViewActorComponent() : base("Scroll", "Scroll")
+        public ScrollViewActorComponent() : base("Scroll View", "ScrollView")
         {
 
         }
@@ -57,11 +57,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             control.ScrollToPercent(horizontalScrollAmount, verticalScrollAmount);
             logger.Information($"Scroll set to {horizontalScrollAmount}%, {verticalScrollAmount}%");
         }
-
-        public override string ToString()
-        {
-            return "Scroll View Actor";
-        }
-
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/SelectControlActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/SelectControlActorComponent.cs
@@ -60,9 +60,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             }
         }
 
-        public override string ToString()
-        {
-            return "Select Control Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/SelectListItemActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/SelectListItemActorComponent.cs
@@ -120,10 +120,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             }
         }
 
-        public override string ToString()
-        {
-            return "Select List Actor";
-        }
-
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/SetFocusActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/SetFocusActorComponent.cs
@@ -36,9 +36,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             logger.Information("Focus was set on control.");
         }
 
-        public override string ToString()
-        {
-            return "Set Focus Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/SetValueActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/SetValueActorComponent.cs
@@ -48,9 +48,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             logger.Information("Value was set on control.");
         }
 
-        public override string ToString()
-        {
-            return "Set Value Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/ToggleStateActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/ToggleStateActorComponent.cs
@@ -21,7 +21,7 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
         /// <summary>
         /// Default constructor
         /// </summary>
-        public ToggleStateActorComponent() : base("Toggle", "Toggle")
+        public ToggleStateActorComponent() : base("Toggle State", "ToggleState")
         {
 
         }
@@ -36,9 +36,5 @@ namespace Pixel.Automation.UIA.Components.ActorComponents
             logger.Information("State of the control was toggled.");
         }
 
-        public override string ToString()
-        {
-            return "Toggle State Actor";
-        }
     }
 }

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Browser/GoBackActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Browser/GoBackActorComponent.cs
@@ -28,7 +28,7 @@ public class GoBackActorComponent : PlaywrightActorComponent
     /// <summary>
     /// Constructor
     /// </summary>
-    public GoBackActorComponent():base("GoBack", "GoBack")
+    public GoBackActorComponent():base("Go Back", "GoBack")
     {
 
     }

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Browser/GoForwardActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Browser/GoForwardActorComponent.cs
@@ -28,7 +28,7 @@ public class GoForwardActorComponent : PlaywrightActorComponent
     /// <summary>
     /// Constructor
     /// </summary>
-    public GoForwardActorComponent():base("GoForward", "GoForward")
+    public GoForwardActorComponent():base("Go Forward", "GoForward")
     {
 
     }

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Browser/SetActivePageActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/Browser/SetActivePageActorComponent.cs
@@ -23,7 +23,7 @@ public class SetActivePageActorComponent : PlaywrightActorComponent
     /// <summary>
     /// Constructor
     /// </summary>
-    public SetActivePageActorComponent() : base("SetActivePage", "SetActivePage")
+    public SetActivePageActorComponent() : base("Set Active Page", "SetActivePage")
     {
 
     }


### PR DESCRIPTION
**Description**
The base class "Component" provides a more rich information including name, tag and isenabled state of the component. It makes more sense to remove these overrides from ActorComponents which provides less information compared to the base implementation.