### PR TITLE
Update workflow file to use Pixel.Automation.sln explicitly

### DIFF
--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -28,8 +28,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore Pixel.Automation.sln
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build Pixel.Automation.sln --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test Pixel.Automation.sln --no-build --verbosity normal


### PR DESCRIPTION
**Description**
Updated workflow file to use Pixel.Automation.sln explicitly for targets of different dotnet commands. This is required as we ran in to an issue with wofklow file while building https://github.com/Nfactor26/pixel-automation/pull/146. This PR adds another project file besides .sln file and the dotnet commands like restore or build fail as they need explicit target if there are multiple options available.