### PR TITLE
Improvements and bug fixes for automation and prefab projects

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabProjectViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabProjectViewModel.cs
@@ -1,9 +1,7 @@
 ﻿using Dawn;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Models;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 
 namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
 {
@@ -39,20 +37,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
                 this.prefabProject.PrefabName = value;
                 OnPropertyChanged();
             }
-        }
-
-        /// <summary>
-        /// NameSpace for generated models. NameSpace must be unique
-        /// </summary>     
-        public string NameSpace
-        {
-            get => this.prefabProject.NameSpace;
-            set
-            {
-                this.prefabProject.NameSpace = value;
-                OnPropertyChanged();
-            }
-        }
+        }      
 
         /// <summary>
         /// Group name used to group prefab on UI

--- a/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabVersionViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabVersionViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using Caliburn.Micro;
 using Dawn;
-using Pixel.Automation.Core;
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.Models;
 using Pixel.Scripting.Editor.Core.Contracts;
@@ -124,10 +123,10 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
            
             this.fileSystem.Initialize(this.prefabProject, this.prefabVersion);
 
-            string prefabProjectName = this.prefabProject.GetPrefabName();
+            string prefabProjectName = this.prefabProject.PrefabName;
             ICodeWorkspaceManager workspaceManager = workspaceFactory.CreateCodeWorkspaceManager(this.fileSystem.DataModelDirectory);
             workspaceManager.WithAssemblyReferences(this.referenceManager.Value.GetCodeEditorReferences());
-            workspaceManager.AddProject(prefabProjectName, $"{Constants.PrefabDataModelName}.{this.prefabProject.GetPrefabName()}", Array.Empty<string>());
+            workspaceManager.AddProject(prefabProjectName, this.prefabProject.Namespace, Array.Empty<string>());
             string[] existingDataModelFiles = Directory.GetFiles(this.fileSystem.DataModelDirectory, "*.cs");
             if (existingDataModelFiles.Any())
             {
@@ -142,7 +141,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
                 }
             }
 
-            string assemblyName = this.prefabProject.GetPrefabName();
+            string assemblyName = this.prefabProject.Namespace;
             using (var compilationResult = workspaceManager.CompileProject(prefabProjectName, assemblyName))
             {
                 compilationResult.SaveAssemblyToDisk(this.fileSystem.ReferencesDirectory);
@@ -176,7 +175,6 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
             File.WriteAllText(processFile, fileContents);
 
         }
-
 
     }
 }

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/NewPrefabViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/NewPrefabViewModel.cs
@@ -3,10 +3,6 @@ using Pixel.Automation.Core;
 using Pixel.Automation.Core.Models;
 using Pixel.Automation.Editor.Core;
 using Serilog;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
 {
@@ -22,8 +18,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
             get => prefabProject.PrefabName;
             set
             {
-                prefabProject.PrefabName = value.Trim();
-                prefabProject.NameSpace = $"{Constants.PrefabDataModelName}.{this.prefabProject.GetPrefabName()}";
+                prefabProject.PrefabName = value ?? string.Empty;              
                 NotifyOfPropertyChange(PrefabName);           
                 ValidateProperty(nameof(PrefabName));
             }
@@ -51,8 +46,6 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
             }
         }
 
-
-
         public NewPrefabViewModel(ApplicationDescriptionViewModel applicationDescriptionViewModel, PrefabProject prefabToolBoxItem)
         {
             this.applicationDescriptionViewModel = applicationDescriptionViewModel;
@@ -71,6 +64,8 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
             errorDescription = string.Empty;
             if(Validate())
             {
+                this.PrefabName = this.PrefabName.Trim();
+                this.prefabProject.Namespace = $"{Constants.PrefabNameSpacePrefix}.{this.PrefabName.Replace(' ', '.')}";
                 logger.Information($"Prefab name is : {PrefabName}. Moving to next screen");            
                 return true;
             }
@@ -89,8 +84,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
         }
 
         #region INotifyDataErrorInfo
-
-        Regex isValidNameSpace = new Regex(@"([A-Za-z_]{1,})((\.){1}([A-Za-z_]{1,}))*", RegexOptions.Compiled);
+      
         private void ValidateProperty(string propertyName)
         {            
             ClearErrors(propertyName);
@@ -98,10 +92,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
             {
                 case nameof(PrefabName):
                     ValidateRequiredProperty(nameof(PrefabName), PrefabName);
-                    if(!isValidNameSpace.IsMatch(PrefabName))
-                    {
-                        AddOrAppendErrors(nameof(PrefabName), $"Value is not in expected format. Only characters, underscore and dots are allowed");
-                    }
+                    ValidatePattern("^([A-Za-z]|[._ ]){4,}$", nameof(PrefabName), PrefabName, "Name must contain only alphabets or ' ' or '_' and should be atleast 4 characters in length.");
                     if (this.applicationDescriptionViewModel.PrefabsCollection.Any(p => p.PrefabName.Equals(PrefabName)))
                     {
                         AddOrAppendErrors(nameof(PrefabName), $"Prefab with name {PrefabName} already exists for application {this.applicationDescriptionViewModel.ApplicationName}");                  

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabBuilderViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabBuilderViewModel.cs
@@ -120,7 +120,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
             var oldAssembly = prefabProject.PrefabRoot.EntityManager.Arguments.GetType()
                 .Assembly.GetName();
             var oldNameSpace = prefabProject.PrefabRoot.EntityManager.Arguments.GetType().Namespace;
-            var newAssemblyName = prefabProject.GetPrefabName();
+            var newAssemblyName = prefabProject.Namespace;
             string fileContents = File.ReadAllText(prefabFileSystem.PrefabFile);
             Regex assmelbyNameMatcher = new Regex($"{oldAssembly.Name}");
             fileContents = assmelbyNameMatcher.Replace(fileContents, (m) =>
@@ -129,7 +129,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
                 // Hence, we append _0 so that Regex matches as expected.
                 return $"{newAssemblyName}_0";
             });
-            fileContents = fileContents.Replace(oldNameSpace, prefabProject.NameSpace);
+            fileContents = fileContents.Replace(oldNameSpace, prefabProject.Namespace);
             File.WriteAllText(prefabFileSystem.PrefabFile, fileContents);
 
         }

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDataModelBuilderViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDataModelBuilderViewModel.cs
@@ -90,11 +90,11 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
             logger.Information("Start creating Prefab data model");
 
             var imports = RequiredProperties.Where(r => r.IsRequired).Select(s => s.NameSpace)?
-                .Distinct().Except(new[] { prefabProject.NameSpace, currentDataModel.GetType().Namespace }) ?? new List<string>();
+                .Distinct().Except(new[] { prefabProject.Namespace, currentDataModel.GetType().Namespace }) ?? new List<string>();
             imports = imports.Append(typeof(ParameterUsage).Namespace); 
             imports = imports.Append(typeof(ParameterUsageAttribute).Namespace);
 
-            var classBuilder = codeGenerator.CreateClassGenerator(Constants.PrefabDataModelName, prefabProject.NameSpace, imports);
+            var classBuilder = codeGenerator.CreateClassGenerator(Constants.PrefabDataModelName, prefabProject.Namespace, imports);
             foreach (var property in RequiredProperties.Where(r => r.IsRequired))
             {
                 classBuilder.AddProperty(property.PropertyName, property.PropertyType);
@@ -113,7 +113,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
         private void MirrorTargetType(Type targetType)
         {
             var imports = targetType.GetProperties().Select(s => s.PropertyType.Namespace).Distinct();
-            string generatedCode = codeGenerator.GenerateClassForType(targetType, prefabProject.NameSpace, imports);
+            string generatedCode = codeGenerator.GenerateClassForType(targetType, prefabProject.Namespace, imports);
             fileSystem.CreateOrReplaceFile(fileSystem.DataModelDirectory, $"{targetType.GetDisplayName()}.cs", generatedCode);
             logger.Information($"Mirror type created for type {targetType.GetDisplayName()}");
         }      

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDataModelEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDataModelEditorViewModel.cs
@@ -1,14 +1,11 @@
-﻿using Pixel.Scripting.Editor.Core.Contracts;
+﻿using Pixel.Automation.Core;
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.Models;
 using Pixel.Automation.Editor.Core;
-using System;
+using Pixel.Scripting.Editor.Core.Contracts;
+using Serilog;
 using System.IO;
 using System.Reflection;
-using System.Threading.Tasks;
-using System.Threading;
-using Pixel.Automation.Core;
-using Serilog;
 
 namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
 {
@@ -36,7 +33,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
         {
             try
             {               
-                using (var compilationResult = this.codeEditorFactory.CompileProject(prefabProject.PrefabId, $"{this.prefabProject.PrefabName.Trim().Replace(' ', '_')}_{++iteration}"))
+                using (var compilationResult = this.codeEditorFactory.CompileProject(prefabProject.PrefabId, $"{this.prefabProject.Namespace}_{++iteration}"))
                 {
                     logger.Information("Prefab assembly was successfuly compiled");
                     compilationResult.SaveAssemblyToDisk(this.prefabFileSystem.TempDirectory);                 
@@ -64,7 +61,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
 
         protected override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            logger.Information($"Activate screen is {nameof(PrefabDataModelEditorViewModel)}");
+            logger.Information($"Activated screen {nameof(PrefabDataModelEditorViewModel)}");
           
             var generatedCode = this.PreviousScreen.GetProcessedResult();
             if(string.IsNullOrEmpty(generatedCode?.ToString()))
@@ -75,7 +72,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
             //Can go back to previous screen and come back here again in which case CodeEditor should be already available.
             if(this.CodeEditor == null)
             {
-                this.codeEditorFactory.AddProject(prefabProject.PrefabId, prefabProject.NameSpace, Array.Empty<string>());
+                this.codeEditorFactory.AddProject(prefabProject.PrefabId, prefabProject.Namespace, Array.Empty<string>());
                 this.CodeEditor = this.codeEditorFactory.CreateMultiCodeEditorControl();
             }
          

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabInputMappingScriptEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabInputMappingScriptEditorViewModel.cs
@@ -46,15 +46,15 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         }
 
         /// <inheritdoc/>   
-        public override bool Validate()
-        {
-            var editorText = this.ScriptEditor.GetEditorText();
-            var (isValid, errors) = this.scriptEngine.IsScriptValid(editorText, dropTarget.EntityManager.Arguments);
-            if (!isValid)
-            {
-                AddOrAppendErrors("", errors);
-            }
-            return isValid;
-        }
+        //public override bool Validate()
+        //{
+        //    var editorText = this.ScriptEditor.GetEditorText();
+        //    var (isValid, errors) = this.scriptEngine.IsScriptValid(editorText, dropTarget.EntityManager.Arguments);
+        //    if (!isValid)
+        //    {
+        //        AddOrAppendErrors("", errors);
+        //    }
+        //    return true;
+        //}
     }
 }

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabInputMappingScriptEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabInputMappingScriptEditorViewModel.cs
@@ -28,6 +28,12 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         }
 
         /// <inheritdoc/>   
+        protected override void AddProject(string[] projectReferences)
+        {
+            this.scriptEditorFactory.AddProject(GetProjectName(), projectReferences, dropTarget.EntityManager.Arguments.GetType());
+        }
+
+        /// <inheritdoc/>   
         protected override string GetProjectName()
         {
             return $"{prefabEntity.Id}-InputMapping-Script";

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabMappingScriptEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabMappingScriptEditorViewModel.cs
@@ -64,14 +64,11 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
             NotifyOfPropertyChange(nameof(this.ScriptEditor));
 
             this.ScriptEditor.Activate();
-
-            void AddProject(string[] projectReferences)
-            {
-                this.scriptEditorFactory.AddProject(GetProjectName(), projectReferences, prefabEntity.GetPrefabDataModelType());
-            }
-        
+          
             return base.OnActivateAsync(cancellationToken);
         }
+
+        protected abstract void AddProject(string[] projectReferences);
 
         /// <summary>
         /// Get the generated code for mapping

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabOutputMappingScriptEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabOutputMappingScriptEditorViewModel.cs
@@ -28,6 +28,12 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         }
 
         /// <inheritdoc/>   
+        protected override void AddProject(string[] projectReferences)
+        {
+            this.scriptEditorFactory.AddProject(GetProjectName(), projectReferences, prefabEntity.GetPrefabDataModelType());
+        }
+
+        /// <inheritdoc/>   
         protected override string GetProjectName()
         {
             return $"{prefabEntity.Id}-OutputMapping-Script";

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabOutputMappingScriptEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabOutputMappingScriptEditorViewModel.cs
@@ -46,16 +46,16 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         }
 
         /// <inheritdoc/>   
-        public override bool Validate()
-        {
-            var editorText = this.ScriptEditor.GetEditorText();
-            var prefabArgument = Activator.CreateInstance(prefabEntity.GetPrefabDataModelType());
-            var (isValid, errors) = this.scriptEngine.IsScriptValid(editorText, prefabArgument);
-            if (!isValid)
-            {
-                AddOrAppendErrors("", errors);
-            }
-            return isValid;
-        }
+        //public override bool Validate()
+        //{
+        //    var editorText = this.ScriptEditor.GetEditorText();
+        //    var prefabArgument = Activator.CreateInstance(prefabEntity.GetPrefabDataModelType());    
+        //    var (isValid, errors) = this.scriptEngine.IsScriptValid(editorText, prefabArgument);
+        //    if (!isValid)
+        //    {
+        //        AddOrAppendErrors("", errors);
+        //    }
+        //    return true;
+        //}
     }
 }

--- a/src/Pixel.Automation.Core.Components/Prefabs/PrefabInstance.cs
+++ b/src/Pixel.Automation.Core.Components/Prefabs/PrefabInstance.cs
@@ -1,6 +1,7 @@
 ﻿using Dawn;
 using Pixel.Automation.Core.Interfaces;
 using System;
+using System.IO;
 
 namespace Pixel.Automation.Core.Components.Prefabs
 {
@@ -25,8 +26,12 @@ namespace Pixel.Automation.Core.Components.Prefabs
         /// </summary>
         /// <returns></returns>
         public Entity GetPrefabRootEntity()
-        {          
-            var prefabRoot = this.prefabFileSystem.GetPrefabEntity(this.dataModelType.GetType().Assembly);
+        {
+            if (!File.Exists(this.prefabFileSystem.PrefabFile))
+            {
+                throw new FileNotFoundException($"{this.prefabFileSystem.PrefabFile} not found");
+            }
+            var prefabRoot = this.prefabFileSystem.LoadFile<Entity>(this.prefabFileSystem.PrefabFile);
             prefabRoot.EntityManager = this.prefabEntityManager;
             this.prefabEntityManager.RestoreParentChildRelation(prefabRoot);
             //Setting argument will initialize all the required services such as script engine, argument processor , etc.
@@ -34,7 +39,7 @@ namespace Pixel.Automation.Core.Components.Prefabs
             this.prefabEntityManager.Arguments = dataModelInstance;
             return prefabRoot;
         }
-
+      
         /// <summary>
         /// Get the data model type for prefab process
         /// </summary>

--- a/src/Pixel.Automation.Core/Constants.cs
+++ b/src/Pixel.Automation.Core/Constants.cs
@@ -8,6 +8,12 @@
         public static readonly string NamespacePrefix = "Pixel.Automation";
 
         /// <summary>
+        /// Namespace prefix for prefab projects
+        /// </summary>
+        public static readonly string PrefabNameSpacePrefix = "Pixel.Prefabs";
+
+
+        /// <summary>
         /// Directory name where the controls belonging to application are stored locally
         /// </summary>
         public static readonly string ControlsDirectory = "Controls";
@@ -64,12 +70,7 @@
         /// Name of Prefab entity file which contains the automation workflow
         /// </summary>
         public static readonly string PrefabProcessFileName = "Prefab.proc";
-
-        /// <summary>
-        /// Namespace prefix for prefab projects
-        /// </summary>
-        public static readonly string PrefabNameSpace = "Pixel.Automation.Prefabs";
-
+     
         /// <summary>
         /// Data model name for the data model associated with the automation project.
         /// This data model acts as a global for scripts within Environment Setup and Environment TearDown

--- a/src/Pixel.Automation.Core/Constants.cs
+++ b/src/Pixel.Automation.Core/Constants.cs
@@ -3,6 +3,11 @@
     public static class Constants
     {
         /// <summary>
+        /// Prefix for generate namespace for automation and prefab projects
+        /// </summary>
+        public static readonly string NamespacePrefix = "Pixel.Automation";
+
+        /// <summary>
         /// Directory name where the controls belonging to application are stored locally
         /// </summary>
         public static readonly string ControlsDirectory = "Controls";

--- a/src/Pixel.Automation.Core/FileSystem/IFileSystem.cs
+++ b/src/Pixel.Automation.Core/FileSystem/IFileSystem.cs
@@ -219,14 +219,6 @@ namespace Pixel.Automation.Core.Interfaces
         Entity GetPrefabEntity();
 
         /// <summary>
-        /// Load Prefab Entity and update all data model reference to use this new data model assembly.
-        /// This is required because every time prefab data model is compiled a new assembly is generated.
-        /// </summary>
-        /// <param name="withDataModelAssembly"></param>
-        /// <returns></returns>
-        Entity GetPrefabEntity(Assembly withDataModelAssembly);
-
-        /// <summary>
         /// Save the specified entity as the prefab template
         /// </summary>
         /// <param name="templateRoot"></param>

--- a/src/Pixel.Automation.Core/FileSystem/PrefabFileSystem.cs
+++ b/src/Pixel.Automation.Core/FileSystem/PrefabFileSystem.cs
@@ -73,26 +73,7 @@ namespace Pixel.Automation.Core
             }
             Entity prefabRoot = this.serializer.Deserialize<Entity>(PrefabFile);
             return prefabRoot;
-        }
-
-        /// <InheritDoc/>      
-        public Entity GetPrefabEntity(Assembly withDataModelAssembly)
-        {
-            if (!File.Exists(this.PrefabFile))
-            {
-                throw new FileNotFoundException($"{this.PrefabFile} not found");
-            }
-            string fileContents = File.ReadAllText(this.PrefabFile);
-            Regex regex = new Regex(@"(Pixel\.Automation\.Project\.DataModels)(\.\w*)(,\s)([\w|\d]*)");           
-            fileContents = regex.Replace(fileContents, (m) =>
-            {
-                string result = m.Value.Replace($"{m.Groups[4].Value}", withDataModelAssembly.GetName().Name);         //replace assembly name
-                result = result.Replace($"{m.Groups[1].Value}", withDataModelAssembly.GetTypes().First().Namespace);  //replace namesapce
-                return result;
-            });          
-            Entity prefabRoot = this.serializer.DeserializeContent<Entity>(fileContents);
-            return prefabRoot;
-        }
+        }     
 
         /// <InheritDoc/>      
         public Assembly GetDataModelAssembly()

--- a/src/Pixel.Automation.Core/Models/AutomationProject.cs
+++ b/src/Pixel.Automation.Core/Models/AutomationProject.cs
@@ -12,12 +12,27 @@ namespace Pixel.Automation.Core.Models
     [DataContract]
     public class AutomationProject
     {
+        /// <summary>
+        /// Unique Identifier of the automation project
+        /// </summary>
         [DataMember(IsRequired = true, Order = 10)]
         public string ProjectId { get; set; } = Guid.NewGuid().ToString();
 
+        /// <summary>
+        /// Display Name of the automation project
+        /// </summary>
         [DataMember(IsRequired = true, Order = 20)]
         public string Name { get; set; } = string.Empty;
 
+        /// <summary>
+        /// NameSpace for generated models. NameSpace must be unique
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 40)]
+        public string Namespace { get; set; }
+
+        /// <summary>
+        /// Indicates when was the project last opened
+        /// </summary>
         [DataMember(IsRequired = true, Order = 40)]
         public DateTime LastOpened { get; set; } = DateTime.Now;
 
@@ -29,6 +44,9 @@ namespace Pixel.Automation.Core.Models
         /// </summary>
         public IEnumerable<ProjectVersion> DeployedVersions { get => AvailableVersions.Where(a => a.IsDeployed).ToList(); }
 
+        /// <summary>
+        /// Active version of the project
+        /// </summary>
         public ProjectVersion ActiveVersion
         {
             get => this.AvailableVersions.FirstOrDefault(a => a.IsActive);
@@ -40,15 +58,6 @@ namespace Pixel.Automation.Core.Models
         public AutomationProject()
         {
            
-        }
-
-        /// <summary>
-        /// Get the name of the project. Spaces are replaced by _ .
-        /// </summary>
-        /// <returns></returns>
-        public string GetProjectName()
-        {
-            return this.Name.Trim().Replace(' ','_');
         }
     }
 }

--- a/src/Pixel.Automation.Core/Models/PrefabProject.cs
+++ b/src/Pixel.Automation.Core/Models/PrefabProject.cs
@@ -28,7 +28,7 @@ namespace Pixel.Automation.Core.Models
         /// NameSpace for generated models. NameSpace must be unique
         /// </summary>
         [DataMember(IsRequired = true, Order = 40)]
-        public string NameSpace { get; set; }
+        public string Namespace { get; set; }
 
         /// <summary>
         /// Get all the versions created for this Prefab
@@ -76,16 +76,7 @@ namespace Pixel.Automation.Core.Models
         {
             this.PrefabRoot = prefabRoot;           
         }
-
-        /// <summary>
-        /// Get the name of the prefab. Empty spaces are replaced with _ .
-        /// </summary>
-        /// <returns></returns>
-        public string GetPrefabName()
-        {
-            return this.PrefabName.Trim().Replace(' ', '_');
-        }
-
+      
         ///</inheritdoc>
         public object Clone()
         {

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
@@ -147,12 +147,12 @@ namespace Pixel.Automation.Designer.ViewModels
               
                 //Add the project to workspace
                 var scriptEditorFactory = entityManager.GetServiceOfType<IScriptEditorFactory>();
-                scriptEditorFactory.AddProject(this.CurrentProject.GetProjectName(), new string[] {}, this.EntityManager.Arguments.GetType());
-                scriptEditorFactory.AddDocument(fileSystem.GetRelativePath(scriptFile), this.CurrentProject.GetProjectName(), File.ReadAllText(scriptFile));
+                scriptEditorFactory.AddProject(this.CurrentProject.Name, new string[] {}, this.EntityManager.Arguments.GetType());
+                scriptEditorFactory.AddDocument(fileSystem.GetRelativePath(scriptFile), this.CurrentProject.Name, File.ReadAllText(scriptFile));
                 //Create script editor and open the document to edit
                 using (IScriptEditorScreen scriptEditorScreen = scriptEditorFactory.CreateScriptEditorScreen())
                 {
-                    scriptEditorScreen.OpenDocument(fileSystem.GetRelativePath(scriptFile), this.CurrentProject.GetProjectName(), string.Empty);
+                    scriptEditorScreen.OpenDocument(fileSystem.GetRelativePath(scriptFile), this.CurrentProject.Name, string.Empty);
                     var result = await this.windowManager.ShowDialogAsync(scriptEditorScreen);
                     if (result.HasValue && result.Value)
                     {
@@ -160,7 +160,7 @@ namespace Pixel.Automation.Designer.ViewModels
                         scriptEngine.ClearState();
                         await scriptEngine.ExecuteFileAsync(scriptFile);
                     }
-                    scriptEditorFactory.RemoveProject(this.CurrentProject.GetProjectName());
+                    scriptEditorFactory.RemoveProject(this.CurrentProject.Name);
                 }             
             }
             catch (Exception ex)

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -67,7 +67,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             string[] dataModelFiles = Directory.GetFiles(this.projectFileSystem.DataModelDirectory, "*.cs");
             if (!dataModelFiles.Any())
             {
-                var classGenerator = this.codeGenerator.CreateClassGenerator(Constants.AutomationProcessDataModelName, $"Pixel.Automation.{this.GetProjectName()}", new[] { typeof(object).Namespace });
+                var classGenerator = this.codeGenerator.CreateClassGenerator(Constants.AutomationProcessDataModelName, this.GetProjectNamespace(), new[] { typeof(object).Namespace });
                 string dataModelInitialContent = classGenerator.GetGeneratedCode();
                 string dataModelFile = Path.Combine(this.fileSystem.DataModelDirectory, $"{Constants.AutomationProcessDataModelName}.cs");
                 await File.WriteAllTextAsync(dataModelFile, dataModelInitialContent);
@@ -209,7 +209,12 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 
         protected override string GetProjectName()
         {
-            return this.activeProject.GetProjectName();
+            return this.activeProject.Name;
+        }
+
+        protected override string GetProjectNamespace()
+        {
+            return this.activeProject.Namespace;
         }
 
         #endregion overridden methods

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/DesignTimePrefabLoader.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/DesignTimePrefabLoader.cs
@@ -1,7 +1,7 @@
-﻿using Pixel.Automation.Core;
-using Pixel.Automation.Core.Interfaces;
+﻿using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.RunTime;
 using Pixel.Scripting.Editor.Core.Contracts;
+using System.Reflection;
 
 namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 {
@@ -15,13 +15,12 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 
         }
 
-        protected override void ConfigureServices(IEntityManager parentEntityManager, IPrefabFileSystem prefabFileSystem)
+        protected override void ConfigureServices(IEntityManager parentEntityManager, IPrefabFileSystem prefabFileSystem, Assembly prefabAssembly)
         {
-            //Process entity manager should be able to resolve any assembly from prefab references folder such as prefab data model assembly 
-            var scriptEngineFactory = parentEntityManager.GetServiceOfType<IScriptEngineFactory>();
-            scriptEngineFactory.WithAdditionalSearchPaths(prefabFileSystem.ReferencesDirectory);
-
-            //Similalry, Script editor when working with prefab input and output mapping script should be able to resolve references from prefab references folder
+            base.ConfigureServices(parentEntityManager, prefabFileSystem, prefabAssembly);
+            
+            //Script editor when working with prefab input and output mapping script should be able to resolve references from prefab references folder
+            //at design time
             var scriptEditorFactory = parentEntityManager.GetServiceOfType<IScriptEditorFactory>();
             scriptEditorFactory.AddSearchPaths(prefabFileSystem.ReferencesDirectory);
         }

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -58,8 +58,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             ConfigureScriptEditor(this.referenceManager, dataModel);          
             this.entityManager.Arguments = dataModel;
             ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);
-            Initialize();
-            SetupInitializationScriptProject(dataModel);
+            Initialize();          
             return this.RootEntity;
         }
     
@@ -179,8 +178,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             var dataModel = CompileAndCreateDataModel(Constants.PrefabDataModelName);
             ConfigureScriptEngine(this.referenceManager, dataModel);
             ConfigureScriptEditor(this.referenceManager, dataModel);           
-            this.entityManager.Arguments = dataModel;
-            SetupInitializationScriptProject(dataModel);
+            this.entityManager.Arguments = dataModel;           
             ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);          
         }
 

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -208,11 +208,12 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 
         protected override string GetProjectName()
         {
-            return this.prefabProject.GetPrefabName();
+            return this.prefabProject.PrefabName;
+        }
 
         protected override string GetProjectNamespace()
         {
-            return this.prefabProject.NameSpace;
+            return this.prefabProject.Namespace;
         }
 
         #endregion overridden methods

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -14,20 +14,21 @@ using Pixel.Scripting.Editor.Core.Contracts;
 using Pixel.Scripting.Reference.Manager.Contracts;
 using Pixel.Scripting.Reference.Manager.Models;
 using System.IO;
-using System.Text.Json.Serialization;
 
 namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 {
+    /// <summary>
+    /// Manager for a <see cref="PrefabProject"/>
+    /// </summary>
     public class PrefabProjectManager : ProjectManager, IPrefabProjectManager
     {
         private readonly IPrefabFileSystem prefabFileSystem;
         private readonly IReferenceManagerFactory referenceManagerFactory;
         private IReferenceManager referenceManager;
         private readonly ApplicationSettings applicationSettings;
-        private PrefabProject prefabProject;
-        private VersionInfo loadedVersion;
+        private PrefabProject prefabProject;       
         private Entity prefabbedEntity;       
-
+             
         public PrefabProjectManager(ISerializer serializer, IEntityManager entityManager, IPrefabFileSystem prefabFileSystem, ITypeProvider typeProvider, IArgumentTypeProvider argumentTypeProvider,
             ICodeEditorFactory codeEditorFactory, IScriptEditorFactory scriptEditorFactory, IScriptEngineFactory scriptEngineFactory,
             ICodeGenerator codeGenerator, IApplicationDataManager applicationDataManager, ApplicationSettings applicationSettings,
@@ -43,8 +44,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 
         public Entity Load(PrefabProject prefabProject, VersionInfo versionToLoad)
         {
-            this.prefabProject = prefabProject;
-            this.loadedVersion = versionToLoad;
+            this.prefabProject = prefabProject;           
             this.prefabFileSystem.Initialize(prefabProject, versionToLoad);
             this.entityManager.SetCurrentFileSystem(this.fileSystem);
             this.entityManager.RegisterDefault<IFileSystem>(this.fileSystem);
@@ -209,6 +209,10 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
         protected override string GetProjectName()
         {
             return this.prefabProject.GetPrefabName();
+
+        protected override string GetProjectNamespace()
+        {
+            return this.prefabProject.NameSpace;
         }
 
         #endregion overridden methods

--- a/src/Pixel.Automation.Designer.ViewModels/Screen/NewProjectViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Screen/NewProjectViewModel.cs
@@ -1,15 +1,12 @@
 ﻿using Dawn;
+using Newtonsoft.Json.Linq;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.Models;
 using Pixel.Automation.Editor.Core;
 using Pixel.Persistence.Services.Client;
 using Serilog;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Pixel.Automation.Designer.ViewModels
 {
@@ -29,7 +26,8 @@ namespace Pixel.Automation.Designer.ViewModels
             get => this.NewProject.Name;
             set
             {
-                this.NewProject.Name = value;
+                value = value ?? string.Empty;
+                this.NewProject.Name = value;               
                 ValidateProjectName(value);
                 NotifyOfPropertyChange(() => Name);
                 NotifyOfPropertyChange(() => CanCreateNewProject);
@@ -56,6 +54,8 @@ namespace Pixel.Automation.Designer.ViewModels
         {
             try
             {
+                this.NewProject.Name = this.NewProject.Name.Trim();
+                this.NewProject.Namespace = $"{Constants.NamespacePrefix}.{this.NewProject.Name.Replace(' ', '.')}";
                 this.NewProject.LastOpened = DateTime.Now;
 
                 //create a directory inside projects directory with name equal to newProject identifier
@@ -95,7 +95,7 @@ namespace Pixel.Automation.Designer.ViewModels
         {
             ClearErrors(nameof(Name));
             ValidateRequiredProperty(nameof(Name), projectName);
-            ValidatePattern("^([A-Za-z]|[_]){4,}$", nameof(Name), projectName, "Name must contain only alphabets or '_' and should be atleast 4 characters in length.");
+            ValidatePattern("^([A-Za-z]|[._ ]){4,}$", nameof(Name), projectName, "Name must contain only alphabets or ' ' or '_' and should be atleast 4 characters in length.");
             if(!IsNameAvailable(projectName))
             {
                 this.AddOrAppendErrors(nameof(Name), "An application already exists with this name");

--- a/src/Pixel.Automation.Designer.ViewModels/VersionManager/ProjectVersionViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/VersionManager/ProjectVersionViewModel.cs
@@ -132,7 +132,7 @@ namespace Pixel.Automation.Designer.ViewModels.VersionManager
 
             ICodeWorkspaceManager workspaceManager = workspaceFactory.CreateCodeWorkspaceManager(this.fileSystem.DataModelDirectory);
             workspaceManager.WithAssemblyReferences(this.referenceManager.Value.GetCodeEditorReferences());
-            workspaceManager.AddProject(this.automationProject.Name, $"Pixel.Automation.{this.automationProject.GetProjectName()}",  Array.Empty<string>());
+            workspaceManager.AddProject(this.automationProject.Name, this.automationProject.Namespace, Array.Empty<string>());
             string[] existingDataModelFiles = Directory.GetFiles(this.fileSystem.DataModelDirectory, "*.cs");
             if (existingDataModelFiles.Any())
             {
@@ -147,7 +147,7 @@ namespace Pixel.Automation.Designer.ViewModels.VersionManager
                 }
             }
 
-            string assemblyName = this.automationProject.Name.Trim().Replace(' ', '_');
+            string assemblyName = this.automationProject.Namespace;
             using (var compilationResult = workspaceManager.CompileProject(this.automationProject.Name, assemblyName))
             {
                 compilationResult.SaveAssemblyToDisk(this.fileSystem.ReferencesDirectory);            

--- a/src/Pixel.Automation.Editor.Core/Helpers/CompositeTypeExtractor.cs
+++ b/src/Pixel.Automation.Editor.Core/Helpers/CompositeTypeExtractor.cs
@@ -1,4 +1,5 @@
-﻿using Pixel.Automation.Editor.Core.Interfaces;
+﻿using Pixel.Automation.Core.Arguments;
+using Pixel.Automation.Editor.Core.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -17,24 +18,30 @@ namespace Pixel.Automation.Editor.Core.Helpers
         {
             if (targetType.Assembly.Equals(containingAssembly))
             {
-                discoveredTypes.Add(targetType);
-                foreach (var property in targetType.GetProperties())
+                if (!discoveredTypes.Contains(targetType))
                 {
-                    foreach (var compositeType in ProcessType(property.PropertyType, containingAssembly, discoveredTypes))
+                    discoveredTypes.Add(targetType);
+                    foreach (var property in targetType.GetProperties())
                     {
-                        if(!discoveredTypes.Contains(compositeType))
+                        foreach (var compositeType in ProcessType(property.PropertyType, containingAssembly, discoveredTypes))
                         {
-                            discoveredTypes.Add(compositeType);
+                            if (!discoveredTypes.Contains(compositeType))
+                            {
+                                discoveredTypes.Add(compositeType);
+                            }
                         }
                     }
-                }                
+                }                     
             }
 
             if (targetType.IsGenericType)
             {
                 foreach (var argument in targetType.GetGenericArguments())
                 {
-                    ProcessType(argument, containingAssembly, discoveredTypes);
+                    if(!discoveredTypes.Contains(argument))
+                    {
+                        ProcessType(argument, containingAssembly, discoveredTypes);
+                    }
                 }
             }
 

--- a/src/Pixel.Automation.RunTime/PrefabLoader.cs
+++ b/src/Pixel.Automation.RunTime/PrefabLoader.cs
@@ -98,10 +98,8 @@ namespace Pixel.Automation.RunTime
             prefabEntityManager.SetIdentifier($"Prefab - {prefabId}");
             IPrefabFileSystem prefabFileSystem = prefabEntityManager.GetServiceOfType<IPrefabFileSystem>();
             prefabFileSystem.Initialize(prefabProject, versionToLoad);
-            prefabEntityManager.SetCurrentFileSystem(prefabFileSystem);
-          
-            ConfigureServices(parentEntityManager, prefabFileSystem);    
-
+            prefabEntityManager.SetCurrentFileSystem(prefabFileSystem);    
+         
             string prefabAssembly = Path.Combine(prefabFileSystem.ReferencesDirectory, versionToLoad.DataModelAssembly);
             if (!prefabFileSystem.Exists(prefabAssembly))
             {
@@ -116,15 +114,18 @@ namespace Pixel.Automation.RunTime
                     $"and preafbId : {prefabId}");
             }
 
+            ConfigureServices(parentEntityManager, prefabFileSystem, prefabDataModelAssembly);
+
             PrefabInstance prefabInstance = new PrefabInstance(prefabEntityManager, prefabFileSystem, dataModelType);
             return prefabInstance;
         }
 
-        protected virtual void ConfigureServices(IEntityManager parentEntityManager, IPrefabFileSystem prefabFileSystem)
+        protected virtual void ConfigureServices(IEntityManager parentEntityManager, IPrefabFileSystem prefabFileSystem, Assembly prefabAssembly)
         {
             //Process entity manager should be able to resolve any assembly from prefab references folder such as prefab data model assembly 
             var scriptEngineFactory = parentEntityManager.GetServiceOfType<IScriptEngineFactory>();
             scriptEngineFactory.WithAdditionalSearchPaths(prefabFileSystem.ReferencesDirectory);
+            scriptEngineFactory.WithAdditionalAssemblyReferences(prefabAssembly);
           
         }
 

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/AutomationProjectFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/AutomationProjectFixture.cs
@@ -17,8 +17,7 @@ namespace Pixel.Automation.Core.Tests.Models
             Assert.IsTrue(!automationProject.AvailableVersions.Any());
             Assert.IsNotNull(automationProject.DeployedVersions);
             Assert.IsTrue(!automationProject.DeployedVersions.Any());
-            Assert.IsNull(automationProject.ActiveVersion);
-            Assert.IsEmpty(automationProject.GetProjectName());
+            Assert.IsNull(automationProject.ActiveVersion);          
         }
 
         [Test]

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/PrefabDescriptionFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/PrefabDescriptionFixture.cs
@@ -18,7 +18,7 @@ namespace Pixel.Automation.Core.Tests.Models
             Assert.AreEqual(null, prefabProject.ApplicationId);
             Assert.AreEqual(null, prefabProject.PrefabId);
             Assert.AreEqual(null, prefabProject.PrefabName);
-            Assert.AreEqual(null, prefabProject.NameSpace);
+            Assert.AreEqual(null, prefabProject.Namespace);
             Assert.NotNull(prefabProject.AvailableVersions);
             Assert.NotNull(prefabProject.DeployedVersions);
             Assert.IsNull(prefabProject.ActiveVersion);
@@ -29,7 +29,7 @@ namespace Pixel.Automation.Core.Tests.Models
             prefabProject.ApplicationId = "ApplicationId";
             prefabProject.PrefabId = "PrefabId";
             prefabProject.PrefabName = "PrefabName";
-            prefabProject.NameSpace = "Prefab.PrefabName";
+            prefabProject.Namespace = $"{Constants.PrefabNameSpacePrefix}.PrefabName";
             prefabProject.AvailableVersions.Add(new PrefabVersion() { IsDeployed = true, Version = new Version(1, 0) });
             prefabProject.AvailableVersions.Add(new PrefabVersion() { IsActive = true, Version = new Version(2, 0) });
             prefabProject.Description = "Description";
@@ -39,7 +39,7 @@ namespace Pixel.Automation.Core.Tests.Models
             Assert.AreEqual("ApplicationId", prefabProject.ApplicationId);
             Assert.AreEqual("PrefabId", prefabProject.PrefabId);
             Assert.AreEqual("PrefabName", prefabProject.PrefabName);
-            Assert.AreEqual("Prefab.PrefabName", prefabProject.NameSpace);
+            Assert.AreEqual($"{Constants.PrefabNameSpacePrefix}.PrefabName", prefabProject.Namespace);
             Assert.AreEqual(2, prefabProject.AvailableVersions.Count());
             Assert.AreEqual(1, prefabProject.DeployedVersions.Count());
             Assert.NotNull(prefabProject.ActiveVersion);


### PR DESCRIPTION
**Improvements**
1. Allow space in automation project name in addition to . and _
2. Allow space in prefab project name in addition to . and _
3. No need to parse prefab file and replace namespace and assembly name  -- This is already done while deploying a prefab.

**Bug Fixes**
1. Add prefab assembly to script engine factory when loading a prefab -- Without this we can't use types and namespaces from prefab assembly
2. Correctly replace the namepsace in script while importing a script for Prefab -While importing scripts for prefab, we need to replace the namespace of  datamodel associated with entity which is used for creating prefab with the namespace of the prefab project. This is because the datamodel of the prefab is the data model defined in the prefab project once prefab is created and not the old model.
3. Composite Type Extractor should not process types that has already been processed -- Stack overflow exception occurs due to recursion as Composite Type Extractor tries to process a type with property of type self.
4. Use correct data model for input mapping script generation --
While generating the input and output mapping script, add the correct data models to act as globals when adding the project to script editor factory.
5. Skip validaiton of generated input and output mapping script -- 
Input and output mapping script can refer to the variables declared in script from the scope to which they are added. These variables can be made available in the script editor but validation fails as we no way to include these script variables while doing validation .This blocks the add prefab wizard. Skip validation for the time being until we have a better solution.