### PR TITLE
Add initialization script project reference for script editors that are in scope

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -58,6 +58,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             await ExecuteInitializationScript();
             ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);
             Initialize();
+            SetupInitializationScriptProject(dataModel);
             return this.RootEntity;
         }   
 
@@ -158,7 +159,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             ConfigureScriptEngine(this.referenceManager, dataModel);
             ConfigureScriptEditor(this.referenceManager, dataModel);          
             this.entityManager.Arguments = dataModel;
-           
+            SetupInitializationScriptProject(dataModel);
             await ExecuteInitializationScript();        
             ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);
             this.RootEntity.ResetHierarchy();

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -58,7 +58,8 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             ConfigureScriptEditor(this.referenceManager, dataModel);          
             this.entityManager.Arguments = dataModel;
             ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);
-            Initialize();           
+            Initialize();
+            SetupInitializationScriptProject(dataModel);
             return this.RootEntity;
         }
     
@@ -179,6 +180,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             ConfigureScriptEngine(this.referenceManager, dataModel);
             ConfigureScriptEditor(this.referenceManager, dataModel);           
             this.entityManager.Arguments = dataModel;
+            SetupInitializationScriptProject(dataModel);
             ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);          
         }
 

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
@@ -120,6 +120,16 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
         }
 
         /// <summary>
+        /// Setup the scripting project for initialization script and add initialization script file as a document to this project
+        /// </summary>
+        protected virtual void SetupInitializationScriptProject(object dataModel)
+        {
+            this.scriptEditorFactory.AddProject(RootEntity.Id, Array.Empty<string>(), dataModel.GetType());
+            var scriptFile = Path.Combine(fileSystem.ScriptsDirectory, Constants.InitializeEnvironmentScript);
+            this.scriptEditorFactory.AddDocument(scriptFile, RootEntity.Id, this.fileSystem.ReadAllText(scriptFile));
+        }
+
+        /// <summary>
         /// Setup ScriptEngineFactory with search path and assembly references
         /// </summary>
         /// <param name="referenceManager"></param>

--- a/src/Pixel.Automation.Editor.Controls/ScriptEditorExtensions.cs
+++ b/src/Pixel.Automation.Editor.Controls/ScriptEditorExtensions.cs
@@ -83,7 +83,7 @@ namespace Pixel.Automation.Editor.Controls
             }
             else
             {
-                editorFactory.AddProject(forComponent.Id, Array.Empty<string>(), forComponent.EntityManager.Arguments.GetType());
+                editorFactory.AddProject(forComponent.Id, new string[] { forComponent.EntityManager.RootEntity.Id }, forComponent.EntityManager.Arguments.GetType());
             }
         }
     }


### PR DESCRIPTION
**Description**
1. There is a initialization script associated with every project. We execute this script as a part of environment setup. The idea was to use this script to initialize the data model and reference only data model members inside script. However, the initialization script can also define it's own variables for the script. These variables defined in initialization don't show up in script editors however that are in scope of same entity manager as the root entity. This change allows script editors in scope of same entity manager to see those variables as intellisense suggestions at design time.

2. The initialization script variables however are still not accessible inside fixtures and test cases. There is noting preventing us from doing this. However, this keeps things simple.