### PR TITLE
Changing the name of control while editing a control using control editor should immediately update on UI

### DIFF
--- a/src/Pixel.Automation.Core/Controls/ControlIdentity.cs
+++ b/src/Pixel.Automation.Core/Controls/ControlIdentity.cs
@@ -23,11 +23,20 @@ namespace Pixel.Automation.Core.Controls
         [Browsable(false)]
         public string ApplicationId { get; set; }
 
+        private string name;
         /// <summary>
         /// Name of the control
         /// </summary>
         [DataMember(Order = 20)]
-        public string Name { get; set; }     
+        public string Name
+        {
+            get => name;
+            set
+            {
+                name = value;
+                OnPropertyChanged();
+            }
+        }
 
         #endregion General
 


### PR DESCRIPTION
**Description**
While editing the control using control editor, if we change the name of the control in property grid, the name doesn't update on the left side of the control list which lets us select the control to edit in property grid. We need to raise notification when the name changes so that the UI can update.