### PR TITLE
Allow input and output mapping script to be picked for prefabs

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabDropHandlerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabDropHandlerViewModel.cs
@@ -31,7 +31,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         /// <param name="entityManager">EntityManager of the Entity which is the drop target</param>
         public PrefabDropHandlerViewModel(IEntityManager entityManager, PrefabProjectViewModel prefabProjectViewModel, EntityComponentViewModel dropTarget)
         {
-            this.DisplayName = "(1/3) Select prefab version";
+            this.DisplayName = "(1/3) Select prefab version and mapping scripts";
             this.scriptEditorFactory = entityManager.GetServiceOfType<IScriptEditorFactory>(); ;
             this.projectFileSystem = entityManager.GetCurrentFileSystem() as IProjectFileSystem;
             this.prefabFileSystem = entityManager.GetServiceOfType<IPrefabFileSystem>();

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabMappingScriptEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabMappingScriptEditorViewModel.cs
@@ -3,6 +3,7 @@ using Pixel.Automation.Core.Components.Prefabs;
 using Pixel.Automation.Core.Components.TestCase;
 using Pixel.Automation.Editor.Core;
 using Pixel.Scripting.Editor.Core.Contracts;
+using System.IO;
 
 namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
 {
@@ -37,7 +38,16 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         /// <inheritdoc/>       
         protected override Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            string generatedCode = GetGeneratedCode();
+            string scriptFile = GetScriptFile();
+            string generatedCode;
+            if (File.Exists(scriptFile))
+            {
+                generatedCode = File.ReadAllText(scriptFile);
+            }
+            else
+            {
+                generatedCode = GetGeneratedCode();
+            }           
             this.ScriptEditor = this.scriptEditorFactory.CreateInlineScriptEditor(new EditorOptions() 
             {
                 EnableDiagnostics = true,

--- a/src/Pixel.Automation.AppExplorer.Views/PrefabDropHandler/PrefabVersionSelectorView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/PrefabDropHandler/PrefabVersionSelectorView.xaml
@@ -4,21 +4,27 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
-        mc:Ignorable="d"
-        MaxHeight="175" Width="350">
+        xmlns:cal="http://www.caliburnproject.org"
+        xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"  
+        mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
             <Thickness x:Key="ControlMargin">0 5 0 0</Thickness>
+            <BooleanToVisibilityConverter x:Key="boolToVisibilityConverter"/>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Grid Margin="10">
+    <Grid Margin="10" DockPanel.Dock="Top">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="10px"></RowDefinition>
-            <RowDefinition Height="Auto"></RowDefinition>            
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="10px"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="10px"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
         </Grid.RowDefinitions>
         <DockPanel LastChildFill="True" MinWidth="320" Grid.Row="0">
-            <Label Content="Name" MinWidth="80" DockPanel.Dock="Left" ></Label>        
+            <Label Content="Name" MinWidth="80" DockPanel.Dock="Left" ></Label>
             <TextBox DockPanel.Dock="Right" Margin="{StaticResource ControlMargin}" VerticalAlignment="Center"
                          Text="{Binding PrefabName, Mode=OneWay}" IsReadOnly="True"
                          Controls:TextBoxHelper.Watermark="Prefab Name"
@@ -29,6 +35,32 @@
             <Label Content="Version" DockPanel.Dock="Left" MinWidth="80"></Label>
             <ComboBox ItemsSource="{Binding AvailableVersions}" DockPanel.Dock="Right" IsEnabled="{Binding CanChangeVersion}"
                   SelectedItem="{Binding SelectedVersion}" ToolTip="Prefab version to use"/>
-        </DockPanel>       
+        </DockPanel>
+        <DockPanel LastChildFill="True" Grid.Row="4">
+            <Label Content="Input Script" DockPanel.Dock="Left" MinWidth="80"></Label>
+            <DockPanel LastChildFill="True" HorizontalAlignment="Stretch" DockPanel.Dock="Left">
+                <Button x:Name="PickInputMappingScriptFile"  Width="20" Height="Auto" Margin="0" Style="{StaticResource SquaredButtonStyle}" 
+                    Content="{iconPacks:FontAwesome Kind=FolderOpenRegular}" DockPanel.Dock="Right"
+                    BorderThickness="0,1,1,1"  Foreground="{DynamicResource MahApps.Brushes.Accent}" 
+                    RenderTransformOrigin="0.5,0.5" ToolTip="Browse for script"/>
+                <TextBox x:Name="InputMappingScriptFile" DockPanel.Dock="Right" VerticalAlignment="Center"                     
+                         Controls:TextBoxHelper.Watermark="Input Mapping Script" HorizontalAlignment="Stretch"
+                         Controls:TextBoxHelper.UseFloatingWatermark="True"                                                   
+                         ToolTip="Script for mapping external variables to prefab inputs" />
+            </DockPanel>
+        </DockPanel>
+        <DockPanel LastChildFill="True" Grid.Row="6">
+            <Label Content="Output Script" DockPanel.Dock="Left" MinWidth="80"></Label>
+            <DockPanel LastChildFill="True" HorizontalAlignment="Stretch" DockPanel.Dock="Left">
+                <Button x:Name="PickOutputMappingScriptFile"  Width="20" Height="Auto" Margin="0" Style="{StaticResource SquaredButtonStyle}" 
+                    Content="{iconPacks:FontAwesome Kind=FolderOpenRegular}" DockPanel.Dock="Right"
+                    BorderThickness="0,1,1,1"  Foreground="{DynamicResource MahApps.Brushes.Accent}" 
+                    RenderTransformOrigin="0.5,0.5" ToolTip="Browse for script"/>
+                <TextBox x:Name="OutputMappingScriptFile" DockPanel.Dock="Right" VerticalAlignment="Center"                     
+                         Controls:TextBoxHelper.Watermark="Output Mapping Script"
+                         Controls:TextBoxHelper.UseFloatingWatermark="True" HorizontalAlignment="Stretch"                                                   
+                         ToolTip="Script for mapping external variables to prefab outputs" />
+            </DockPanel>
+        </DockPanel>
     </Grid>
 </UserControl>

--- a/src/Pixel.Automation.Editor.Core/SmartScreen.cs
+++ b/src/Pixel.Automation.Editor.Core/SmartScreen.cs
@@ -21,6 +21,7 @@ namespace Pixel.Automation.Editor.Core
         public virtual void DismissModelErrors()
         {
             ClearErrors("");
+            NotifyOfPropertyChange(() => HasErrors);
             NotifyOfPropertyChange(() => ShowModelErrors);
         }
 
@@ -46,8 +47,7 @@ namespace Pixel.Automation.Editor.Core
             {
                 existingErrors.Add(error);               
             }
-            OnErrorsChanged(propertyName);
-            NotifyOfPropertyChange(() => ShowModelErrors);
+            OnErrorsChanged(propertyName);          
         }
 
 
@@ -59,8 +59,7 @@ namespace Pixel.Automation.Editor.Core
             }
             var existingErrors = propertyErrors[propertyName];         
             existingErrors.AddRange(errors);
-            OnErrorsChanged(propertyName);
-            NotifyOfPropertyChange(() => ShowModelErrors);
+            OnErrorsChanged(propertyName);           
         }
 
         protected virtual void ClearErrors(string propertyName)
@@ -75,6 +74,8 @@ namespace Pixel.Automation.Editor.Core
         protected virtual void OnErrorsChanged(string propertyName)
         {
             ErrorsChanged.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+            NotifyOfPropertyChange(() => HasErrors);
+            NotifyOfPropertyChange(() => ShowModelErrors);
         }
 
         #endregion INotifyDataErrorInfo


### PR DESCRIPTION
**Description**
While adding a prefab , allow users to select existing scripts for input and output mapping. Same prefab might be used multiple times in a test case or across test cases. It should be possible to share mapping scripts among these prefabs.