### PR TITLE
Allow associated scripts to be marked for deletion when deleting a component

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/Screen/DeleteComponentViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Screen/DeleteComponentViewModel.cs
@@ -1,0 +1,82 @@
+﻿using Caliburn.Micro;
+using Dawn;
+using Pixel.Automation.Editor.Core.ViewModels;
+using Serilog;
+using System.IO;
+using Screen = Caliburn.Micro.Screen;
+
+namespace Pixel.Automation.Designer.ViewModels
+{
+    /// <summary>
+    /// Delete Component View is present as a popup window while deleting a component.
+    /// It serves as a confirmation and allows marking if scripts associated with component should be deleted as well.
+    /// </summary>
+    public class DeleteComponentViewModel : Screen
+    {
+        private readonly ILogger logger = Log.ForContext<DeleteComponentViewModel>();
+       
+        /// <summary>
+        /// Component being deleted
+        /// </summary>
+        private readonly ComponentViewModel componentViewModel;
+        
+        /// <summary>
+        /// Scripts associated with the component
+        /// </summary>
+        public BindableCollection<SelectableItem<string>> Scripts { get; private set; } = new ();
+
+        public bool HasScripts
+        {
+            get => this.Scripts.Any();
+        }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="componentViewModel"></param>
+        /// <param name="scripts"></param>
+        public DeleteComponentViewModel(ComponentViewModel componentViewModel, IEnumerable<ScriptStatus> scripts)
+        {
+            this.DisplayName = "Delete Component";
+            this.componentViewModel = Guard.Argument(componentViewModel).NotNull();
+            Guard.Argument(scripts).NotNull();
+            this.Scripts.AddRange(scripts.Select(s => new SelectableItem<string>(s.ScriptName, true)));          
+        }
+
+        /// <summary>
+        /// Handler for click event of Delete button
+        /// </summary>
+        /// <returns></returns>
+        public async Task Delete()
+        {
+            var fileSystem = this.componentViewModel.Model.EntityManager.GetCurrentFileSystem();
+            foreach (var script in Scripts)
+            {
+                try
+                {
+                    if(script.IsSelected)
+                    {
+                        File.Delete(Path.Combine(fileSystem.WorkingDirectory, script.Item));
+                        logger.Information($"Deleted script file {script.Item}");
+                    }                    
+                }
+                catch (Exception ex)
+                {
+                    logger.Error($"There was an error while trying to delete file : {script.Item}", ex);
+                }
+            }
+            componentViewModel.Parent.RemoveComponent(componentViewModel);
+            await this.TryCloseAsync(true);         
+        }
+
+        /// <summary>
+        /// Handler for click event of Cancel button
+        /// </summary>
+        /// <returns></returns>
+        public async Task Cancel()
+        {
+            await this.TryCloseAsync(false);
+        }
+    }
+
+}

--- a/src/Pixel.Automation.Designer.Views/Screen/DeleteComponentView.xaml
+++ b/src/Pixel.Automation.Designer.Views/Screen/DeleteComponentView.xaml
@@ -1,0 +1,43 @@
+﻿<Controls:MetroWindow  x:Class="Pixel.Automation.Designer.Views.DeleteComponentView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Pixel.Automation.Designer.Views"
+             xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             mc:Ignorable="d" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner"          
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Controls:MetroWindow.Resources>
+        <ResourceDictionary>
+            <Thickness x:Key="ControlMargin">10 10 10 10</Thickness>
+            <BooleanToVisibilityConverter x:Key="boolToVisibilityConverter"/>
+        </ResourceDictionary>
+    </Controls:MetroWindow.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+        </Grid.RowDefinitions>
+        <TextBlock Text="Are you sure you want to delete this component?" Margin="10,20,10,5" Grid.Row="0" FontWeight="Bold"/>
+        <StackPanel Orientation="Vertical" MinWidth="320" Grid.Row="1" Margin="10,5,10,10" Visibility="{Binding HasScripts, Converter={StaticResource boolToVisibilityConverter}}">
+            <TextBlock Text="Selected scripts will be deleted along with Component !!" Margin="5"/>
+            <ItemsControl x:Name="Scripts" Margin="5">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <CheckBox x:Name="IsSelected" IsChecked="{Binding IsSelected}"/>
+                            <TextBlock x:Name="Item" Text="{Binding Item}"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+        <DockPanel LastChildFill="False"  Grid.Row="2">
+            <Border DockPanel.Dock="Top" BorderThickness="1" Height="1" HorizontalAlignment="Stretch" 
+                    Width="{Binding Path=Width,RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type DockPanel}}}" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+            <Button x:Name="Cancel" Content="CANCEL" Width="100" DockPanel.Dock="Right"  Margin="{StaticResource ControlMargin}" Style="{DynamicResource MahApps.Styles.Button.Square}"/>
+            <Button x:Name="Delete" Content="DELETE" DockPanel.Dock="Right" Width="100" Margin="0,10,0,10"  Style="{DynamicResource MahApps.Styles.Button.Square.Accent}"/>
+        </DockPanel>
+    </Grid>
+</Controls:MetroWindow>

--- a/src/Pixel.Automation.Designer.Views/Screen/DeleteComponentView.xaml.cs
+++ b/src/Pixel.Automation.Designer.Views/Screen/DeleteComponentView.xaml.cs
@@ -1,0 +1,13 @@
+﻿namespace Pixel.Automation.Designer.Views
+{
+    /// <summary>
+    /// Interaction logic for DeleteComponentView.xaml
+    /// </summary>
+    public partial class DeleteComponentView
+    {
+        public DeleteComponentView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IEditor.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IEditor.cs
@@ -20,7 +20,7 @@ namespace Pixel.Automation.Editor.Core.Interfaces
         /// Remove a component from view
         /// </summary>
         /// <param name="componentViewModel"></param>
-        void DeleteComponent(ComponentViewModel componentViewModel);
+        Task DeleteComponent(ComponentViewModel componentViewModel);
 
         /// <summary>
         /// Open code editor that can be used to add , remove or modify existing data models for the project

--- a/src/Pixel.Automation.Editor.Core/ViewModels/SelectableItem.cs
+++ b/src/Pixel.Automation.Editor.Core/ViewModels/SelectableItem.cs
@@ -1,0 +1,43 @@
+﻿using Dawn;
+using Pixel.Automation.Core;
+
+namespace Pixel.Automation.Editor.Core.ViewModels
+{
+    /// <summary>
+    /// Wrapper for models that can be marked as selected
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class SelectableItem<T> : NotifyPropertyChanged where T:class
+    {
+        /// <summary>
+        /// Item that needs to be marked
+        /// </summary>
+        public T Item { get; private set; }
+
+        private bool isSelected;
+        /// <summary>
+        /// Indicates if Item is selected
+        /// </summary>
+        public bool IsSelected
+        {
+            get => isSelected;
+            set
+            {
+                isSelected = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="item">Item to be marked</param>
+        /// <param name="isSelected">Indicate if item is initially selected</param>
+        public SelectableItem(T item, bool isSelected)
+        {
+            this.Item = Guard.Argument(item).NotNull();
+            this.IsSelected = isSelected;
+        }
+
+    }
+}


### PR DESCRIPTION
**Description**
When deleting a component, we would want to delete all the scripts associated with it. However, there can be scenarios where there script is shared. Hence, it should be possible to specify what scripts should be deleted when deleting a component instead of automatically deleting all scripts.