### PR TITLE
Allow script files to be browsed and edited from property grid editor

### DIFF
--- a/src/Pixel.Automation.Designer.Views/PropertyGrid/PropertyGridView.xaml.cs
+++ b/src/Pixel.Automation.Designer.Views/PropertyGrid/PropertyGridView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Pixel.Automation.Editor.Controls.Arguments;
 using Pixel.Automation.Editor.Controls.HotKeys;
+using Pixel.Automation.Editor.Controls.Scripts.EditorPropertyGrid;
 using Serilog;
 using System;
 using System.Diagnostics;
@@ -30,26 +31,38 @@ namespace Pixel.Automation.Designer.Views
                 {
                     return;
                 }
-                if (targetPropertyItem.Value.GetType().Name.StartsWith("InArgument"))
+                else if (targetPropertyItem.Value.GetType().Name.StartsWith("InArgument"))
                 {
                     targetPropertyItem.Editor = new InArgumentEditor().ResolveEditor(targetPropertyItem);
                     return;
                 }
-                if (targetPropertyItem.Value.GetType().Name.StartsWith("OutArgument"))
+                else if (targetPropertyItem.Value.GetType().Name.StartsWith("OutArgument"))
                 {
                     targetPropertyItem.Editor = new OutArgumentEditor().ResolveEditor(targetPropertyItem);
                     return;
                 }
-                if (targetPropertyItem.Value.GetType().Name.StartsWith("PredicateArgument"))
+                else if (targetPropertyItem.Value.GetType().Name.StartsWith("PredicateArgument"))
                 {
                     targetPropertyItem.Editor = new InArgumentEditor().ResolveEditor(targetPropertyItem);
                     return;
                 }
-                if (targetPropertyItem.DisplayName.Equals("Hot Key") || targetPropertyItem.DisplayName.Equals("Keys"))
+                else if (targetPropertyItem.DisplayName.Equals("Hot Key") || targetPropertyItem.DisplayName.Equals("Keys"))
                 {
                     targetPropertyItem.Editor = new KeyEditor().ResolveEditor(targetPropertyItem);
                     return;
-                }                
+                }    
+                else if(targetPropertyItem.DisplayName.Equals("Input Mapping Script") || targetPropertyItem.DisplayName.Equals("Output Mapping Script"))
+                {
+                    //we don't want to show edit script button on property grid for script files of a prefab entity as they need to be loaded first which is not handled
+                    //by this control.
+                    var browserScriptEditor = new BrowseScriptEditor() { ShowEditButton = false };
+                    targetPropertyItem.Editor = browserScriptEditor.ResolveEditor(targetPropertyItem);
+                }
+                else if(targetPropertyItem.DisplayName.Equals("Script File") && !targetPropertyItem.IsReadOnly)
+                {
+                    //for script files of execute script actor
+                    targetPropertyItem.Editor = new BrowseScriptEditor().ResolveEditor(targetPropertyItem);
+                }
             }
             catch (Exception ex)
             {

--- a/src/Pixel.Automation.Designer.Views/Resources/Scripting.Components.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Scripting.Components.xaml
@@ -6,7 +6,7 @@
                     xmlns:Metro="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
                     xmlns:cal="http://www.caliburnproject.org"                   
                     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
-                    xmlns:editors="clr-namespace:Pixel.Automation.Editor.Controls;assembly=Pixel.Automation.Editor.Controls"
+                    xmlns:editors="clr-namespace:Pixel.Automation.Editor.Controls.Scripts.EditorUserControl;assembly=Pixel.Automation.Editor.Controls"
                     xmlns:se="clr-namespace:Pixel.Scripting.Script.Editor.Script;assembly=Pixel.Scripting.Script.Editor">
     
     <DataTemplate x:Key="ExecuteScriptTemplate">

--- a/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
@@ -77,12 +77,9 @@
     </Style>
 
     <Style x:Key="ShowDialogButtonStyle" TargetType="Button" BasedOn="{StaticResource SquaredButtonStyle}">
-        <Setter Property="Content" Value="{StaticResource IconDotsVertical}"/>
+        <Setter Property="Content" Value="{StaticResource IconDotsVertical}" />
     </Style>
-    <Style x:Key="EditScriptButtonStyle" TargetType="Button" BasedOn="{StaticResource SquaredButtonStyle}">
-        <Setter Property="Content" Value="{StaticResource IconPageEdit}"/>
-    </Style>
-
+  
     <Style x:Key="InfoButtonStyle" TargetType="Button" BasedOn="{StaticResource MahApps.Styles.Button.Circle}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"></Setter>
         <Setter Property="Width" Value="24"></Setter>

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/InArgumentEditor.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/InArgumentEditor.xaml
@@ -46,10 +46,9 @@
 
                 <DockPanel Visibility="{Binding Argument.Mode,ElementName=InArgumentControl,Converter={StaticResource ArgsModeToVisConverter}, 
                     ConverterParameter=VisibleOnScripted}" LastChildFill="True">
-                    <Button x:Name="BrowseScriptButton" Click="BrowseScript" Style="{StaticResource SquaredButtonStyle}"
-                        Content="{iconPacks:Entypo DotsThreeHorizontal}" Width="24" ToolTip="Browse for Script" 
-                        BorderThickness="0,1,1,1" DockPanel.Dock="Right"></Button>
-                    <Button x:Name="ScriptEditorButton" Click="ShowScriptEditor" Style="{StaticResource EditScriptButtonStyle}"
+                    <Button x:Name="BrowseScriptButton" Click="BrowseScript" Style="{StaticResource SquaredButtonStyle}" Content="{iconPacks:FontAwesome Kind=FolderOpenRegular}" 
+                        Width="24" ToolTip="Browse for Script" BorderThickness="0,1,1,1" DockPanel.Dock="Right"></Button>
+                    <Button x:Name="ScriptEditorButton" Click="ShowScriptEditor" Style="{StaticResource SquaredButtonStyle}" Content="{iconPacks:FontAwesome Kind=EditRegular}"
                         Width="26" ToolTip="Open Script editor" BorderThickness="0,1,1,1" DockPanel.Dock="Right"></Button>
                     <TextBox x:Name="ScriptPath" Text="{Binding Argument.ScriptFile, ElementName=InArgumentControl}" BorderBrush="#FFCCCCCC" DockPanel.Dock="Left"/>
                 </DockPanel>

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/OutArgumentEditor.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorPropertyGrid/OutArgumentEditor.xaml
@@ -41,12 +41,10 @@
 
                     <DockPanel Visibility="{Binding Argument.Mode,ElementName=OutArgumentControl,Converter={StaticResource ArgsModeToVisConverter}, 
                         ConverterParameter=VisibleOnScripted}" LastChildFill="True">
-                        <Button x:Name="BrowseScriptButton" Click="BrowseScript" Style="{StaticResource SquaredButtonStyle}"
-                            Content="{iconPacks:Entypo DotsThreeHorizontal}" Width="24" ToolTip="Browse for Script" 
-                            BorderThickness="0,1,1,1" DockPanel.Dock="Right"></Button>
-                        <Button x:Name="ScriptEditorButton" Click="ShowScriptEditor" Style="{StaticResource EditScriptButtonStyle}"
-                            Width="26" ToolTip="Open Script editor"  
-                            BorderThickness="0,1,1,1" DockPanel.Dock="Right"></Button>
+                        <Button x:Name="BrowseScriptButton" Click="BrowseScript" Style="{StaticResource SquaredButtonStyle}" Content="{iconPacks:FontAwesome Kind=FolderOpenRegular}"
+                            Width="24" ToolTip="Browse for Script" BorderThickness="0,1,1,1" DockPanel.Dock="Right"></Button>
+                        <Button x:Name="ScriptEditorButton" Click="ShowScriptEditor" Style="{StaticResource SquaredButtonStyle}" Content="{iconPacks:FontAwesome Kind=EditRegular}"                          
+                            Width="26" ToolTip="Open Script editor" BorderThickness="0,1,1,1" DockPanel.Dock="Right"></Button>
                         <TextBox x:Name="ScriptPath" Text="{Binding Argument.ScriptFile, ElementName=OutArgumentControl}"
                                  BorderBrush="#FFCCCCCC" DockPanel.Dock="Left"/>
                     </DockPanel>

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/InArgumentUserControl.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/InArgumentUserControl.xaml
@@ -5,7 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Pixel.Automation.Editor.Controls.Arguments"
              xmlns:converters="clr-namespace:Pixel.Automation.Editor.Controls.Converters"
-             xmlns:Metro="http://metro.mahapps.com/winfx/xaml/controls"       
+             xmlns:Metro="http://metro.mahapps.com/winfx/xaml/controls"    
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              mc:Ignorable="d" x:Name="InArgumentControl"
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>
@@ -47,7 +48,8 @@
 
                 <DockPanel Visibility="{Binding Argument.Mode,ElementName=InArgumentControl,Converter={StaticResource ArgsModeToVisConverter}, 
                     ConverterParameter=VisibleOnScripted}" LastChildFill="True" Width="158" MaxWidth="158">
-                    <Button x:Name="ScriptEditorButton" Click="ShowScriptEditor" Style="{StaticResource EditScriptButtonStyle}"
+                    <Button x:Name="ScriptEditorButton" Click="ShowScriptEditor" 
+                        Style="{StaticResource SquaredButtonStyle}" Content="{iconPacks:FontAwesome Kind=EditRegular}"
                         ToolTip="Open Script editor" BorderThickness="0,1,1,1" DockPanel.Dock="Right"></Button>
                     <TextBox x:Name="ScriptPath" Text="{Binding Argument.ScriptFile, ElementName=InArgumentControl}" VerticalContentAlignment="Center"
                              MaxWidth="158" BorderBrush="#FFCCCCCC" DockPanel.Dock="Left"/>

--- a/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/OutArgumentUserControl.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Arguments/EditorUserControl/OutArgumentUserControl.xaml
@@ -5,7 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"             
              xmlns:local="clr-namespace:Pixel.Automation.Editor.Controls.Arguments"
              xmlns:converters="clr-namespace:Pixel.Automation.Editor.Controls.Converters"
-             xmlns:Metro="http://metro.mahapps.com/winfx/xaml/controls"            
+             xmlns:Metro="http://metro.mahapps.com/winfx/xaml/controls"  
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              mc:Ignorable="d" x:Name="OutArgumentControl"
              d:DesignHeight="300" d:DesignWidth="300">
     <local:ArgumentUserControl.Resources>
@@ -41,7 +42,8 @@
 
                 <DockPanel Visibility="{Binding Argument.Mode,ElementName=OutArgumentControl,Converter={StaticResource ArgsModeToVisConverter}, 
                     ConverterParameter=VisibleOnScripted}" LastChildFill="True" Width="158" MaxWidth="158">
-                    <Button x:Name="ScriptEditorButton" Click="ShowScriptEditor" Style="{StaticResource EditScriptButtonStyle}"
+                    <Button x:Name="ScriptEditorButton" Click="ShowScriptEditor" 
+                        Style="{StaticResource SquaredButtonStyle}" Content="{iconPacks:FontAwesome Kind=EditRegular}"
                         ToolTip="Open Script editor" BorderThickness="0,1,1,1" DockPanel.Dock="Right"></Button>
                     <TextBox x:Name="ScriptPath" Text="{Binding Argument.ScriptFile, ElementName=OutArgumentControl}" VerticalContentAlignment="Center"
                              BorderBrush="#FFCCCCCC" DockPanel.Dock="Left"/>

--- a/src/Pixel.Automation.Editor.Controls/Scripts/EditorPropertyGrid/BrowseScriptEditor.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Scripts/EditorPropertyGrid/BrowseScriptEditor.xaml
@@ -1,0 +1,25 @@
+﻿<UserControl x:Class="Pixel.Automation.Editor.Controls.Scripts.EditorPropertyGrid.BrowseScriptEditor"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:uc="clr-namespace:Pixel.Automation.Editor.Controls.Scripts.EditorUserControl"
+             mc:Ignorable="d" x:Name="BrowseScriptEditorControl"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="boolToVisConverter"/>
+    </UserControl.Resources>
+    <Grid>
+        <DockPanel LastChildFill="True" >
+            <uc:BrowseScriptButton x:Name="BrowseScriptButton" ActorComponent="{Binding ActorComponent, ElementName=BrowseScriptEditorControl}"
+                                   ScriptFile="{Binding Text, ElementName=ScriptPath, Mode=TwoWay}"  BorderThickness="0,1,1,1"  BorderBrush="#FFCCCCCC"  
+                                   Visibility="{Binding ShowBrowseButton, ElementName=BrowseScriptEditorControl, Converter={StaticResource boolToVisConverter}}"
+                                   DockPanel.Dock="Right"/>
+            <uc:ScriptEditorButton x:Name="EditScriptButton" ActorComponent="{Binding ActorComponent, ElementName=BrowseScriptEditorControl}"
+                                   ScriptFile="{Binding Text, ElementName=ScriptPath}" BorderThickness="0,1,1,1"  BorderBrush="#FFCCCCCC"  
+                                   Visibility="{Binding ShowEditButton, ElementName=BrowseScriptEditorControl, Converter={StaticResource boolToVisConverter}}"
+                                   DockPanel.Dock="Right"/>
+            <TextBox x:Name="ScriptPath" DockPanel.Dock="Right"  BorderBrush="#FFCCCCCC"  />
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/src/Pixel.Automation.Editor.Controls/Scripts/EditorPropertyGrid/BrowseScriptEditor.xaml.cs
+++ b/src/Pixel.Automation.Editor.Controls/Scripts/EditorPropertyGrid/BrowseScriptEditor.xaml.cs
@@ -1,0 +1,59 @@
+﻿using Pixel.Automation.Core;
+using Pixel.Automation.Editor.Controls.Scripts.EditorUserControl;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using Xceed.Wpf.Toolkit.PropertyGrid;
+using Xceed.Wpf.Toolkit.PropertyGrid.Editors;
+
+namespace Pixel.Automation.Editor.Controls.Scripts.EditorPropertyGrid
+{
+    /// <summary>
+    /// Interaction logic for BrowseScriptEditor.xaml
+    /// </summary>
+    public partial class BrowseScriptEditor : UserControl, ITypeEditor
+    {
+        public static readonly DependencyProperty ActorComponentProperty = DependencyProperty.Register("ActorComponent", typeof(Component), typeof(BrowseScriptEditor),
+                                                                                                 new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.None));
+        public Component ActorComponent
+        {
+            get { return (Component)GetValue(ActorComponentProperty); }
+            set { SetValue(ActorComponentProperty, value); }
+        }
+
+        public static readonly DependencyProperty ShowBrowseButtonProperty = DependencyProperty.Register("ShowBrowseButton", typeof(bool), typeof(BrowseScriptEditor),
+                                                                                              new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.None));
+        public bool ShowBrowseButton
+        {
+            get { return (bool)GetValue(ShowBrowseButtonProperty); }
+            set { SetValue(ShowBrowseButtonProperty, value); }
+        }
+
+        public static readonly DependencyProperty ShowEditButtonProperty = DependencyProperty.Register("ShowEditButton", typeof(bool), typeof(BrowseScriptEditor),
+                                                                                            new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.None));
+        public bool ShowEditButton
+        {
+            get { return (bool)GetValue(ShowEditButtonProperty); }
+            set { SetValue(ShowEditButtonProperty, value); }
+        }
+
+
+        public BrowseScriptEditor()
+        {
+            InitializeComponent();
+        }
+
+        public FrameworkElement ResolveEditor(PropertyItem propertyItem)
+        {
+            this.ActorComponent = propertyItem.Instance as Component;
+            var binding = new Binding(propertyItem.PropertyName);
+            binding.Source = propertyItem.Instance;           
+            binding.Mode = propertyItem.IsReadOnly ? BindingMode.OneWay : BindingMode.TwoWay;
+            binding.NotifyOnSourceUpdated = true;
+            binding.NotifyOnTargetUpdated = true;
+            binding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
+            BindingOperations.SetBinding(BrowseScriptEditorControl.ScriptPath, TextBox.TextProperty, binding);
+            return this;
+        }
+    }
+}

--- a/src/Pixel.Automation.Editor.Controls/Scripts/EditorUserControl/BrowseScriptButton.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Scripts/EditorUserControl/BrowseScriptButton.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Pixel.Automation.Editor.Controls.BrowseScriptButton"
+﻿<UserControl x:Class="Pixel.Automation.Editor.Controls.Scripts.EditorUserControl.BrowseScriptButton"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -6,7 +6,7 @@
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"  
              mc:Ignorable="d" d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
-        <Button Width="20" Height="20" Margin="0" Style="{DynamicResource MahApps.Styles.Button.Circle}" Content="{iconPacks:FontAwesome FolderOpenRegular}" BorderThickness="0"
+        <Button Width="20" Height="Auto" Margin="0" Style="{StaticResource SquaredButtonStyle}" Content="{iconPacks:FontAwesome Kind=FolderOpenRegular}" BorderThickness="0"
                 Click="BrowseForScript" Foreground="{DynamicResource MahApps.Brushes.Accent}" RenderTransformOrigin="0.5,0.5" ToolTip="Browse for script">
         </Button>
     </Grid>

--- a/src/Pixel.Automation.Editor.Controls/Scripts/EditorUserControl/BrowseScriptButton.xaml.cs
+++ b/src/Pixel.Automation.Editor.Controls/Scripts/EditorUserControl/BrowseScriptButton.xaml.cs
@@ -6,7 +6,7 @@ using System;
 using System.Windows;
 using System.Windows.Controls;
 
-namespace Pixel.Automation.Editor.Controls
+namespace Pixel.Automation.Editor.Controls.Scripts.EditorUserControl
 {
     /// <summary>
     /// Interaction logic for BrowseScriptButton.xaml

--- a/src/Pixel.Automation.Editor.Controls/Scripts/EditorUserControl/ScriptEditorButton.xaml
+++ b/src/Pixel.Automation.Editor.Controls/Scripts/EditorUserControl/ScriptEditorButton.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Pixel.Automation.Editor.Controls.ScriptEditorButton"
+﻿<UserControl x:Class="Pixel.Automation.Editor.Controls.Scripts.EditorUserControl.ScriptEditorButton"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -8,7 +8,7 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
-        <Button Width="20" Height="20" Margin="0" Style="{DynamicResource MahApps.Styles.Button.Circle}" Content="{iconPacks:FontAwesome EditRegular}" BorderThickness="0"
+        <Button Width="20" Height="20" Margin="0" Style="{StaticResource SquaredButtonStyle}" Content="{iconPacks:FontAwesome Kind=EditRegular}" BorderThickness="0"
                 Click="OpenScriptEditorWindow" Foreground="{DynamicResource MahApps.Brushes.Accent}" RenderTransformOrigin="0.5,0.5" ToolTip="Open Script Editor">
         </Button>
     </Grid>

--- a/src/Pixel.Automation.Editor.Controls/Scripts/EditorUserControl/ScriptEditorButton.xaml.cs
+++ b/src/Pixel.Automation.Editor.Controls/Scripts/EditorUserControl/ScriptEditorButton.xaml.cs
@@ -7,7 +7,7 @@ using System;
 using System.Windows;
 using System.Windows.Controls;
 
-namespace Pixel.Automation.Editor.Controls
+namespace Pixel.Automation.Editor.Controls.Scripts.EditorUserControl
 {
     /// <summary>
     /// Interaction logic for ScriptEditorButton.xaml

--- a/src/Pixel.Automation.Scripting.Components/ExecuteAsyncScriptActorComponent.cs
+++ b/src/Pixel.Automation.Scripting.Components/ExecuteAsyncScriptActorComponent.cs
@@ -20,8 +20,7 @@ namespace Pixel.Automation.Scripting.Components
     {
         protected string scriptFile;
         [DataMember]
-        [System.ComponentModel.DisplayName("Script File")]
-        [System.ComponentModel.ReadOnly(true)]
+        [System.ComponentModel.DisplayName("Script File")]      
         public string ScriptFile
         {
             get => scriptFile;

--- a/src/Pixel.Automation.Scripting.Components/ExecuteScriptActorComponent.cs
+++ b/src/Pixel.Automation.Scripting.Components/ExecuteScriptActorComponent.cs
@@ -20,8 +20,7 @@ namespace Pixel.Automation.Scripting.Components
     {
         protected string scriptFile;
         [DataMember]
-        [System.ComponentModel.DisplayName("Script File")]
-        [System.ComponentModel.ReadOnly(true)]
+        [System.ComponentModel.DisplayName("Script File")]        
         public string ScriptFile
         {
             get => scriptFile;


### PR DESCRIPTION
**Description**
To allow scripts to be shared , it should be possible to browse and pick up an existing script file. Also, show an edit script button on property grid editor for convenience.
1. For PrefabEntity, allow to browse script for input mapping and output mapping from property grid editor. Editing these script is possible only from settings context menu as before we can edit these, we need to load the prefab.
2. For scripting components except for inline script actor, allow both browsing and editing script from property grid editor.
