### PR TITLE
New look for the home screen

### DIFF
--- a/src/Pixel.Automation.Core/Models/AutomationProject.cs
+++ b/src/Pixel.Automation.Core/Models/AutomationProject.cs
@@ -29,13 +29,7 @@ namespace Pixel.Automation.Core.Models
         /// </summary>
         [DataMember(IsRequired = true, Order = 40)]
         public string Namespace { get; set; }
-
-        /// <summary>
-        /// Indicates when was the project last opened
-        /// </summary>
-        [DataMember(IsRequired = true, Order = 40)]
-        public DateTime LastOpened { get; set; } = DateTime.Now;
-
+      
         [DataMember(IsRequired = true, Order = 50)]
         public List<ProjectVersion> AvailableVersions { get; } = new List<ProjectVersion>();
 

--- a/src/Pixel.Automation.Designer.ViewModels/Screen/AutomationProjectViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Screen/AutomationProjectViewModel.cs
@@ -1,0 +1,78 @@
+﻿using Caliburn.Micro;
+using Pixel.Automation.Core;
+using Pixel.Automation.Core.Models;
+
+namespace Pixel.Automation.Designer.ViewModels
+{
+    /// <summary>
+    /// View Model for <see cref="automationProject"/>
+    /// </summary>
+    public class AutomationProjectViewModel : NotifyPropertyChanged
+    {
+        private readonly AutomationProject automationProject;
+
+        /// <summary>
+        /// Automation Project
+        /// </summary>
+        public AutomationProject Project
+        {
+            get => automationProject;
+        }
+
+        /// <summary>
+        /// Identifier of the Project
+        /// </summary>
+        public string ProjectId
+        {
+            get => automationProject.ProjectId;
+        }
+
+        /// <summary>
+        /// Name of the project
+        /// </summary>
+        public string Name
+        {
+            get => automationProject.Name;
+            set
+            {
+               automationProject.Name = value;
+               OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Editable versions available for the project. Editable versions are those that are not yet deployed.
+        /// </summary>
+        public BindableCollection<ProjectVersion> EditableVersions { get; private set; } = new();
+
+        /// <summary>
+        /// Selected version to open on the UI
+        /// </summary>
+        public ProjectVersion SelectedVersion { get; set; }
+
+        private bool isOpenInEditor;
+        /// <summary>
+        /// Indicate if the project is open in editor
+        /// </summary>
+        public bool IsOpenInEditor
+        {
+            get => this.isOpenInEditor;
+            set
+            {
+                this.isOpenInEditor = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="automationProject"></param>
+        public AutomationProjectViewModel(AutomationProject automationProject)
+        {
+            this.automationProject = automationProject;
+            this.EditableVersions.AddRange(automationProject.AvailableVersions.Where(a => !a.IsDeployed));
+            this.SelectedVersion = automationProject.ActiveVersion;
+        }
+    }
+}

--- a/src/Pixel.Automation.Designer.ViewModels/Screen/NewProjectViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Screen/NewProjectViewModel.cs
@@ -55,8 +55,7 @@ namespace Pixel.Automation.Designer.ViewModels
             try
             {
                 this.NewProject.Name = this.NewProject.Name.Trim();
-                this.NewProject.Namespace = $"{Constants.NamespacePrefix}.{this.NewProject.Name.Replace(' ', '.')}";
-                this.NewProject.LastOpened = DateTime.Now;
+                this.NewProject.Namespace = $"{Constants.NamespacePrefix}.{this.NewProject.Name.Replace(' ', '.')}";              
 
                 //create a directory inside projects directory with name equal to newProject identifier
                 string projectFolder = this.fileSystem.GetAutomationProjectDirectory(this.NewProject);

--- a/src/Pixel.Automation.Designer.Views/Screen/HomeView.xaml
+++ b/src/Pixel.Automation.Designer.Views/Screen/HomeView.xaml
@@ -3,75 +3,106 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:core="clr-namespace:Pixel.Automation.Editor.Core.Converters;assembly=Pixel.Automation.Editor.Core"
              xmlns:local="clr-namespace:Pixel.Automation.Designer.Views"
              xmlns:cal="http://www.caliburnproject.org" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <UserControl.Resources>
         <ResourceDictionary>
-            <Style x:Key="LinkButton"
-           TargetType="Button">
-                <Setter Property="Cursor"
-                Value="Hand" />
-                <Setter Property="Foreground"  Value="{DynamicResource LinkButtonForeground}" />
+            <core:InverseBooleanConverter x:Key="inverseBooleanConverter"/>
+            <Style x:Key="AddProjectButtonStyle" TargetType="{x:Type Button}">
+                <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}"></Setter>
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent2}"/>
+                <Setter Property="Width" Value="32"/>
+                <Setter Property="Height" Value="32"/>
                 <Setter Property="Template">
                     <Setter.Value>
-                        <ControlTemplate TargetType="Button">
-                            <TextBlock><ContentPresenter /></TextBlock>
+                        <ControlTemplate>
+                            <Border IsHitTestVisible="True" Background="{DynamicResource  MahApps.Brushes.Control.Background}" BorderThickness="0">
+                                <iconPacks:PackIconMaterial x:Name="PlusIcon" Width="{TemplateBinding Width}"
+                                        Height="{TemplateBinding Height}" IsHitTestVisible="False"
+                                        Margin="2" Padding="4" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        Foreground="{DynamicResource MahApps.Brushes.Accent2}"
+                                        Kind="PlusCircleOutline" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter TargetName="PlusIcon" Property="Foreground" Value="Gray"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>                
+            </Style>            
+       
+            <Style TargetType="{x:Type ListBoxItem}" x:Key="ProjectItemStyle">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                            <Border x:Name="ProjectItemContainer" Padding="5,5,0,5">
+                                <DockPanel LastChildFill="False" Background="{DynamicResource MahApps.Brushes.Control.Background}">
+                                    <TextBlock Text="{Binding Name}" FontSize="16" VerticalAlignment="Center"
+                                              DockPanel.Dock="Left" ToolTip="Name of the project"/>
+                                    <ComboBox x:Name="EditableVersions" FontSize="14" BorderThickness="0,0,0,0"
+                                                  VerticalAlignment="Center" DockPanel.Dock="Left" Margin="12,2,0,0"
+                                                  ToolTip="Select version to open"
+                                                  ItemsSource="{Binding EditableVersions}" SelectedItem="{Binding SelectedVersion}"/>
+                                    <Button x:Name="OpenProject" HorizontalAlignment="Right" VerticalAlignment="Center" 
+                                                DockPanel.Dock="Right" IsEnabled="{Binding IsOpenInEditor, Converter={StaticResource inverseBooleanConverter}}"
+                                                Height="20" Width="20" ToolTip="Open selected version of project"                                 
+                                                Style="{StaticResource EditControlButtonStyle}" Visibility="Hidden"
+                                                cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"
+                                                cal:Message.Attach="[Event Click] = [Action OpenProject($dataContext)]"
+                                                Content="{iconPacks:FontAwesome Kind=EditRegular}"/>
+                                </DockPanel>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent2}"/>
+                                    <Setter TargetName="EditableVersions" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent2}"/>
+                                    <Setter TargetName="OpenProject" Property="Visibility" Value="Visible"/>
+                                </Trigger>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Highlight}"/>
+                                    <Setter TargetName="EditableVersions" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Highlight}"/>
+                                    <Setter TargetName="OpenProject" Property="Visibility" Value="Visible"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
-                <Style.Triggers>
-                    <Trigger Property="IsMouseOver"
-                     Value="true">
-                        <Setter Property="Foreground" Value="{DynamicResource LinkButtonForegroundHighlighted}" />
-                    </Trigger>
-                </Style.Triggers>
             </Style>
+
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid Background="{DynamicResource MahApps.Brushes.Window.Background}">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*"></ColumnDefinition>
-            <ColumnDefinition Width="0px"></ColumnDefinition>
-            <ColumnDefinition Width="8*"></ColumnDefinition>
+            <ColumnDefinition Width="6*"></ColumnDefinition>
+            <ColumnDefinition Width="4*"></ColumnDefinition>
         </Grid.ColumnDefinitions>
-        <StackPanel Grid.Column="0" Margin="10,0,0,0">
-            <TextBlock Margin="0,10,0,10"
-                           FontSize="18"                          
-                           Text="Projects" />
-            <Separator Background="#11FFFFFF" />
-            <Button FontSize="14" x:Name="CreateNewProject"
-                        Margin="0,10,0,3"
-                        Content="New Project..."                       
-                        Style="{DynamicResource LinkButton}" />
-            <Button FontSize="14" x:Name="OpenProject"
-                        Margin="0,3,0,10"
-                        Content="Open Project..."                      
-                        Style="{DynamicResource LinkButton}" />
-            <Separator Background="#11FFFFFF" />
-            <TextBlock Margin="0,10,0,5"
-                           FontSize="18"                          
-                           Text="Recent" />
-            <ListBox x:Name="RecentProjects">
-                <ListBox.ItemTemplate>
-                    <DataTemplate>
-                        <Border Padding="5,5,5,5">
-                            <StackPanel>
-                                <Button FontSize="14" x:Name="btnOpenProject" cal:Message.Attach="[Event Click] = [Action OpenProject($dataContext)]"
-                                    Content="{Binding Name}"                                 
-                                    Style="{DynamicResource LinkButton}" />
-                                <!--<TextBlock Text="{Binding GeneratedSlnPath}"></TextBlock>-->
-                            </StackPanel>
-                        </Border>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
-        </StackPanel>
-        <GridSplitter Grid.Column="1"></GridSplitter>
-        <StackPanel Grid.Column="2">
-
+        <StackPanel Grid.Column="0" Orientation="Vertical" HorizontalAlignment="Left" Margin="10">
+            <StackPanel Orientation="Horizontal">
+                <Button x:Name="CreateNewProject" Margin="0" VerticalAlignment="Center"                                                                                  
+                                            ToolTip="Create a new automation project"                                   
+                                            Style="{StaticResource AddProjectButtonStyle}"/>
+                <Label Content="Projects" FontSize="18" VerticalAlignment="Center"/>
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Margin="0,10,0,0">
+                <StackPanel Orientation="Horizontal">
+                    <TextBox Name="Filter" Text="{Binding FilterText,UpdateSourceTrigger=PropertyChanged}" Margin="2,0,0,0"
+                     controls:TextBoxHelper.ClearTextButton="True" controls:TextBoxHelper.UseFloatingWatermark="False" 
+                     controls:TextBoxHelper.Watermark="Search" HorizontalAlignment="Left" Width="380"/>
+                </StackPanel>
+                <StackPanel Orientation="Vertical" Margin="0,10,0,0" HorizontalAlignment="Stretch">
+                    <ListBox x:Name="Projects" ItemContainerStyle="{StaticResource ProjectItemStyle}" 
+                             ScrollViewer.VerticalScrollBarVisibility="Hidden" MaxHeight="400">
+                    </ListBox>
+                </StackPanel>
+            </StackPanel>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/AutomationProjectFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/AutomationProjectFixture.cs
@@ -12,7 +12,6 @@ namespace Pixel.Automation.Core.Tests.Models
             var automationProject = new AutomationProject();
             Assert.IsNotNull(automationProject.ProjectId);
             Assert.IsEmpty(automationProject.Name);
-            Assert.IsNotNull(automationProject.LastOpened);
             Assert.IsNotNull(automationProject.AvailableVersions);
             Assert.IsTrue(!automationProject.AvailableVersions.Any());
             Assert.IsNotNull(automationProject.DeployedVersions);


### PR DESCRIPTION
**Description**
1. It is possible to search for projects on home screen now
2. Removed last opened property from automation project as it would vary for individual users and should not be attribute of automation project
3. It is possible to select version of the project to open now. Versions that are not deployed are available.
4. Remove browse for project file from local disk to open. We don't want users to edit a deployed project as we don't support opening project in read only mode.
5. A new look for projects section on home screen.