### PR TITLE
Removed JsonIgnore attribute from PrefabEntity->Components

### DIFF
--- a/src/Pixel.Automation.Core.Components/Pixel.Automation.Core.Components.csproj
+++ b/src/Pixel.Automation.Core.Components/Pixel.Automation.Core.Components.csproj
@@ -20,10 +20,7 @@
 	<ItemGroup>
 		<PackageReference Include="Dawn.Guard" Version="1.12.0" >
 			<IncludeAssets>compile</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1">
-			<IncludeAssets>compile</IncludeAssets>
-		</PackageReference>		
+		</PackageReference>	
 		<PackageReference Include="Serilog" Version="2.11.0">
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>

--- a/src/Pixel.Automation.Core.Components/Prefabs/PrefabEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Prefabs/PrefabEntity.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Pixel.Automation.Core.Attributes;
+﻿using Pixel.Automation.Core.Attributes;
 using Pixel.Automation.Core.Interfaces;
 using Serilog;
 using System;
@@ -81,8 +80,7 @@ namespace Pixel.Automation.Core.Components.Prefabs
         [NonSerialized]
         private Entity prefabEntity;
 
-        [IgnoreDataMember] // TODO : Revisit this. Doesn't work with overriden property. 
-        [JsonIgnore]
+        [IgnoreDataMember]
         [Browsable(false)]
         public override List<IComponent> Components
         {
@@ -120,13 +118,18 @@ namespace Pixel.Automation.Core.Components.Prefabs
 
         public override async Task OnCompletionAsync()
         {
-            IScriptEngine scriptEngine = this.EntityManager.GetScriptEngine();
-            var outputMappingAction = await scriptEngine.CreateDelegateAsync<Action<object>>(this.OutputMappingScriptFile);
-            outputMappingAction.Invoke(prefabDataModel);
-            logger.Information($"Executed output mapping script : {this.OutputMappingScriptFile} for Prefab : {this.PrefabId}");
-
-            this.Components.Clear();
-            this.prefabDataModel = null;       
+            try
+            {
+                IScriptEngine scriptEngine = this.EntityManager.GetScriptEngine();
+                var outputMappingAction = await scriptEngine.CreateDelegateAsync<Action<object>>(this.OutputMappingScriptFile);
+                outputMappingAction.Invoke(prefabDataModel);
+                logger.Information($"Executed output mapping script : {this.OutputMappingScriptFile} for Prefab : {this.PrefabId}");             
+            }
+            finally
+            {
+                this.Components.Clear();
+                this.prefabDataModel = null;
+            }   
         }
 
         #region overridden methods


### PR DESCRIPTION
**Description**
Pixel.Automation.Core.Components project takes a dependency on Newtonsoft so mark Components property on PrefabEntity with JsonIgnore attribute. We don't want Components to be serialized hence this is necessary. However, we are setting this collection just before prefab entity is executed and clearing it after execution is completed in a finally block to guarantee this collection will be cleared. This should safeguard against serializing Components with any items in it unless someone saves the details while this is executing. Even if this gets serialized somehow , it should not matter as the Component collection will be cleared and loaded later from prefab.