### PR TITLE
Use default test data file if suffixed file doesn't exist

### DIFF
--- a/src/Pixel.Automation.RunTime/DataSourceReader.cs
+++ b/src/Pixel.Automation.RunTime/DataSourceReader.cs
@@ -76,7 +76,11 @@ namespace Pixel.Automation.RunTime
             string scriptFile = testDataSource.ScriptFile;        
             if(!string.IsNullOrEmpty(this.dataSourceSuffix))
             {
-                scriptFile = $"{Path.GetFileNameWithoutExtension(scriptFile)}.{this.dataSourceSuffix}{Path.GetExtension(scriptFile)}";
+                var suffixedScriptFile = $"{Path.GetFileNameWithoutExtension(scriptFile)}.{this.dataSourceSuffix}{Path.GetExtension(scriptFile)}";
+                if(this.fileSystem.Exists(suffixedScriptFile))
+                {
+                    scriptFile = suffixedScriptFile;
+                }
             }
             ScriptResult result = await codeScriptEngine.Value.ExecuteFileAsync(scriptFile);          
             result = await codeScriptEngine.Value.ExecuteScriptAsync("GetDataRows()");
@@ -97,7 +101,11 @@ namespace Pixel.Automation.RunTime
             string csvFile = csvDataSourceConfiguration.TargetFile;
             if (!string.IsNullOrEmpty(this.dataSourceSuffix))
             {
-                csvFile = $"{Path.GetFileNameWithoutExtension(csvFile)}.{this.dataSourceSuffix}{Path.GetExtension(csvFile)}";
+                var suffixedCsvFile = $"{Path.GetFileNameWithoutExtension(csvFile)}.{this.dataSourceSuffix}{Path.GetExtension(csvFile)}";
+                if(this.fileSystem.Exists(suffixedCsvFile))
+                {
+                    csvFile = suffixedCsvFile;
+                }
             }
             csvDataSourceConfiguration.TargetFile = Path.Combine(this.fileSystem.TestDataRepository, csvFile);
 

--- a/src/Unit.Tests/Pixel.Automation.RunTime.Tests/CsvDataReaderTests.cs
+++ b/src/Unit.Tests/Pixel.Automation.RunTime.Tests/CsvDataReaderTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Pixel.Automation.RunTime.Tests
 {
-    class CsvDataReaderTests
+    public class CsvDataReaderTests
     {
         private CsvDataReader csvDataReader;
 


### PR DESCRIPTION
**Description**
If a custom data source suffix is configured, the test data loader tries to load all files with suffix. However, all test data source doesn't have to provide a suffixed data file. Only certain tests will have this kind of requirement to dynamically load data source.
To make the suffixed file optional, the data loader will check if the suffixed file exists. If the suffixed file doesn't exists, it will use the default data source file instead.