### PR TITLE
Enable diagonstics while editing prefab input and output mapping script and test data script

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabMappingScriptEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabMappingScriptEditorViewModel.cs
@@ -38,7 +38,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         protected override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             string generatedCode = GetGeneratedCode();
-            this.ScriptEditor = this.scriptEditorFactory.CreateInlineScriptEditor();
+            this.ScriptEditor = this.scriptEditorFactory.CreateInlineScriptEditor(new EditorOptions() { EnableDiagnostics = true });
             this.ScriptEditor.SetEditorOptions(new EditorOptions() { ShowLineNumbers = true, FontSize = 23 });
             if (dropTarget.TryGetAnsecstorOfType<TestCaseEntity>(out TestCaseEntity testCaseEntity))
             {

--- a/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataModelEditorViewModel.cs
+++ b/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataModelEditorViewModel.cs
@@ -136,7 +136,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
         {
             if(this.ScriptEditor == null)
             {
-                this.ScriptEditor = editorFactory.CreateInlineScriptEditor();
+                this.ScriptEditor = editorFactory.CreateInlineScriptEditor(new EditorOptions() { EnableDiagnostics = true });
                 this.ScriptEditor.SetEditorOptions(new EditorOptions() { FontSize = 23 });
             }            
             if (TryGenerateDataModelCode(out string generatedCode, out string errorDescription))

--- a/src/Pixel.Scripting.Editor.Core/Contracts/EditorOptions.cs
+++ b/src/Pixel.Scripting.Editor.Core/Contracts/EditorOptions.cs
@@ -1,12 +1,22 @@
-﻿namespace Pixel.Scripting.Editor.Core.Contracts
+﻿using System.Diagnostics.SymbolStore;
+
+namespace Pixel.Scripting.Editor.Core.Contracts
 {
     public class EditorOptions
     {
+        public static EditorOptions DefaultOptions { get; set; } = new EditorOptions();
+
+        public bool EnableDiagnostics { get; set; } = false;
+
+        public bool EnableCodeActions { get; set; } = false;
+
         public int FontSize { get; set; } = 13;
 
         public string FontFamily { get; set; } = "Consolas";
 
         public bool ShowLineNumbers { get; set; } = true;
 
+        public int Thickness { get; set; } = 2;
+     
     }
 }

--- a/src/Pixel.Scripting.Editor.Core/Contracts/IEditorFactory.cs
+++ b/src/Pixel.Scripting.Editor.Core/Contracts/IEditorFactory.cs
@@ -90,10 +90,16 @@ namespace Pixel.Scripting.Editor.Core.Contracts
         IScriptEditorScreen CreateScriptEditorScreen();       
 
         /// <summary>
-        /// Create an inline script editor that will automatically remove underlying project on dispose
+        /// Create an inline script editor with default editor options that will automatically remove underlying project on dispose
         /// </summary>
         /// <returns></returns>
         IInlineScriptEditor CreateInlineScriptEditor();
+
+        /// <summary>
+        /// Create an inline script editor with custom editor options that will automatically remove underlying project on dispose
+        /// </summary>
+        /// <returns></returns>
+        IInlineScriptEditor CreateInlineScriptEditor(EditorOptions editorOptions);
 
         /// <summary>
         /// Get an existing inline script editor with given identifer or create a new one.

--- a/src/Pixel.Scripting.Script.Editor/Editor/Script/InlineScriptEditorViewModel.cs
+++ b/src/Pixel.Scripting.Script.Editor/Editor/Script/InlineScriptEditorViewModel.cs
@@ -22,19 +22,25 @@ namespace Pixel.Scripting.Script.Editor.Script
 
         public CodeTextEditor Editor { get; private set; }
 
-        public InlineScriptEditorViewModel(IEditorService editorService)
+
+        public InlineScriptEditorViewModel(IEditorService editorService) : this(editorService, EditorOptions.DefaultOptions)
+        {           
+        }
+
+        public InlineScriptEditorViewModel(IEditorService editorService , EditorOptions editorOptions)
         {
             Guard.Argument(editorService).NotNull();
+            Guard.Argument(editorOptions).NotNull();
 
             this.editorService = editorService;
             this.Editor = new CodeTextEditor(editorService)
             {
-                EnableDiagnostics = false,
-                EnableCodeActions = false,
-                ShowLineNumbers = false,
-                Margin = new Thickness(2),
-                FontSize = 14,
-                FontFamily = new FontFamily("Consolas"),
+                EnableDiagnostics = editorOptions.EnableDiagnostics,
+                EnableCodeActions = editorOptions.EnableCodeActions,
+                ShowLineNumbers = editorOptions.ShowLineNumbers,
+                Margin = new Thickness(editorOptions.Thickness),
+                FontSize = editorOptions.FontSize,
+                FontFamily = new FontFamily(editorOptions.FontFamily),
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden,
                 VerticalScrollBarVisibility = ScrollBarVisibility.Hidden,
                 HorizontalAlignment = HorizontalAlignment.Stretch,

--- a/src/Pixel.Scripting.Script.Editor/EditorFactory/ScriptEditorFactory.cs
+++ b/src/Pixel.Scripting.Script.Editor/EditorFactory/ScriptEditorFactory.cs
@@ -57,6 +57,12 @@ namespace Pixel.Scripting.Script.Editor
             return new InlineScriptEditorViewModel(this.editorService);
         }
 
+        public IInlineScriptEditor CreateInlineScriptEditor(EditorOptions editorOptions)
+        {
+            EnsureInitialized();
+            return new InlineScriptEditorViewModel(this.editorService, editorOptions);
+        }
+
         public IInlineScriptEditor CreateInlineScriptEditor(string cacheKey)
         {
             EnsureInitialized();

--- a/src/Unit.Tests/Pixel.Automation.TestData.Repository.ViewModels.Tests/TestDataModelEditorViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.TestData.Repository.ViewModels.Tests/TestDataModelEditorViewModelFixture.cs
@@ -25,7 +25,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
         {
             scriptEditor = Substitute.For<IInlineScriptEditor>();
             scriptEditorFactory = Substitute.For<IScriptEditorFactory>();
-            scriptEditorFactory.CreateInlineScriptEditor().Returns(scriptEditor);
+            scriptEditorFactory.CreateInlineScriptEditor(Arg.Any<EditorOptions>()).Returns(scriptEditor);
             //scriptEditorFactory.When(x => x.AddProject(Arg.Any<string>(), Arg.Any<string[]>(), Arg.Is<Type>(typeof(Empty)))).Do(x => { });
 
            
@@ -60,7 +60,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels.Tests
 
 
             testDataModelEditorViewModel.ActivateAsync();
-            scriptEditorFactory.Received(1).CreateInlineScriptEditor();
+            scriptEditorFactory.Received(1).CreateInlineScriptEditor(Arg.Any<EditorOptions>());
             scriptEditorFactory.Received(1).AddProject(Arg.Any<string>(), Arg.Any<string[]>(), Arg.Is<Type>(typeof(EmptyModel)));
             scriptEditor.Received(1).OpenDocument(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
             scriptEditor.Received(1).Activate();           


### PR DESCRIPTION
**Description**
No diagnostics is shown while editing input and output mapping script for a prefab or editing test data scripts.  Enable diagnostics for these script for convenience of user.