### PR TITLE
Attempt to install stock chrome and edge browsers by default

### DIFF
--- a/src/Pixel.Automation.Web.Playwright.Components/WebApplicationEntity.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/WebApplicationEntity.cs
@@ -198,6 +198,11 @@ public class WebApplicationEntity : ApplicationEntity
                 {
                     exitCode = Program.Main(new[] { "install", channel });
                 }
+                else
+                {
+                    //for stock browser, exitCode is non-zero if browser is already installed so we don't check it.
+                    Program.Main(new[] { "install", channel });
+                }
                 break;
             case Browsers.Edge:
                 //Don't install the stock edge. It is expected to be present on system
@@ -205,6 +210,11 @@ public class WebApplicationEntity : ApplicationEntity
                 if (!string.Equals(channel, "msedge"))
                 {
                     exitCode = Program.Main(new[] { "install", channel });
+                }
+                else
+                {
+                    //for stock browser, exitCode is non-zero if browser is already installed so we don't check it.
+                    Program.Main(new[] { "install", channel });
                 }
                 break;
             case Browsers.WebKit:               

--- a/src/Pixel.Automation.Web.Scrapper/BrowserControlScrapper.cs
+++ b/src/Pixel.Automation.Web.Scrapper/BrowserControlScrapper.cs
@@ -89,6 +89,7 @@ public class BrowserControlScrapper : PropertyChangedBase, IControlScrapper, IHa
     public async Task StartCapture()
     {
         capturedControls.Clear();
+        InstallBrowser();
         playWright = await Microsoft.Playwright.Playwright.CreateAsync();
         string pathToExtension = Path.Combine(Environment.CurrentDirectory, "Extensions", "pixel-browser-scrapper");
         string dataDirectory = Path.Combine(Environment.CurrentDirectory, "Extensions", "Context");
@@ -159,6 +160,15 @@ public class BrowserControlScrapper : PropertyChangedBase, IControlScrapper, IHa
             logger.Error(ex.Message, ex);
         }
     }
+
+    /// <summary>
+    /// Install chrome stock browser for use with scraping
+    /// </summary>  
+    void InstallBrowser()
+    {        
+        Program.Main(new[] { "install", "chrome" });        
+    }
+
 
     ///</inheritdoc>
     public async Task StopCapture()


### PR DESCRIPTION
**Description**
There can be systems where the stock chrome and edge browsers are missing. However, plugin currently skips installation of these browsers. Added support to attempt installation of stock chrome and edge browsers. However, if there is any issue with installation it won't be reported unlike installation of other browser flavors.