### PR TITLE
Fix issue with control failing to be cloned

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Control/ControlExplorerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Control/ControlExplorerViewModel.cs
@@ -373,15 +373,22 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Control
         /// <param name="controlToRename"></param>
         public async Task CloneControl(ControlDescriptionViewModel controlToClone)
         {
-            Guard.Argument(controlToClone).NotNull();
+            try
+            {
+                Guard.Argument(controlToClone).NotNull();
 
-            var clonedControl = controlToClone.ControlDescription.Clone() as ControlDescription;
-            var controlDescriptionViewModel = new ControlDescriptionViewModel(clonedControl);
-            controlDescriptionViewModel.ControlName = Path.GetRandomFileName();
-            await SaveBitMapSource(controlDescriptionViewModel.ControlDescription, controlDescriptionViewModel.ImageSource);
-            await SaveControlDetails(controlDescriptionViewModel, true);          
-            this.Controls.Add(controlDescriptionViewModel);
-            logger.Information("Created a clone of control : {0}", controlToClone.ControlDescription);
+                var clonedControl = controlToClone.ControlDescription.Clone() as ControlDescription;
+                var controlDescriptionViewModel = new ControlDescriptionViewModel(clonedControl);
+                controlDescriptionViewModel.ControlName = Path.GetRandomFileName();
+                await SaveBitMapSource(controlDescriptionViewModel.ControlDescription, controlDescriptionViewModel.ImageSource);
+                await SaveControlDetails(controlDescriptionViewModel, true);
+                this.Controls.Add(controlDescriptionViewModel);
+                logger.Information("Created a clone of control : {0}", controlToClone.ControlDescription);
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "There was an error while trying to clone the control.");
+            }
         }
 
         /// <summary>

--- a/src/Pixel.Automation.Core/Controls/ControlDescription.cs
+++ b/src/Pixel.Automation.Core/Controls/ControlDescription.cs
@@ -86,7 +86,8 @@ namespace Pixel.Automation.Core.Controls
                 ControlName = this.ControlName,              
                 ControlImage = this.ControlImage,                         
                 GroupName = this.GroupName,
-                ApplicationId = this.ApplicationId               
+                ApplicationId = this.ApplicationId,
+                Version = this.Version
             };
         }
 


### PR DESCRIPTION
**Description**
The clone operation on a control fails due to a null reference exception as the version is null on the copy.
