### PR TITLE
pixel runner complete refactoring

### DIFF
--- a/src/Pixel.Automation.Test.Runner/Commands/CleanDataCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/CleanDataCommand.cs
@@ -1,0 +1,29 @@
+﻿using Dawn;
+using Pixel.Persistence.Services.Client;
+using Spectre.Console.Cli;
+
+namespace Pixel.Automation.Test.Runner.Commands;
+
+/// <summary>
+/// Clean data command deletes all the local application and automation data
+/// </summary>
+internal sealed class CleanDataCommand : Command<Settings>
+{
+    private readonly IApplicationDataManager applicationDataManager;
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="applicationDataManager"></param>
+    public CleanDataCommand(IApplicationDataManager applicationDataManager)
+    {
+        this.applicationDataManager = Guard.Argument(applicationDataManager, nameof(applicationDataManager)).NotNull().Value;
+    }
+
+    /// <inheritdoc/>    
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        applicationDataManager.CleanLocalData();       
+        return 0;
+    }
+}

--- a/src/Pixel.Automation.Test.Runner/Commands/CreateTemplateCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/CreateTemplateCommand.cs
@@ -1,0 +1,28 @@
+﻿using Spectre.Console.Cli;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Test.Runner.Commands;
+
+/// <summary>
+/// Create template command is used to create a new test session template
+/// </summary>
+internal sealed class CreateTemplateCommand : AsyncCommand<TemplateSettings>
+{
+    private readonly TemplateManager templateManager;
+ 
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="templateManager"></param>
+    public CreateTemplateCommand(TemplateManager templateManager)
+    {         
+        this.templateManager = templateManager;        
+    }
+
+    /// <inheritdoc/>    
+    public override async Task<int> ExecuteAsync(CommandContext context, TemplateSettings settings)
+    {
+        await templateManager.CreateNewAsync();
+        return 0;
+    }
+}

--- a/src/Pixel.Automation.Test.Runner/Commands/EditTemplateCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/EditTemplateCommand.cs
@@ -1,0 +1,37 @@
+﻿using Dawn;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Test.Runner.Commands;
+
+/// <summary>
+/// Edit template command is used to edit an existing template
+/// </summary>
+internal sealed class EditTemplateCommand : AsyncCommand<TemplateSettings>
+{
+    private readonly TemplateManager templateManager;
+    private readonly IAnsiConsole console;
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="templateManager"></param>
+    /// <param name="console"></param>
+    public EditTemplateCommand(TemplateManager templateManager, IAnsiConsole console)
+    {
+        this.templateManager = Guard.Argument(templateManager, nameof(templateManager)).NotNull();
+        this.console = Guard.Argument(console, nameof(console)).NotNull().Value;
+    }
+
+    /// <inheritdoc/>    
+    public override async Task<int> ExecuteAsync(CommandContext context, TemplateSettings settings)
+    {
+        var templateName = console.Ask<string>("Enter name of [green]template[/] to edit");
+        var templateToEdit = await templateManager.GetByNameAsync(templateName) ?? 
+            throw new ArgumentException($"Template with name {templateName} could not be retrieved");
+        await templateManager.UpdateAsync(templateToEdit);
+        return 0;
+    }
+}

--- a/src/Pixel.Automation.Test.Runner/Commands/ExecuteAdhocTestCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/ExecuteAdhocTestCommand.cs
@@ -1,0 +1,79 @@
+﻿using Dawn;
+using Pixel.Persistence.Core.Models;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using static Pixel.Automation.Test.Runner.Commands.ExecuteAdhocTestCommand;
+
+namespace Pixel.Automation.Test.Runner.Commands;
+
+/// <summary>
+/// Execute adhoc test command is used to execute tests without using a template
+/// </summary>
+internal sealed class ExecuteAdhocTestCommand : AsyncCommand<AdhocTestSettings>
+{
+    public sealed class AdhocTestSettings : ExecuteTestSettings
+    {
+        [Description("Name of the automation project")]
+        [CommandArgument(0, "<Project>")]
+        public string Project { get; init; }
+
+        [Description("Version of the automation project to use")]
+        [CommandArgument(1, "[Version]")]
+        public string Version { get; init; }
+
+        [Description("Test case selector script")]
+        [CommandArgument(2, "<Selector>")]
+        public string Selector { get; init; }
+
+        [Description("Name of the initialization script file")]
+        [CommandArgument(3, "<InitScriptFile>")]
+        public string InitializationScript { get; init; }
+
+        [Description("Only list the test cases without executing them")]
+        [CommandOption("-l|--list")]
+        public bool? List { get; set; }
+    }
+
+    private readonly IAnsiConsole console;
+    private readonly ProjectManager projectManager;
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="console"></param>
+    /// <param name="projectManager"></param>
+    public ExecuteAdhocTestCommand(IAnsiConsole console, ProjectManager projectManager)
+    {
+        this.projectManager = Guard.Argument(projectManager, nameof(projectManager)).NotNull();
+        this.console = Guard.Argument(console, nameof(console)).NotNull().Value;
+    }
+
+    /// <inheritdoc/>    
+    public override async Task<int> ExecuteAsync(CommandContext context, AdhocTestSettings settings)
+    {
+        Debugger.Launch();
+        var sessionTemplate = new SessionTemplate()
+        {
+            Name = Guid.NewGuid().ToString(),
+            ProjectName = settings.Project,            
+            Selector = settings.Selector,
+            InitializeScript =  settings.InitializationScript
+        };       
+    
+        await projectManager.LoadProjectAsync(sessionTemplate, settings.Version);
+        projectManager.LoadTestCases();
+        if (settings.List.GetValueOrDefault())
+        {
+            await projectManager.ListAllAsync(sessionTemplate.Selector, console);
+        }
+        else
+        {
+            await projectManager.RunAllAsync(sessionTemplate.Selector);
+        }
+        return 0;
+    }
+}

--- a/src/Pixel.Automation.Test.Runner/Commands/ExecuteTestFromTemplateCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/ExecuteTestFromTemplateCommand.cs
@@ -1,0 +1,62 @@
+﻿using Dawn;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using static Pixel.Automation.Test.Runner.Commands.ExecuteTestFromTemplateCommand;
+
+namespace Pixel.Automation.Test.Runner.Commands;
+
+
+/// <summary>
+/// Execute test from template command is used to execute tests by specifying a template and optionally project version to use
+/// </summary>
+internal sealed class ExecuteTestFromTemplateCommand : AsyncCommand<ExecuteTestFromTemplateSettings>
+{
+    public sealed class ExecuteTestFromTemplateSettings : ExecuteTestSettings
+    {
+        [Description("Name of the template to use")]
+        [CommandArgument(0, "<Name>")]
+        public string TemplateName { get; init; }
+
+        [Description("Version of the project to use e.g. 1.0.0.0")]
+        [CommandArgument(1, "[Version]")]
+        public string Version { get; init; }
+
+        [Description("Only list the test cases without executing them")]
+        [CommandOption("-l|--list")]
+        public bool? List { get; set; }
+
+    }
+
+    private readonly IAnsiConsole console;
+    private readonly TemplateManager templateManager;
+    private readonly ProjectManager projectManager;
+
+    public ExecuteTestFromTemplateCommand(IAnsiConsole console, TemplateManager templateManager, ProjectManager projectManager)
+    {
+        this.templateManager = Guard.Argument(templateManager, nameof(templateManager)).NotNull();
+        this.projectManager = Guard.Argument(projectManager, nameof(projectManager)).NotNull();
+        this.console = Guard.Argument(console, nameof(console)).NotNull().Value;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, ExecuteTestFromTemplateSettings settings)
+    {
+        Debugger.Launch();
+        var sessionTemplate = await templateManager.GetByNameAsync(settings.TemplateName) ??
+            throw new ArgumentException($"Template with name : {0} doesn't exist", settings.TemplateName);
+        await projectManager.LoadProjectAsync(sessionTemplate, settings.Version);
+        projectManager.LoadTestCases();
+        if(settings.List.GetValueOrDefault())
+        {
+            await projectManager.ListAllAsync(sessionTemplate.Selector, console);
+        }
+        else
+        {
+            await projectManager.RunAllAsync(sessionTemplate.Selector);
+        }
+        return 0;
+    }
+}

--- a/src/Pixel.Automation.Test.Runner/Commands/ListTemplatesCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/ListTemplatesCommand.cs
@@ -1,0 +1,28 @@
+﻿using Spectre.Console.Cli;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Test.Runner.Commands;
+
+/// <summary>
+/// List templates command is used to list all available templates
+/// </summary>
+internal sealed class ListTemplatesCommand : AsyncCommand<TemplateSettings>
+{
+    private readonly TemplateManager templateManager;
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="templateManager"></param>
+    public ListTemplatesCommand(TemplateManager templateManager)
+    {
+        this.templateManager = templateManager;
+    }
+
+    /// <inheritdoc/>    
+    public override async Task<int> ExecuteAsync(CommandContext context, TemplateSettings settings)
+    {
+        await templateManager.ListAllAsync();
+        return 0;
+    }
+}

--- a/src/Pixel.Automation.Test.Runner/Commands/Settings.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/Settings.cs
@@ -1,0 +1,18 @@
+﻿using Spectre.Console.Cli;
+using System.ComponentModel;
+
+namespace Pixel.Automation.Test.Runner.Commands;
+
+internal class Settings : CommandSettings
+{
+
+}
+
+internal class TemplateSettings : CommandSettings
+{
+}
+
+internal class ExecuteTestSettings : CommandSettings
+{   
+  
+}

--- a/src/Pixel.Automation.Test.Runner/Pixel.Automation.Test.Runner.csproj
+++ b/src/Pixel.Automation.Test.Runner/Pixel.Automation.Test.Runner.csproj
@@ -3,7 +3,8 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0-windows</TargetFramework>
-		<AssemblyName>PixelRun</AssemblyName>
+		<AssemblyName>pixel-run</AssemblyName>
+		<PreserveCompilationContext>true</PreserveCompilationContext>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	</PropertyGroup>
 
@@ -12,8 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Dawn.Guard" Version="1.12.0" />
-		<PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
+		<PackageReference Include="Dawn.Guard" Version="1.12.0" />	
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
@@ -22,10 +22,11 @@
 		<PackageReference Include="ninject.extensions.conventions" Version="3.3.0" />
 		<PackageReference Include="Polly" Version="7.2.3" />
 		<PackageReference Include="Serilog" Version="2.11.0" />
-		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />		
 		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+		<PackageReference Include="Serilog.Sinks.SpectreConsole" Version="0.3.3" />
 		<PackageReference Include="Spectre.Console" Version="0.45.0" />
+		<PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -37,6 +38,7 @@
 		<ProjectReference Include="..\Pixel.Persistence.Core\Pixel.Persistence.Core.csproj" />
 		<ProjectReference Include="..\Pixel.Persistence.Services.Client\Pixel.Persistence.Services.Client.csproj" />
 		<ProjectReference Include="..\Pixel.Scripting.Common.CSharp\Pixel.Scripting.Common.CSharp.csproj" />
+		<ProjectReference Include="..\Pixel.Scripting.Editor.Core\Pixel.Scripting.Editor.Core.csproj" />
 		<ProjectReference Include="..\Pixel.Scripting.Engine.CSharp\Pixel.Scripting.Engine.CSharp.csproj" />
 	</ItemGroup>
 

--- a/src/Pixel.Automation.Test.Runner/Program.cs
+++ b/src/Pixel.Automation.Test.Runner/Program.cs
@@ -1,68 +1,40 @@
-﻿using McMaster.Extensions.CommandLineUtils;
-using Ninject;
+﻿using Ninject;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Attributes;
 using Pixel.Automation.Core.Components;
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.RunTime;
 using Pixel.Automation.RunTime.Serialization;
+using Pixel.Automation.Test.Runner.Commands;
 using Pixel.Automation.Test.Runner.Modules;
-using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Services.Client;
 using Serilog;
-using System;
-using System.Diagnostics;
+using Serilog.Events;
+using Spectre.Console.Cli;
 using System.Threading.Tasks;
+using Serilog.Sinks.SpectreConsole;
 
 namespace Pixel.Automation.Test.Runner
 {
     class Program
     {
-        static int Main(string[] args)
-        {
-            var app = new CommandLineApplication();
-            app.HelpOption("-h|--help");
-           
-            var debug = app.Option("-d | --debug", $"Prompt to attach debugger on start", CommandOptionType.SingleOrNoValue);
-
-            var clean = app.Option("-c || --clean", "Clean local data before execution", CommandOptionType.NoValue);
-            var run = app.Option("-r || --run", "Indicates that test should be executed", CommandOptionType.NoValue);
-            var list = app.Option("-l | --list", "List all the tests that matches selection criteria", CommandOptionType.NoValue);
-                   
-            var newTemplate = app.Option("-nt | --newTemplate", "Create a new session template", CommandOptionType.NoValue);          
-            var listTemplate = app.Option("-lt | --listTemplate", "List all the available templates e.g. --listTemplate", CommandOptionType.NoValue);
-            var modifyTemplate = app.Option("-mt | --modifyTemplate", "Modify a template given it's name e.g. --modifyTemplate:\"TemplateName\"", CommandOptionType.SingleValue);
-            var template =  app.Option("-t | --template", "Execute the specified template e.g. --template:\"TemplateName\"", CommandOptionType.SingleValue);
-
-
-            var project = app.Option("-p | --project", "Target project containing tests e.g. --project:\"ProjectName\"", CommandOptionType.SingleOrNoValue);
-            var version = app.Option("-v | --version", "Deployed version of target project to use --version:\"n.0.0.0\"", CommandOptionType.SingleOrNoValue);          
-            var where = app.Option("-w | --where", "Test selector function e.g. fixture.Category == \"SomeCategory\" && (test.Priority == Priority.Medium || test.Tags[\"key\"] != \"value\")", CommandOptionType.SingleOrNoValue);
-            var script = app.Option("-s | --script", $"Script file (*.csx) override that can be used to initialize the process data model e.g. --script:\"CustomScript.csx\". By default {Constants.InitializeEnvironmentScript} generated at design time is used", CommandOptionType.SingleOrNoValue);
-
-
+        static async Task<int> Main(string[] args)
+        {           
             Log.Logger = new LoggerConfiguration()
                .Enrich.WithThreadId()
-               .WriteTo.Console(Serilog.Events.LogEventLevel.Information, outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [Thread:{ThreadId}] [{SourceContext:l}] {Message:lj}{NewLine}{Exception}")
-               .WriteTo.File("logs\\Pixel-Automation-.txt", restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Verbose,
+               //.WriteTo.SpectreConsole("{Timestamp:HH:mm:ss} [{Level:u4}] {Message:lj}{NewLine}{Exception}", minLevel: LogEventLevel.Information)
+               .WriteTo.File("logs\\Pixel-Automation-.txt", restrictedToMinimumLevel: LogEventLevel.Verbose,
                  outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [Thread:{ThreadId}] [{SourceContext:l}] {Message:lj}{NewLine}{Exception}", rollingInterval: RollingInterval.Day)
                .CreateLogger();
             var logger = Log.ForContext<Program>();
 
-            template.DefaultValue = "Bing_Demo_Template";
-
-            app.OnExecuteAsync(async c =>
+            try
             {
-                if(debug.HasValue())
-                {
-                    Debugger.Launch();
-                }
-
                 var pluginManager = new PluginManager(new JsonSerializer());
                 var platformFeatureAssemblies = pluginManager.LoadPluginsFromDirectory("Plugins", PluginType.PlatformFeature);
                 var pluginAssemblies = pluginManager.LoadPluginsFromDirectory("Plugins", PluginType.Component);
-              
-                var kernel = new StandardKernel(new CommonModule(), new ScopedModules(), new ScriptingModule(), 
+
+                var kernel = new StandardKernel(new CommonModule(), new ScopedModules(), new ScriptingModule(),
                     new NativeModule(platformFeatureAssemblies), new SettingsModule(), new PersistenceModules());
                 kernel.Settings.Set("InjectAttribute", typeof(InjectedAttribute));
 
@@ -79,92 +51,47 @@ namespace Pixel.Automation.Test.Runner
                 #endif
 
                 var applicationDataManager = kernel.Get<IApplicationDataManager>();
-
-                if (clean.HasValue())
-                {
-                    applicationDataManager.CleanLocalData();
-                }
-
-                logger.Information("Downloading application data now");
                 await applicationDataManager.DownloadApplicationsDataAsync();
-                logger.Information("Download of application data completed");
-                logger.Information("Downloading project information now");
                 await applicationDataManager.DownloadProjectsAsync();
-                logger.Information("Download of project information completed");
 
-                var projectManager = kernel.Get<ProjectManager>();
-                var templateManager = kernel.Get<TemplateManager>();
-
-                if (newTemplate.HasValue())
+                //Debugger.Launch();
+                var registrar = new TypeRegistrar(kernel);
+                var app = new CommandApp(registrar);
+                app.Configure(config =>
                 {
-                    await templateManager.CreateNewAsync();
-                    return await Task.FromResult<int>(1);
-                }
-                if(listTemplate.HasValue())
-                {
-                    await templateManager.ListAllAsync();
-                    return await Task.FromResult<int>(1);
-                }
-                if (modifyTemplate.HasValue())
-                {
-                    var template = await templateManager.GetByNameAsync(modifyTemplate.Value());
-                    await templateManager.UpdateAsync(template);
-                    return await Task.FromResult<int>(1);
-                }
-
-                SessionTemplate sessionTemplate;
-                if(template.HasValue())
-                {
-                    sessionTemplate = await templateManager.GetByNameAsync(template.Value());
-                    if(sessionTemplate == null)
+                    config.AddBranch<ExecuteTestSettings>("run", run =>
                     {
-                        logger.Warning("Template with name : {0} doesn't exist", template.Value());                       
-                    }
-                }
-                else if (project.HasValue() && version.HasValue() && where.HasValue())
-                {
-                    sessionTemplate = new SessionTemplate()
+                        run.SetDescription("Execute test cases");
+                        run.AddCommand<ExecuteTestFromTemplateCommand>("template")
+                        .WithDescription("Execute tests by specifying a template and optionally project version to use")
+                        .WithExample(new[] { "run", "template", "template-name"})
+                        .WithExample(new[] { "run", "template", "template-name", "--list"  })
+                        .WithExample(new[] { "run", "template", "template-name", "1.0.0.0" });
+                        run.AddCommand<ExecuteAdhocTestCommand>("adhoc").WithDescription("Execute tests without using a template")
+                        .WithExample(new[] { "run", "adhoc", "project-name", "project-version", "true", "InitializationScript.csx" })
+                         .WithExample(new[] { "run", "adhoc", "project-name", "project-version", "true", "InitializationScript.csx", "--list" })
+                        .WithExample(new[] { "run", "adhoc", "project-name", "project-version", "\"fixture.Name.Equals(\"fixture-name\") &&" +
+                        " test.Name.Contains(\"test-prefix\")\"", "InitializationScript.csx" });
+                    });
+                    config.AddBranch<TemplateSettings>("template", template =>
                     {
-                        Name = Guid.NewGuid().ToString(),
-                        ProjectName = project.Value(),
-                        ProjectVersion = version.Value(),
-                        Selector = where.Value()
-                    };  
-                    if(script.HasValue())
-                    {
-                        sessionTemplate.InitializeScript = script.Value();
-                    }
-                }
-                else
-                {
-                    logger.Error("No operation specified to execute or insufficient parameters for operation to be executed.");
-                    app.ShowHelp();
-                    Console.WriteLine("Press any key to exit");
-                    Console.ReadLine();
-                    return await Task.FromResult<int>(1);
-                }
-
-             
-                await projectManager.LoadProjectAsync(sessionTemplate);
-                projectManager.LoadTestCases();
-               
-                if (list.HasValue())
-                {
-                    await projectManager.ListAllAsync(sessionTemplate.Selector);
-                }
-                else
-                {
-                    // use --run as default if --list is not specified
-                    await projectManager.RunAllAsync(sessionTemplate.Selector);
-                }
-                return await Task.FromResult<int>(0);
-
-            });
-
-            Log.CloseAndFlush();
-
-            return app.Execute(args);
-
+                        template.SetDescription("create or edit or list templates");
+                        template.AddCommand<CreateTemplateCommand>("new").WithDescription("Create a new template for tests")
+                         .WithExample(new[] { "template", "new" });
+                        template.AddCommand<ListTemplatesCommand>("list").WithDescription("List existing templates")
+                        .WithExample(new[] { "template", "list" });
+                        template.AddCommand<EditTemplateCommand>("update").WithDescription("Update an existing template")
+                        .WithExample(new[] { "template", "edit" });
+                    });
+                    config.AddCommand<CleanDataCommand>("clean").WithDescription("Clean local data and download latest")
+                    .WithExample(new[] { "clean" });
+                });
+                return await app.RunAsync(args);
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
         }
     }
 }

--- a/src/Pixel.Automation.Test.Runner/TypeRegistrar.cs
+++ b/src/Pixel.Automation.Test.Runner/TypeRegistrar.cs
@@ -1,0 +1,53 @@
+﻿using Dawn;
+using Ninject;
+using Spectre.Console.Cli;
+using System;
+
+namespace Pixel.Automation.Test.Runner;
+
+/// <summary>
+/// Default implementation of <see cref="ITypeRegistrar"/>
+/// </summary>
+public class TypeRegistrar : ITypeRegistrar
+{
+    private readonly StandardKernel kernel;
+   
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="kernel"></param>
+    public TypeRegistrar(StandardKernel kernel)
+    {
+        this.kernel = Guard.Argument(kernel).NotNull();
+    }
+
+    /// <inheritdoc/>    
+    public ITypeResolver Build()
+    {
+        return new TypeResolver(kernel);
+    }
+
+    /// <inheritdoc/>    
+    public void Register(Type service, Type implementation)
+    {
+        Guard.Argument(service).NotNull();
+        Guard.Argument(implementation).NotNull();
+        kernel.Bind(service).To(implementation);
+    }
+
+    /// <inheritdoc/>    
+    public void RegisterInstance(Type service, object implementation)
+    {
+        Guard.Argument(service).NotNull();
+        Guard.Argument(implementation).NotNull();
+        kernel.Bind(service).ToConstant(implementation);
+    }
+
+    /// <inheritdoc/>    
+    public void RegisterLazy(Type service, Func<object> factoryMethod)
+    {
+        Guard.Argument(service).NotNull();
+        Guard.Argument(factoryMethod).NotNull();
+        kernel.Bind(service).ToMethod((context) => factoryMethod());
+    }
+}

--- a/src/Pixel.Automation.Test.Runner/TypeResolver.cs
+++ b/src/Pixel.Automation.Test.Runner/TypeResolver.cs
@@ -1,0 +1,45 @@
+﻿using Dawn;
+using Ninject;
+using Spectre.Console.Cli;
+using System;
+
+namespace Pixel.Automation.Test.Runner
+{
+    /// <summary>
+    /// Default implementation of <see cref="ITypeResolver"/>
+    /// </summary>
+    public class TypeResolver : ITypeResolver, IDisposable
+    {
+        private readonly StandardKernel kernel;
+    
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="kernel"></param>
+        public TypeResolver(StandardKernel kernel)
+        {
+            this.kernel = Guard.Argument(kernel).NotNull();
+        }
+
+        /// <inheritdoc/>
+        public object? Resolve(Type? type)
+        {
+            if(type != null)
+            {
+                return kernel.Get(type);
+            }
+            return null;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            //GC.SuppressFinalize(this);
+
+            //if (kernel is IDisposable disposable)
+            //{
+            //    disposable.Dispose();
+            //}
+        }
+    }
+}

--- a/src/Pixel.Persistence.Core/Models/SessionTemplate.cs
+++ b/src/Pixel.Persistence.Core/Models/SessionTemplate.cs
@@ -32,21 +32,14 @@ namespace Pixel.Persistence.Core.Models
         [Required]
         [DataMember]
         public string ProjectName { get; set; }
-
-        /// <summary>
-        /// Version of the project executed in test session
-        /// </summary>
-        [Required]
-        [DataMember]
-        public string ProjectVersion { get; set; }
-
+      
         /// <summary>
         /// Query script for selecting the tests
         /// </summary>
         [Required]
         [DataMember]
         public string Selector { get; set; }
-
+      
         /// <summary>
         /// Script file (*.csx) override that can be used to initialize the process data model e.g. 
         /// By default InitializeEnvironment.csx generated at design time is used

--- a/src/Pixel.Persistence.Core/Models/TestSession.cs
+++ b/src/Pixel.Persistence.Core/Models/TestSession.cs
@@ -105,13 +105,13 @@ namespace Pixel.Persistence.Core.Models
         }
 
 
-        public TestSession(SessionTemplate template) : this()
+        public TestSession(SessionTemplate template, string projectVersion) : this()
         {
             this.TemplateId = template.Id;
             this.TemplateName = template.Name;
             this.ProjectId = template.ProjectId;
             this.ProjectName = template.ProjectName;
-            this.ProjectVersion = template.ProjectVersion;
+            this.ProjectVersion = projectVersion;
         }
 
         /// <summary>

--- a/src/Pixel.Persistence.Respository/TemplateRepository.cs
+++ b/src/Pixel.Persistence.Respository/TemplateRepository.cs
@@ -50,7 +50,7 @@ namespace Pixel.Persistence.Respository
             var filter = Builders<SessionTemplate>.Filter.Eq(t => t.Id, template.Id);
 
             var updateDefinition = Builders<SessionTemplate>.Update           
-            .Set(t => t.ProjectVersion, template.ProjectVersion)
+            .Set(t => t.Name, template.Name)
             .Set(t => t.Selector, template.Selector)
             .Set(t => t.InitializeScript, template.InitializeScript);            
 


### PR DESCRIPTION
**Description**
1. Use spectre.console instead of McMaster.Extensions.CommandLineUtils for advanced features like table and tree rendering and command system
2. SessionTemplate are no more tied to a project version. Project version can be passed as a parameter at runtime.
3. It is now possible to execute the active versions of projects as well. This is because for daily builds of application under test the most recent active version of automation project won't be in a deployed state as it is evolving too. However, we would want to run it on a daily basis.