### PR TITLE
PrefabEntity drag-drop bug fixes

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/DragDropHandlers/ComponentDragHandler.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/DragDropHandlers/ComponentDragHandler.cs
@@ -65,7 +65,7 @@ namespace Pixel.Automation.Designer.ViewModels.DragDropHandlers
                                 }
                             }
                             //It should not be possible to drag an item if the targetItem doesn't allow drop or source and target have different EntityManager
-                            if (targetItem is EntityComponentViewModel entityTarget && entityTarget.IsDropTarget && 
+                            if (targetItem is EntityComponentViewModel entityTarget && !(entityTarget.Model is PrefabEntity) && entityTarget.IsDropTarget && 
                                 (sourceItem.Model.EntityManager == targetItem.Model.EntityManager) && (sourceItem.Parent != targetItem))
                             {
                                 dropInfo.DropTargetAdorner = DropTargetAdorners.Highlight;

--- a/src/Pixel.Automation.Designer.Views/Resources/Component.Templates.Slim.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Component.Templates.Slim.xaml
@@ -229,7 +229,8 @@
 
     <DataTemplate x:Key="PrefabTemplate">
         <Border x:Name="brdContainer"  BorderThickness="2" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"
-                HorizontalAlignment="Stretch" Margin="0,4,0,4" MinWidth="224" Background="{DynamicResource MahApps.Brushes.Control.Background}">
+                HorizontalAlignment="Stretch" Margin="0,4,0,4" MinWidth="224" dd:DragDrop.IsDragSource="True"
+                Background="{DynamicResource MahApps.Brushes.Control.Background}">
             <DockPanel LastChildFill="True" Margin="4" Width="Auto" HorizontalAlignment="Stretch"
                        Background="White" IsHitTestVisible="True">
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="2"


### PR DESCRIPTION
**Description**
It should be possible to rearrange an PrefabEntity within a parent entity . Also, when dragging another item while holding alt key, prefabs should not be highliged as drop target as they don't allow child components to be added.