### PR TITLE
More bug fixes for prefabs

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/NewPrefabViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/NewPrefabViewModel.cs
@@ -48,6 +48,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
 
         public NewPrefabViewModel(ApplicationDescriptionViewModel applicationDescriptionViewModel, PrefabProject prefabToolBoxItem)
         {
+            this.DisplayName = "(1/4) Create a new Prefab";
             this.applicationDescriptionViewModel = applicationDescriptionViewModel;
             this.prefabProject = prefabToolBoxItem;
             this.prefabProject.PrefabName = "Prefab";

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabBuilderViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabBuilderViewModel.cs
@@ -35,7 +35,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
             IPrefabFileSystem prefabFileSystem, ICodeGenerator codeGenerator, ICodeEditorFactory codeEditorFactory,
             IScriptEngineFactory scriptEngineFactory, IReferenceManagerFactory referenceManagerFactory)
         {
-            this.DisplayName = "Prefab Builder";
+            this.DisplayName = "(1/4) Create a new Prefab";
             this.prefabFileSystem = prefabFileSystem;
             this.codeGenerator = codeGenerator;
             this.codeEditorFactory = codeEditorFactory;

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDataModelBuilderViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDataModelBuilderViewModel.cs
@@ -49,7 +49,8 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
             Guard.Argument(compositeTypeExtractor).NotNull();
             Guard.Argument(argumentExtractor).NotNull();
             Guard.Argument(scriptEngine).NotNull();
-
+           
+            this.DisplayName = "(2/4) Select required properties";
             this.prefabProject = prefabProject;
             this.codeGenerator = codeGenerator;
             this.scriptEngine = scriptEngine;

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDataModelEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDataModelEditorViewModel.cs
@@ -24,6 +24,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
 
         public PrefabDataModelEditorViewModel(PrefabProject prefabProject, IPrefabFileSystem projectFileSystem, ICodeEditorFactory codeEditorFactory)
         {
+            this.DisplayName = "(3/4) Edit data model";
             this.prefabProject = prefabProject;
             this.codeEditorFactory = codeEditorFactory;           
             this.prefabFileSystem = projectFileSystem;

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDragHandler.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDragHandler.cs
@@ -1,6 +1,8 @@
 ﻿using GongSolutions.Wpf.DragDrop;
 using Pixel.Automation.AppExplorer.ViewModels.Prefab;
 using Pixel.Automation.Core;
+using Pixel.Automation.Core.Components.Prefabs;
+using Pixel.Automation.Core.Enums;
 using Pixel.Automation.Editor.Core.ViewModels;
 using Serilog;
 using System.Windows;
@@ -9,12 +11,18 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
 {
     public class PrefabDragHandler : IDropTarget
     {
+        private readonly ILogger logger = Log.ForContext<PrefabDragHandler>();
         public void DragOver(IDropInfo dropInfo)
         {
             if (dropInfo.Data != null)
             {
-                if (dropInfo.Data is EntityComponentViewModel)
+                if (dropInfo.Data is EntityComponentViewModel ecvm)
                 {
+                    if ((ecvm.Model is PrefabEntity) || (ecvm.Model is Entity e
+                        && e.GetFirstComponentOfType<PrefabEntity>(SearchScope.Descendants, false) != null))
+                    {                       
+                        return;
+                    }
                     dropInfo.DropTargetAdorner = DropTargetAdorners.Highlight;
                     dropInfo.Effects = DragDropEffects.Copy;
                 }
@@ -33,7 +41,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                logger.Error(ex, ex.Message);
             }
         }
     }

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabScriptsImporterViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabScriptsImporterViewModel.cs
@@ -39,6 +39,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
         public PrefabScriptsImporterViewModel(PrefabProject prefabToolBoxItem, Entity rootEntity, IScriptExtactor scriptExtractor,
             IArgumentExtractor argumentExtractor, IPrefabFileSystem prefabFileSystem, IScriptEngineFactory scriptEngineFactory, IReferenceManager referenceManager)
         {
+            this.DisplayName = "(4/4) Import required scripts";
             this.prefabProject = Guard.Argument(prefabToolBoxItem).NotNull().Value;
             this.prefabFileSystem = Guard.Argument(prefabFileSystem).NotNull().Value;
             this.scriptExtractor = Guard.Argument(scriptExtractor).NotNull().Value;

--- a/src/Pixel.Automation.Core/Component/Entity.cs
+++ b/src/Pixel.Automation.Core/Component/Entity.cs
@@ -16,7 +16,7 @@ namespace Pixel.Automation.Core
     [Serializable]
     public class Entity : Component
     {
-        protected List<IComponent> components = new ();       
+        protected readonly List<IComponent> components = new ();       
         /// <summary>
         /// List of all components added to Entity
         /// </summary>
@@ -27,11 +27,7 @@ namespace Pixel.Automation.Core
             get
             {
                 return components;
-            }
-            protected set
-            {
-                components = value;
-            }
+            }           
         }
        
         /// <summary>


### PR DESCRIPTION
**Description**
1. Prefab builder wizards now have proper display names for each step
2. Nested prefabs should not be allowed to be created.
3. Serializing a PrefabEntity would also cause its components to serialize as part of test case and fail it to load later as the custom types from prefab are not available while loading test case. Ensure that Components are always cleared after execution so that it doesn't get's serialized.