### PR TITLE
ITestCaseFileSystem should not inherit from  IFileSystem

### DIFF
--- a/src/Pixel.Automation.Core/FileSystem/FileSystem.cs
+++ b/src/Pixel.Automation.Core/FileSystem/FileSystem.cs
@@ -9,33 +9,48 @@ using System.IO;
 
 namespace Pixel.Automation.Core
 {
+    /// <summary>
+    /// Implementation of <see cref="IFileSystem"/>
+    /// </summary>
     public abstract class FileSystem : IFileSystem
     {
         protected readonly ISerializer serializer;
 
-        protected readonly ApplicationSettings applicationSettings;   
+        protected readonly ApplicationSettings applicationSettings;
 
+        /// <InheritDoc/>
         public string WorkingDirectory { get; protected set; }
 
+        /// <InheritDoc/>      
         public string ScriptsDirectory { get; protected set; }
 
+        /// <InheritDoc/>
         public string TempDirectory { get; protected set; }
 
+        /// <InheritDoc/>
         public string DataModelDirectory { get; protected set; }
 
+        /// <InheritDoc/>  
         public string ReferencesDirectory { get; protected set; }
 
+        /// <InheritDoc/>
         public string ControlReferencesFile { get; protected set; }
 
+        /// <InheritDoc/> 
         public AssemblyReferenceManager ReferenceManager { get; internal protected set; }
 
-
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="serializer"></param>
+        /// <param name="applicationSettings"></param>
         public FileSystem(ISerializer serializer, ApplicationSettings applicationSettings)
         {
             this.serializer = Guard.Argument(serializer).NotNull().Value;
             this.applicationSettings = Guard.Argument(applicationSettings).NotNull();
         }
 
+        /// <InheritDoc/>
         protected void Initialize()
         {
             if(String.IsNullOrEmpty(this.WorkingDirectory))
@@ -73,13 +88,15 @@ namespace Pixel.Automation.Core
             {
                 Directory.CreateDirectory(ReferencesDirectory);
             }
-        }               
+        }
 
+        /// <InheritDoc/>
         public T LoadFile<T>(string fileName) where T: new()
         {
             return this.serializer.Deserialize<T>(fileName);
         }
 
+        /// <InheritDoc/>
         public IEnumerable<T> LoadFiles<T>(string directory) where T : new()
         {
             var fileDescription = TypeDescriptor.GetAttributes(typeof(T))[typeof(FileDescriptionAttribute)] as FileDescriptionAttribute;
@@ -94,6 +111,7 @@ namespace Pixel.Automation.Core
             yield break;
         }
 
+        /// <InheritDoc/>
         public void SaveToFile<T>(T model, string directory) where T : new()
         {
             var fileDescription = TypeDescriptor.GetAttributes(typeof(T))[typeof(FileDescriptionAttribute)] as FileDescriptionAttribute;
@@ -108,6 +126,7 @@ namespace Pixel.Automation.Core
             }
         }
 
+        /// <InheritDoc/>
         public void SaveToFile<T>(T model, string directory, string fileName) where T : new()
         {
             if (!Directory.Exists(directory))
@@ -122,6 +141,7 @@ namespace Pixel.Automation.Core
             this.serializer.Serialize<T>(targetFile, model);           
         }
 
+        /// <InheritDoc/>
         public void CreateOrReplaceFile(string directory, string fileName, string content)
         {
             var targetFile = Path.Combine(directory, fileName);
@@ -135,28 +155,41 @@ namespace Pixel.Automation.Core
             }
         }
 
+        /// <InheritDoc/>
         public bool Exists(string path)
         {
             return File.Exists(path);
         }
 
+        /// <InheritDoc/>
         public string ReadAllText(string path)
         {
             return File.ReadAllText(path);
         }
 
+        /// <InheritDoc/>
         public string GetRelativePath(string path)
         {
             return Path.GetRelativePath(this.WorkingDirectory, path);
         }
     }
 
+    /// <summary>
+    /// Implementation of <see cref="IVersionedFileSystem"/>
+    /// </summary>
     public abstract class VersionedFileSystem : FileSystem, IVersionedFileSystem
     {
+        /// <InheritDoc/>
         public VersionInfo ActiveVersion { get; protected set; }
 
+        /// <InheritDoc/>
         public abstract void SwitchToVersion(VersionInfo versionInfo);
 
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="serializer"></param>
+        /// <param name="applicationSettings"></param>
         public VersionedFileSystem(ISerializer  serializer, ApplicationSettings applicationSettings) : base(serializer, applicationSettings)
         {
            

--- a/src/Pixel.Automation.Core/FileSystem/IFileSystem.cs
+++ b/src/Pixel.Automation.Core/FileSystem/IFileSystem.cs
@@ -237,8 +237,17 @@ namespace Pixel.Automation.Core.Interfaces
 
     }
 
-    public interface ITestCaseFileSystem : IFileSystem
+    /// <summary>
+    /// <see cref="ITestCaseFileSystem"/> is a simplified file system which only knows about the structure of the test fixtures and test cases and related assets.
+    /// However, it doesn't provide any methods to actually interact with the file system like <see cref="IFileSystem"/>
+    /// </summary>
+    public interface ITestCaseFileSystem
     {
+        /// <summary>
+        /// Working directory for the test case file system
+        /// </summary>
+        string WorkingDirectory { get; }
+
         /// <summary>
         /// Path of test fixture directory which contains test fixture file along with  test case file  test process file and test scripts for all tests belonging to it
         /// </summary>

--- a/src/Pixel.Automation.Core/FileSystem/PrefabFileSystem.cs
+++ b/src/Pixel.Automation.Core/FileSystem/PrefabFileSystem.cs
@@ -9,33 +9,47 @@ using System.Text.RegularExpressions;
 
 namespace Pixel.Automation.Core
 {
+    /// <summary>
+    /// Implementation of <see cref="IPrefabFileSystem"/>
+    /// </summary>
     public class PrefabFileSystem : VersionedFileSystem, IPrefabFileSystem
     {
         private string applicationId;
         private string prefabId;
 
+        /// <InheritDoc/>      
         public string PrefabDescriptionFile { get; private set; }
 
+        /// <InheritDoc/>      
         public string PrefabFile { get; private set; }
 
+        /// <InheritDoc/>      
         public string TemplateFile { get; private set; }
     
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="serializer"></param>
+        /// <param name="applicationSettings"></param>
         public PrefabFileSystem(ISerializer serializer, ApplicationSettings applicationSettings) : base(serializer, applicationSettings)
         {
 
         }
 
+        /// <InheritDoc/>      
         public void Initialize(PrefabProject prefabProject, VersionInfo versionInfo)
         {
             Guard.Argument(prefabProject).NotNull();
             this.Initialize(prefabProject.ApplicationId, prefabProject.PrefabId, versionInfo);
         }
 
+        /// <InheritDoc/>      
         public override void SwitchToVersion(VersionInfo version)
         {
             Initialize(this.applicationId, this.prefabId, version);
         }
 
+        /// <InheritDoc/>      
         void Initialize(string applicationId, string prefabId, VersionInfo versionInfo)
         {          
             this.applicationId = Guard.Argument(applicationId).NotNull().NotEmpty();
@@ -51,8 +65,9 @@ namespace Pixel.Automation.Core
 
             this.ReferenceManager = new AssemblyReferenceManager(this.applicationSettings, this.DataModelDirectory, this.ScriptsDirectory);
 
-        }     
+        }
 
+        /// <InheritDoc/>      
         public Entity GetPrefabEntity()
         {
             if (!File.Exists(this.PrefabFile))
@@ -61,8 +76,9 @@ namespace Pixel.Automation.Core
             }
             Entity prefabRoot = this.serializer.Deserialize<Entity>(PrefabFile);
             return prefabRoot;
-        }    
+        }
 
+        /// <InheritDoc/>      
         public Entity GetPrefabEntity(Assembly withDataModelAssembly)
         {
             if (!File.Exists(this.PrefabFile))
@@ -81,6 +97,7 @@ namespace Pixel.Automation.Core
             return prefabRoot;
         }
 
+        /// <InheritDoc/>      
         public Assembly GetDataModelAssembly()
         {
             var assemblyFiles = Directory.GetFiles(this.TempDirectory, "*.dll").Select(f => new FileInfo(Path.Combine(this.TempDirectory,f)));
@@ -88,11 +105,13 @@ namespace Pixel.Automation.Core
             return Assembly.LoadFrom(targetFile.FullName);          
         }
 
+        /// <InheritDoc/>      
         public bool HasDataModelAssemblyChanged()
         {
             return true;
         }
 
+        /// <InheritDoc/>      
         public void CreateOrReplaceTemplate(Entity templateRoot)
         {
             if(File.Exists(this.TemplateFile))
@@ -102,6 +121,7 @@ namespace Pixel.Automation.Core
             this.serializer.Serialize<Entity>(this.TemplateFile, templateRoot);
         }
 
+        /// <InheritDoc/>      
         public Entity GetTemplate()
         {
             if(File.Exists(this.TemplateFile))

--- a/src/Pixel.Automation.Core/FileSystem/ProjectFileSystem.cs
+++ b/src/Pixel.Automation.Core/FileSystem/ProjectFileSystem.cs
@@ -8,37 +8,54 @@ using System.IO;
 
 namespace Pixel.Automation.Core
 {
+    /// <summary>
+    /// Implementation of <see cref="IProjectFileSystem"/>
+    /// </summary>
     public class ProjectFileSystem : VersionedFileSystem, IProjectFileSystem
-    {       
+    {
+        /// <InheritDoc/>      
         public string ProjectId { get; private set; }
 
+        /// <InheritDoc/>      
         public string ProjectFile { get; private set; }
-        
+
+        /// <InheritDoc/>      
         public string ProcessFile { get; private set; }
 
+        /// <InheritDoc/>      
         public string PrefabReferencesFile { get; private set; }
 
+        /// <InheritDoc/>      
         public string TestCaseRepository { get; protected set; }
 
+        /// <InheritDoc/>      
         public string TestDataRepository { get; protected set; }
         
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="serializer"></param>
+        /// <param name="applicationSettings"></param>
         public ProjectFileSystem(ISerializer serializer, ApplicationSettings applicationSettings) 
             : base(serializer, applicationSettings)
         {
          
         }
 
+        /// <InheritDoc/>      
         public void Initialize(AutomationProject automationProject, VersionInfo versionInfo)
         {
             Guard.Argument(automationProject).NotNull();           
             this.Initialize(automationProject.ProjectId, versionInfo);
         }
 
+        /// <InheritDoc/>      
         public override void SwitchToVersion(VersionInfo versionInfo)
         {
             Initialize(this.ProjectId, versionInfo);
         }
 
+        /// <InheritDoc/>      
         void Initialize(string projectId, VersionInfo versionInfo)
         {
             this.ProjectId  = Guard.Argument(projectId).NotNull().NotEmpty();
@@ -64,18 +81,17 @@ namespace Pixel.Automation.Core
 
             this.ReferenceManager = new AssemblyReferenceManager(this.applicationSettings, this.DataModelDirectory, this.ScriptsDirectory);
 
-        }        
+        }
 
+        /// <InheritDoc/>      
         public ITestCaseFileSystem CreateTestCaseFileSystemFor(string testFixtureId)
         {
-            var fileSystem = new TestCaseFileSystem(this.serializer, this.applicationSettings)
-            {
-                ReferenceManager = this.ReferenceManager
-            };
+            var fileSystem = new TestCaseFileSystem();           
             fileSystem.Initialize(this.WorkingDirectory, testFixtureId);
             return fileSystem;
         }
 
+        /// <InheritDoc/>      
         public IEnumerable<TestDataSource> GetTestDataSources()
         {
             string repositoryFolder = this.TestDataRepository;

--- a/src/Pixel.Automation.Core/FileSystem/TestCaseFileSystem.cs
+++ b/src/Pixel.Automation.Core/FileSystem/TestCaseFileSystem.cs
@@ -3,21 +3,35 @@ using System.IO;
 
 namespace Pixel.Automation.Core
 {
-    public class TestCaseFileSystem : FileSystem, ITestCaseFileSystem
+    /// <summary>
+    /// Implementation of <see cref="ITestCaseFileSystem"/>
+    /// </summary>
+    public class TestCaseFileSystem : ITestCaseFileSystem
     {
+        /// <InheritDoc/>       
+        public string WorkingDirectory { get; private set; }
+
+        /// <InheritDoc/>      
         public string FixtureDirectory { get; private set; }
 
+        /// <InheritDoc/>      
         public string FixtureFile { get; private set; }
 
+        /// <InheritDoc/>      
         public string FixtureProcessFile { get; private set; }
 
+        /// <InheritDoc/>      
         public string FixtureScript { get; private set; }
 
-        public TestCaseFileSystem(ISerializer serializer, ApplicationSettings applicationSettings) : base(serializer, applicationSettings)
+        /// <summary>
+        /// constructor
+        /// </summary>
+        public TestCaseFileSystem()
         {
 
         }
 
+        /// <InheritDoc/>      
         public void Initialize(string projectWorkingDirectory, string testFixtureId)
         {
             this.WorkingDirectory = projectWorkingDirectory;
@@ -25,30 +39,32 @@ namespace Pixel.Automation.Core
             this.FixtureFile = Path.Combine(this.FixtureDirectory, $"{testFixtureId}.fixture");
             this.FixtureProcessFile = Path.Combine(this.FixtureDirectory, $"{testFixtureId}.proc");
             this.FixtureScript = Path.Combine(this.FixtureDirectory, $"{testFixtureId}.csx");
-            this.ScriptsDirectory = this.FixtureDirectory;
-            
+                      
             if (!Directory.Exists(FixtureDirectory))
             {
                 Directory.CreateDirectory(FixtureDirectory);
             }           
         }
 
+        /// <InheritDoc/>      
         public string GetTestCaseFile(string testCaseId)
         {
             return Path.Combine(FixtureDirectory, $"{testCaseId}.test");
         }
 
+        /// <InheritDoc/>      
         public string GetTestProcessFile(string testCaseId)
         {
             return Path.Combine(FixtureDirectory, $"{testCaseId}.proc"); ;
         }
 
+        /// <InheritDoc/>      
         public string GetTestScriptFile(string testCaseId)
         {
             return Path.Combine(FixtureDirectory, $"{testCaseId}.csx"); ;
         }
 
-      
+        /// <InheritDoc/>      
         public void DeleteTestCase(string testCaseId)
         {
             File.Delete(GetTestCaseFile(testCaseId));

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
@@ -6,8 +6,10 @@ using Pixel.Automation.Core.Components.TestCase;
 using Pixel.Automation.Core.Enums;
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.TestData;
+using Pixel.Automation.Editor.Core;
 using Pixel.Automation.Editor.Core.Interfaces;
 using Pixel.Automation.Editor.Core.Notfications;
+using Pixel.Scripting.Editor.Core;
 using Pixel.Scripting.Editor.Core.Contracts;
 using Serilog;
 using System;
@@ -18,9 +20,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
-using Pixel.Automation.Editor.Core.Helpers;
-using Pixel.Automation.Editor.Core;
-using Pixel.Scripting.Editor.Core;
 
 namespace Pixel.Automation.TestExplorer.ViewModels
 {
@@ -274,7 +273,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                         var fixtureEntityManager = fixtureVM.TestFixtureEntity.EntityManager;
                         IScriptEditorFactory editorFactory = fixtureEntityManager.GetServiceOfType<IScriptEditorFactory>();
                         editorFactory.AddProject(fixtureVM.Id, Array.Empty<string>(), typeof(EmptyModel));
-                        string fixtureScriptContent = testCaseFileSystem.ReadAllText(testCaseFileSystem.FixtureScript);
+                        string fixtureScriptContent = this.fileSystem.ReadAllText(testCaseFileSystem.FixtureScript);
                         editorFactory.AddDocument(fixtureVM.ScriptFile, fixtureVM.Id, fixtureScriptContent);
                     }                    
                    
@@ -438,11 +437,11 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                 ITestCaseFileSystem testCaseFileSystem = this.fileSystem.CreateTestCaseFileSystemFor(testFixtureVM.Id);
                 if (string.IsNullOrEmpty(testFixtureVM.ScriptFile))
                 {
-                    testFixtureVM.ScriptFile = testCaseFileSystem.GetRelativePath(testCaseFileSystem.FixtureScript);
-                    testCaseFileSystem.CreateOrReplaceFile(testCaseFileSystem.FixtureDirectory, Path.GetFileName(testFixtureVM.ScriptFile), string.Empty);
+                    testFixtureVM.ScriptFile = this.fileSystem.GetRelativePath(testCaseFileSystem.FixtureScript);
+                    this.fileSystem.CreateOrReplaceFile(testCaseFileSystem.FixtureDirectory, Path.GetFileName(testFixtureVM.ScriptFile), string.Empty);
                 }
 
-                testCaseFileSystem.SaveToFile<TestFixture>(testFixtureVM.TestFixture, testCaseFileSystem.FixtureDirectory, Path.GetFileName(testCaseFileSystem.FixtureFile));
+                this.fileSystem.SaveToFile<TestFixture>(testFixtureVM.TestFixture, testCaseFileSystem.FixtureDirectory, Path.GetFileName(testCaseFileSystem.FixtureFile));
               
                 if (saveFixtureEntity)
                 {
@@ -453,7 +452,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                         testEntity.Parent.RemoveComponent(testEntity);
                     }
 
-                    testCaseFileSystem.SaveToFile<Entity>(testFixtureVM.TestFixtureEntity, testCaseFileSystem.FixtureDirectory, Path.GetFileName(testCaseFileSystem.FixtureProcessFile));
+                    this.fileSystem.SaveToFile<Entity>(testFixtureVM.TestFixtureEntity, testCaseFileSystem.FixtureDirectory, Path.GetFileName(testCaseFileSystem.FixtureProcessFile));
 
                     //Add back the test cases that were removed earlier
                     foreach (var testEntity in testCaseEntities)
@@ -631,7 +630,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
 
                         //Add the test script project and script file to script editor
                         editorFactory.AddProject(testCaseVM.Id, new string[] { parentFixture.Id }, testEntityManager.Arguments.GetType());
-                        string scriptFileContent = testCaseFileSystem.ReadAllText(testCaseFileSystem.GetTestScriptFile(testCaseVM.Id));
+                        string scriptFileContent = this.fileSystem.ReadAllText(testCaseFileSystem.GetTestScriptFile(testCaseVM.Id));
                         editorFactory.AddDocument(testCaseVM.ScriptFile, testCaseVM.Id, scriptFileContent);
                     }                   
                 }
@@ -806,8 +805,8 @@ namespace Pixel.Automation.TestExplorer.ViewModels
             {
                 if (string.IsNullOrEmpty(testCaseVM.ScriptFile))
                 {
-                    testCaseVM.ScriptFile = testCaseFileSystem.GetRelativePath(testCaseFileSystem.GetTestScriptFile(testCaseVM.Id));
-                    testCaseFileSystem.CreateOrReplaceFile(testCaseFileSystem.FixtureDirectory, Path.GetFileName(testCaseVM.ScriptFile), string.Empty);
+                    testCaseVM.ScriptFile = this.fileSystem.GetRelativePath(testCaseFileSystem.GetTestScriptFile(testCaseVM.Id));
+                    this.fileSystem.CreateOrReplaceFile(testCaseFileSystem.FixtureDirectory, Path.GetFileName(testCaseVM.ScriptFile), string.Empty);
                 }
 
                 //e.g. while assigning test data source , test case is not open for edit and hence will have
@@ -825,10 +824,10 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                     }
                 }
 
-                testCaseFileSystem.SaveToFile<TestCase>(testCaseVM.TestCase, testCaseFileSystem.FixtureDirectory);
+                this.fileSystem.SaveToFile<TestCase>(testCaseVM.TestCase, testCaseFileSystem.FixtureDirectory);
                 if (saveTestEntity)
                 {
-                    testCaseFileSystem.SaveToFile<Entity>(testCaseVM.TestCaseEntity, testCaseFileSystem.FixtureDirectory, testCaseFileSystem.GetTestProcessFile(testCaseVM.Id));
+                    this.fileSystem.SaveToFile<Entity>(testCaseVM.TestCaseEntity, testCaseFileSystem.FixtureDirectory, testCaseFileSystem.GetTestProcessFile(testCaseVM.Id));
                 }
                 logger.Information("Changes to TestCase {0} were saved to local storage.", testCaseVM.DisplayName);
             }

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/FileSystem/TestCaseFileSystemFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/FileSystem/TestCaseFileSystemFixture.cs
@@ -17,7 +17,7 @@ namespace Pixel.Automation.Core.Tests.FileSystem
         {
             var serializer = Substitute.For<ISerializer>();
             appSettings = new ApplicationSettings() { IsOfflineMode = true, ApplicationDirectory = "Applications", AutomationDirectory = "Automations" };
-            testCaseFileSystem = new TestCaseFileSystem(serializer, appSettings);
+            testCaseFileSystem = new TestCaseFileSystem();
         }
 
         [OneTimeTearDown]

--- a/src/Unit.Tests/Pixel.Automation.TestExplorer.ViewModels.Tests/TestExplorerViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.TestExplorer.ViewModels.Tests/TestExplorerViewModelFixture.cs
@@ -85,12 +85,11 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
             scriptEditorFactory = Substitute.For<IScriptEditorFactory>();
             applicationSettings = new ApplicationSettings();
 
-            projectFileSystem.CreateTestCaseFileSystemFor(Arg.Any<string>()).Returns(testCaseFileSystem);
-            testCaseFileSystem.FixtureDirectory.Returns(Environment.CurrentDirectory);
-            testCaseFileSystem.GetRelativePath(Arg.Any<string>()).Returns(Path.Combine("FixureId", fixtureScriptFile));
-            testCaseFileSystem.When(x => x.CreateOrReplaceFile(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
-            testCaseFileSystem.When(x => x.SaveToFile<TestFixture>(Arg.Any<TestFixture>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
-            testCaseFileSystem.When(x => x.SaveToFile<Entity>(Arg.Any<Entity>(), Arg.Any<string>(), Arg.Any<string>())).Do
+            projectFileSystem.CreateTestCaseFileSystemFor(Arg.Any<string>()).Returns(testCaseFileSystem);           
+            projectFileSystem.GetRelativePath(Arg.Any<string>()).Returns(Path.Combine("FixureId", fixtureScriptFile));
+            projectFileSystem.When(x => x.CreateOrReplaceFile(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
+            projectFileSystem.When(x => x.SaveToFile<TestFixture>(Arg.Any<TestFixture>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
+            projectFileSystem.When(x => x.SaveToFile<Entity>(Arg.Any<Entity>(), Arg.Any<string>(), Arg.Any<string>())).Do
              (
                  x =>
                  {
@@ -102,11 +101,13 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
                      }
                  }
              );
+            projectFileSystem.ReadAllText(Arg.Is<string>(fixtureScriptFile)).Returns(string.Empty);
+
+
+            testCaseFileSystem.FixtureDirectory.Returns(Environment.CurrentDirectory);
             testCaseFileSystem.FixtureFile.Returns(fixtureFile);
             testCaseFileSystem.FixtureProcessFile.Returns(fixtureProcessFile);
             testCaseFileSystem.FixtureScript.Returns(fixtureScriptFile);
-            testCaseFileSystem.ReadAllText(Arg.Is<string>(fixtureScriptFile)).Returns(string.Empty);
-
 
             scriptEditorFactory.When(x => x.AddProject(Arg.Any<string>(), Arg.Is<string[]>(Array.Empty<string>()), Arg.Is<Type>(typeof(EmptyModel)))).Do(DoNothing);
             scriptEditorFactory.When(x => x.AddDocument(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
@@ -377,12 +378,12 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
             Assert.AreEqual(1, testCaseEntities.Count());
 
             projectFileSystem.Received(1).CreateTestCaseFileSystemFor(Arg.Is<string>(testFixtureViewModel.Id));
-            testCaseFileSystem.Received(1).GetRelativePath(Arg.Is<string>(fixtureScriptFile));
-            testCaseFileSystem.Received(1).CreateOrReplaceFile(Arg.Any<string>(), Arg.Is<string>(fixtureScriptFile), Arg.Is<string>(string.Empty));
-            testCaseFileSystem.Received(1).SaveToFile<TestFixture>(Arg.Any<TestFixture>(), Arg.Any<string>(), Arg.Is(fixtureFile));
+            projectFileSystem.Received(1).GetRelativePath(Arg.Is<string>(fixtureScriptFile));
+            projectFileSystem.Received(1).CreateOrReplaceFile(Arg.Any<string>(), Arg.Is<string>(fixtureScriptFile), Arg.Is<string>(string.Empty));
+            projectFileSystem.Received(1).SaveToFile<TestFixture>(Arg.Any<TestFixture>(), Arg.Any<string>(), Arg.Is(fixtureFile));
 
             int expectedWhenSaveFixtureEntity = shouldSaveFixtureEntity ? 1 : 0;
-            testCaseFileSystem.Received(expectedWhenSaveFixtureEntity).SaveToFile<Entity>(Arg.Any<Entity>(), Arg.Is(Environment.CurrentDirectory), Arg.Is(fixtureProcessFile));
+            projectFileSystem.Received(expectedWhenSaveFixtureEntity).SaveToFile<Entity>(Arg.Any<Entity>(), Arg.Is(Environment.CurrentDirectory), Arg.Is(fixtureProcessFile));
 
         }
       
@@ -426,14 +427,15 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
             scriptEditorFactory = Substitute.For<IScriptEditorFactory>();
             applicationSettings = new ApplicationSettings();
 
-            projectFileSystem.CreateTestCaseFileSystemFor(Arg.Any<string>()).Returns(testCaseFileSystem);
+            projectFileSystem.CreateTestCaseFileSystemFor(Arg.Any<string>()).Returns(testCaseFileSystem);         
+            projectFileSystem.GetRelativePath(Arg.Any<string>()).Returns(Path.Combine("FixtureId", testScriptFile));        
+            projectFileSystem.When(x => x.CreateOrReplaceFile(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
+            projectFileSystem.When(x => x.SaveToFile<TestCase>(Arg.Any<TestCase>(), Arg.Any<string>())).Do(DoNothing);
+            projectFileSystem.When(x => x.SaveToFile<Entity>(Arg.Any<Entity>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
+
             testCaseFileSystem.FixtureDirectory.Returns(Environment.CurrentDirectory);
-            testCaseFileSystem.GetRelativePath(Arg.Any<string>()).Returns(Path.Combine("FixtureId", testScriptFile));
             testCaseFileSystem.GetTestProcessFile(Arg.Any<string>()).Returns(testProcessFile);
             testCaseFileSystem.GetTestScriptFile(Arg.Any<string>()).Returns(Path.Combine(Environment.CurrentDirectory, "FixutreId", testScriptFile));
-            testCaseFileSystem.When(x => x.CreateOrReplaceFile(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
-            testCaseFileSystem.When(x => x.SaveToFile<TestCase>(Arg.Any<TestCase>(), Arg.Any<string>())).Do(DoNothing);
-            testCaseFileSystem.When(x => x.SaveToFile<Entity>(Arg.Any<Entity>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);          
 
             scriptEditorFactory.When(x => x.AddProject(Arg.Any<string>(), Arg.Is<string[]>(Array.Empty<string>()), Arg.Any<Type>())).Do(DoNothing);
             scriptEditorFactory.When(x => x.AddDocument(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
@@ -724,12 +726,12 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
 
             projectFileSystem.Received(1).CreateTestCaseFileSystemFor(Arg.Is<string>(fixtureViewModel.Id));     
             testCaseFileSystem.Received(1).GetTestScriptFile(Arg.Is<string>(testCaseViewModel.Id));
-            testCaseFileSystem.Received(1).GetRelativePath(Arg.Is<string>(Path.Combine(Environment.CurrentDirectory, "FixutreId", testScriptFile)));
-            testCaseFileSystem.Received(1).CreateOrReplaceFile(Arg.Is<string>(Environment.CurrentDirectory), Arg.Is<string>(Path.GetFileName(testCaseViewModel.ScriptFile)), Arg.Is<string>(string.Empty));
-            testCaseFileSystem.Received(1).SaveToFile<TestCase>(Arg.Is<TestCase>(testCaseViewModel.TestCase), Arg.Is(Environment.CurrentDirectory));
+            projectFileSystem.Received(1).GetRelativePath(Arg.Is<string>(Path.Combine(Environment.CurrentDirectory, "FixutreId", testScriptFile)));
+            projectFileSystem.Received(1).CreateOrReplaceFile(Arg.Is<string>(Environment.CurrentDirectory), Arg.Is<string>(Path.GetFileName(testCaseViewModel.ScriptFile)), Arg.Is<string>(string.Empty));
+            projectFileSystem.Received(1).SaveToFile<TestCase>(Arg.Is<TestCase>(testCaseViewModel.TestCase), Arg.Is(Environment.CurrentDirectory));
 
             int expectedWhenSaveFixtureEntity = shouldSaveTestEntity ? 1 : 0;
-            testCaseFileSystem.Received(expectedWhenSaveFixtureEntity).SaveToFile<Entity>(Arg.Is<Entity>(testEntity), Arg.Is(Environment.CurrentDirectory), Arg.Is(testProcessFile));
+            projectFileSystem.Received(expectedWhenSaveFixtureEntity).SaveToFile<Entity>(Arg.Is<Entity>(testEntity), Arg.Is(Environment.CurrentDirectory), Arg.Is(testProcessFile));
 
         }
     }
@@ -788,11 +790,12 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
             testCaseFileSystem.FixtureDirectory.Returns(Environment.CurrentDirectory);
             testCaseFileSystem.FixtureProcessFile.Returns(fixtureProcessFile);
             testCaseFileSystem.GetTestProcessFile(Arg.Any<string>()).Returns(testProcessFile);
-            testCaseFileSystem.GetRelativePath(Arg.Any<string>()).Returns(Path.Combine("TestId", testScriptFile));           
             testCaseFileSystem.GetTestScriptFile(Arg.Any<string>()).Returns(testScriptFile);
-            testCaseFileSystem.When(x => x.CreateOrReplaceFile(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
-            testCaseFileSystem.When(x => x.SaveToFile<TestCase>(Arg.Any<TestCase>(), Arg.Any<string>())).Do(DoNothing);
-            testCaseFileSystem.When(x => x.SaveToFile<Entity>(Arg.Any<Entity>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
+
+            projectFileSystem.GetRelativePath(Arg.Any<string>()).Returns(Path.Combine("TestId", testScriptFile));          
+            projectFileSystem.When(x => x.CreateOrReplaceFile(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
+            projectFileSystem.When(x => x.SaveToFile<TestCase>(Arg.Any<TestCase>(), Arg.Any<string>())).Do(DoNothing);
+            projectFileSystem.When(x => x.SaveToFile<Entity>(Arg.Any<Entity>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);
 
             scriptEditorFactory.When(x => x.AddProject(Arg.Any<string>(), Arg.Is<string[]>(Array.Empty<string>()), Arg.Any<Type>())).Do(DoNothing);
             scriptEditorFactory.When(x => x.AddDocument(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())).Do(DoNothing);


### PR DESCRIPTION
**Description**
IFileSystem has some additional properties that are specific to automation projects and prefab projects and doesn't make sense for a test case file system. Test case file system is much simpler which only provides information about structure of the assets belonging to a test fixture or test case. Project file system can do all the work required for interacting with the actual file system if needed as project file system is available everywhere a ITestCaseFileSystem would exist. This also simplified dependency management for IFileSystem.