### PR TITLE
Show updated script variables on opening the combo box dropdown

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/PropertyGrid/PropertyGridViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/PropertyGrid/PropertyGridViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using Pixel.Automation.Editor.Core;
-using System;
 using System.Windows.Input;
 
 namespace Pixel.Automation.Designer.ViewModels
@@ -26,15 +25,12 @@ namespace Pixel.Automation.Designer.ViewModels
 
         private Func<bool> canSave;
 
-        private ICommand saveCommand;
-        public ICommand SaveCommand
-        {
-            get { return saveCommand ?? new RelayCommand(p => Save(), p => CanSave()); }
-        }      
+        public ICommand SaveCommand { get; private set; }
 
         public PropertyGridViewModel()
         {
             this.DisplayName = "Properties";
+            this.SaveCommand = new RelayCommand(p => Save(), p => CanSave());
         }
 
         public void SetState(object selectedObject, bool isReadOnly, Action saveCommand, Func<bool> canSave)

--- a/src/Pixel.Automation.Designer.Views/PropertyGrid/PropertyGridView.xaml
+++ b/src/Pixel.Automation.Designer.Views/PropertyGrid/PropertyGridView.xaml
@@ -10,28 +10,14 @@
              d:DesignHeight="300" d:DesignWidth="300">
     <UserControl.Resources>
         <ResourceDictionary>
-
             <converters:InverseBooleanConverter x:Key="inverseBoolConverter"/>
-
-            <!--<Thickness x:Key="ControlMargin">0 5 0 0</Thickness>-->
-
-            <!--<Style x:Key="TextBoxStyle" TargetType="{x:Type TextBox}" BasedOn="{StaticResource MahApps.Styles.TextBox}">
-                <Setter Property="BorderThickness" Value="0,0,0,1"></Setter>
-                <Setter Property="Margin" Value="{StaticResource ControlMargin}"/>
-                <Style.Triggers>
-                    <Trigger Property="IsReadOnly" Value="True">
-                        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Gray3}"/>
-                    </Trigger>
-                </Style.Triggers>
-            </Style>-->
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
         <!--We also have IsReadOnly property. However, we need to make custom used control/styles on property grid support isreadonly as well-->
         <xctk:PropertyGrid x:Name="propertyGrid" SelectedObject="{Binding SelectedObject}"  ShowSortOptions="True" IsCategorized="True"
-          IsEnabled="{Binding IsReadOnly, Converter={StaticResource inverseBoolConverter}}"                          
+          IsEnabled="{Binding IsReadOnly, Converter={StaticResource inverseBoolConverter}}"                        
           BorderThickness="0"  ShowSearchBox="True" Style="{StaticResource PropertyGridStyle}" 
                            PropertyContainerStyle="{StaticResource PropertyItemStyle}"/>
-
     </Grid>
 </UserControl>

--- a/src/Pixel.Automation.Designer.Views/PropertyGrid/PropertyGridView.xaml.cs
+++ b/src/Pixel.Automation.Designer.Views/PropertyGrid/PropertyGridView.xaml.cs
@@ -1,5 +1,4 @@
-﻿using Pixel.Automation.Editor.Controls;
-using Pixel.Automation.Editor.Controls.Arguments;
+﻿using Pixel.Automation.Editor.Controls.Arguments;
 using Pixel.Automation.Editor.Controls.HotKeys;
 using Serilog;
 using System;

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/ArgumentEditor.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/ArgumentEditor.cs
@@ -255,5 +255,13 @@ namespace Pixel.Automation.Editor.Controls.Arguments
             }
         }
 
+        protected void RefreshAvailableProperties(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (this.Argument.Mode == ArgumentMode.DataBound)
+            {
+                this.AvailableProperties.Clear();
+                LoadAvailableProperties();
+            }
+        }
     }
 }

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/InArgumentEditor.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/InArgumentEditor.xaml
@@ -38,6 +38,7 @@
 
                 <ComboBox x:Name="ArgumentsComboBox" ItemsSource="{Binding AvailableProperties,ElementName=InArgumentControl}" 
                           IsEditable="True" Metro:TextBoxHelper.UseFloatingWatermark="True"
+                          PreviewMouseDown="RefreshAvailableProperties"
                           Metro:TextBoxHelper.Watermark="{Binding Argument.ArgumentType,ElementName=InArgumentControl}"
                           SelectedValue="{Binding Argument.PropertyPath,ElementName=InArgumentControl}"
                           Style="{DynamicResource MahApps.Styles.ComboBox.Virtualized}"

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/OutArgumentEditor.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/OutArgumentEditor.xaml
@@ -33,6 +33,7 @@
 
                     <ComboBox x:Name="ArgumentsComboBox" ItemsSource="{Binding AvailableProperties,ElementName=OutArgumentControl}" 
                           IsEditable="True" Metro:TextBoxHelper.UseFloatingWatermark="True"
+                          PreviewMouseDown="RefreshAvailableProperties"
                           Metro:TextBoxHelper.Watermark="{Binding Argument.ArgumentType,ElementName=OutArgumentControl}"
                           SelectedValue="{Binding Argument.PropertyPath,Mode=TwoWay,ElementName=OutArgumentControl}"
                           Style="{DynamicResource MahApps.Styles.ComboBox.Virtualized}"

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/ArgumentUserControl.cs
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/ArgumentUserControl.cs
@@ -213,5 +213,14 @@ namespace Pixel.Automation.Editor.Controls.Arguments
             }
         }
 
+        protected void RefreshAvailableProperties(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (this.Argument.Mode == ArgumentMode.DataBound)
+            {
+                this.AvailableProperties.Clear();
+                LoadAvailableProperties();
+            }
+        }
+
     }
 }

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/InArgumentUserControl.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/InArgumentUserControl.xaml
@@ -37,6 +37,7 @@
 
                 <ComboBox x:Name="ArgumentsComboBox" ItemsSource="{Binding AvailableProperties,ElementName=InArgumentControl}" 
                           IsEditable="True" Width="158" MaxWidth="158"
+                          PreviewMouseDown="RefreshAvailableProperties"
                           Metro:TextBoxHelper.UseFloatingWatermark="True"
                           Metro:TextBoxHelper.Watermark="{Binding Argument.ArgumentType,ElementName=InArgumentControl}"
                           SelectedValue="{Binding Argument.PropertyPath,ElementName=InArgumentControl}"

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/OutArgumentUserControl.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/OutArgumentUserControl.xaml
@@ -31,6 +31,7 @@
 
                 <ComboBox x:Name="ArgumentsComboBox" ItemsSource="{Binding AvailableProperties,ElementName=OutArgumentControl}" 
                           IsEditable="True" Width="158" MaxWidth="158"
+                          PreviewMouseDown="RefreshAvailableProperties"
                           Metro:TextBoxHelper.UseFloatingWatermark="True"
                           Metro:TextBoxHelper.Watermark="{Binding Argument.ArgumentType,ElementName=OutArgumentControl}"
                           SelectedValue="{Binding Argument.PropertyPath,Mode=TwoWay,ElementName=OutArgumentControl}"


### PR DESCRIPTION
**Description**
If a component is selected on designer with some argument in data bound mode, the argument dropdown doesn't show any new variables that has been defined unless we select some other component and select it back. Ideally, The desirable thing is to have property grid refresh whenever the script is edited. This will ensure the value is cleared as well if some script variable is deleted that is bound to one of the argument of selected component. However, in lack of a good solution to do this , a quick fix is to refresh the available variables every time we click the combo box dropdown for argument in data bound mode. This will show the updated script variables and we don't have to select something else and select it back.