### PR TITLE
Additional imports are never added to script engine's script options

### DIFF
--- a/src/Pixel.Scripting.Engine.CSharp/ScriptEngineFactory.cs
+++ b/src/Pixel.Scripting.Engine.CSharp/ScriptEngineFactory.cs
@@ -128,7 +128,7 @@ namespace Pixel.Scripting.Engine.CSharp
                 this.namespaces = this.namespaces.Union(namespaces).ToList<string>();
                 foreach(var import in namespaces)
                 {
-                    if(!this.namespaces.Contains(import))
+                    if(!this.scriptOptions.Imports.Contains(import))
                     {
                         this.scriptOptions = this.scriptOptions.AddImports(import);
                     }


### PR DESCRIPTION
**Description**
Trying to add additional imports to ScriptEngineFactory->WithAdditionalNamespaces(...)  doesn't work as the incorrect condition skips the logic to update the ScriptOptions with new imports. This is fixed now.