### PR TITLE
Reload project if the assembly references are modified to reflect changes immediately

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
@@ -122,26 +122,7 @@ namespace Pixel.Automation.Designer.ViewModels
                 }
                 logger.Information($"Editing data model completed for project : {this.CurrentProject.Name}");
 
-                logger.Information($"Closing all open TestCases for project: {this.CurrentProject.Name}");
-
-                //closing fixture will also close test cases
-                var testCaseEntities = this.EntityManager.RootEntity.GetComponentsOfType<TestCaseEntity>(SearchScope.Descendants);
-                var testFixtures = testCaseEntities.Select(t => t.Parent as TestFixtureEntity).Distinct();
-                foreach (var fixture in testFixtures)
-                {
-                    await this.testExplorer.CloseTestFixtureAsync(fixture.Tag);
-                }
-
-                await this.projectManager.Refresh();
-
-                UpdateWorkFlowRoot();
-
-                //Opening test case will also open parent TestFixture if not already open.
-                logger.Information($"Opening all test cases back for projoect : {this.CurrentProject.Name}");
-                foreach (var testEntity in testCaseEntities)
-                {
-                    await this.testExplorer.OpenTestCaseAsync(testEntity.Tag);
-                }
+                await this.Reload();
             }
             catch (Exception ex)
             { 
@@ -193,7 +174,32 @@ namespace Pixel.Automation.Designer.ViewModels
             base.BuildWorkFlow(root);
             this.componentViewBuilder.SetRoot(root);
         }
-        
+
+        protected override async Task Reload()
+        {
+            logger.Information($"Closing all open TestCases for project: {this.CurrentProject.Name}");
+
+            //closing fixture will also close test cases
+            var testCaseEntities = this.EntityManager.RootEntity.GetComponentsOfType<TestCaseEntity>(SearchScope.Descendants);
+            var testFixtures = testCaseEntities.Select(t => t.Parent as TestFixtureEntity).Distinct();
+            foreach (var fixture in testFixtures)
+            {
+                await this.testExplorer.CloseTestFixtureAsync(fixture.Tag);
+            }
+
+            await this.projectManager.Reload();
+
+            UpdateWorkFlowRoot();
+
+            //Opening test case will also open parent TestFixture if not already open.
+            logger.Information($"Opening all test cases back for projoect : {this.CurrentProject.Name}");
+            foreach (var testEntity in testCaseEntities)
+            {
+                await this.testExplorer.OpenTestCaseAsync(testEntity.Tag);
+            }
+        }
+
+
         #endregion Automation Project
 
         #region OnLoad

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -10,6 +10,7 @@ using Pixel.Automation.Editor.Core.Interfaces;
 using Pixel.Persistence.Services.Client;
 using Pixel.Scripting.Editor.Core.Contracts;
 using Pixel.Scripting.Reference.Manager.Contracts;
+using Pixel.Scripting.Reference.Manager.Models;
 using System.IO;
 
 namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
@@ -43,7 +44,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             this.projectFileSystem.Initialize(activeProject, versionToLoad);
             this.entityManager.SetCurrentFileSystem(this.fileSystem);
             this.entityManager.RegisterDefault<IFileSystem>(this.fileSystem);
-            this.referenceManager = referenceManagerFactory.CreateForAutomationProject(activeProject, versionToLoad);
+            this.referenceManager = this.referenceManagerFactory.CreateForAutomationProject(activeProject, versionToLoad);
             this.entityManager.RegisterDefault<IReferenceManager>(this.referenceManager);
 
             await CreateDataModelFile();
@@ -147,10 +148,12 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
         /// </summary>
         /// <param name="entityManager"></param>
         /// <returns></returns>
-        public override async Task Refresh()
+        public override async Task Reload()
         {        
 
             logger.Information($"{this.GetProjectName()} will be re-loaded");
+            var reference = this.fileSystem.LoadFile<ReferenceCollection>(this.fileSystem.AssemblyReferencesFile);
+            this.referenceManager.SetReferenceCollection(reference);
             var dataModel = CompileAndCreateDataModel(Constants.AutomationProcessDataModelName);
             ConfigureScriptEngine(this.referenceManager, dataModel);
             ConfigureScriptEditor(this.referenceManager, dataModel);          

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
@@ -255,6 +255,12 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             }
         }
 
+        /// <summary>
+        /// Reload the project while preserving the last editor state e.g. test cases opened earlier
+        /// </summary>
+        /// <returns></returns>
+        protected abstract Task Reload();       
+
         /// <inheritdoc/>      
         public async Task ManageControlReferencesAsync()
         {
@@ -275,7 +281,11 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             try
             {
                 var versionManager = this.versionManagerFactory.CreateAssemblyReferenceManager(this.EntityManager.GetCurrentFileSystem());
-                await this.windowManager.ShowDialogAsync(versionManager);
+                var result = await this.windowManager.ShowDialogAsync(versionManager);
+                if(result.HasValue && result.Value)
+                {
+                    await this.Reload();
+                }               
             }
             catch (Exception ex)
             {

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
@@ -69,12 +69,18 @@ namespace Pixel.Automation.Designer.ViewModels
                 await editor.AddDocumentAsync($"{Constants.PrefabDataModelName}.cs", this.PrefabProject.PrefabName, string.Empty, false);
                 await editor.OpenDocumentAsync($"{Constants.PrefabDataModelName}.cs", this.PrefabProject.PrefabName);                            
              
-                await this.windowManager.ShowDialogAsync(editor);               
-            }
-            await this.projectManager.Refresh();
+                await this.windowManager.ShowDialogAsync(editor);
 
-            UpdateWorkFlowRoot();
-        }  
+                await this.Reload();
+            }
+           
+        }
+
+        protected override async Task Reload()
+        {
+            await this.projectManager.Reload();
+            this.UpdateWorkFlowRoot();
+        }
 
         #endregion Automation Project     
 

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
@@ -56,7 +56,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
         public abstract Task Save();
 
         ///<inheritdoc/>
-        public abstract Task Refresh();
+        public abstract Task Reload();
 
         ///<inheritdoc/>
         public IProjectManager WithEntityManager(EntityManager entityManager)

--- a/src/Pixel.Automation.Designer.ViewModels/VersionManager/AssemblyReferenceManagerViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/VersionManager/AssemblyReferenceManagerViewModel.cs
@@ -77,7 +77,7 @@ public class AssemblyReferenceManagerViewModel : SmartScreen, IVersionManager
     /// <returns></returns>
     public async Task CloseAsync()
     {
-        await this.TryCloseAsync(true);
+        await this.TryCloseAsync(false);
     }
 
 }

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IProjectManager.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IProjectManager.cs
@@ -26,7 +26,11 @@ namespace Pixel.Automation.Editor.Core.Interfaces
         /// <returns></returns>
         T Load<T>(string fileName) where T : new();
 
-        Task Refresh();
+        /// <summary>
+        /// Reload the project
+        /// </summary>
+        /// <returns></returns>
+        Task Reload();
     }
 
     public interface IAutomationProjectManager: IProjectManager

--- a/src/Pixel.Scripting.Reference.Manager/Contracts/IReferenceManager.cs
+++ b/src/Pixel.Scripting.Reference.Manager/Contracts/IReferenceManager.cs
@@ -1,4 +1,6 @@
-﻿namespace Pixel.Scripting.Reference.Manager.Contracts;
+﻿using Pixel.Scripting.Reference.Manager.Models;
+
+namespace Pixel.Scripting.Reference.Manager.Contracts;
 
 /// <summary>
 /// IReferenceManager defines the contract for retrieving assmbly references and imports for code editor, script editor and script engine associated
@@ -35,4 +37,11 @@ public interface IReferenceManager
     /// </summary>
     /// <returns></returns>
     IEnumerable<string> GetWhiteListedReferences();
+
+    /// <summary>
+    /// Set the <see cref="ReferenceCollection"/> for the ReferenceManager.
+    /// </summary>
+    /// <param name="referenceCollection"></param>
+    void SetReferenceCollection(ReferenceCollection referenceCollection);
+
 }

--- a/src/Pixel.Scripting.Reference.Manager/ReferenceManager.cs
+++ b/src/Pixel.Scripting.Reference.Manager/ReferenceManager.cs
@@ -10,7 +10,7 @@ namespace Pixel.Scripting.Reference.Manager;
 /// </summary>
 public class ReferenceManager : IReferenceManager
 {
-    private readonly ReferenceCollection referenceCollection;
+    private ReferenceCollection referenceCollection;
 
     /// <summary>
     /// constructor
@@ -49,5 +49,11 @@ public class ReferenceManager : IReferenceManager
     public IEnumerable<string> GetWhiteListedReferences()
     {
         return this.referenceCollection.WhiteListedReferences;
+    }
+
+    ///<inheritdoc/>  
+    public void SetReferenceCollection(ReferenceCollection referenceCollection)
+    {
+        this.referenceCollection = Guard.Argument(referenceCollection).NotNull();
     }
 }


### PR DESCRIPTION
**Description**
On updating the assembly references , the project should be reloaded to make the new references available for editors and script engines.