### PR TITLE
dotnet test should run on release build

### DIFF
--- a/.github/workflows/on-demand-build-with-artifact.yml
+++ b/.github/workflows/on-demand-build-with-artifact.yml
@@ -66,7 +66,7 @@ jobs:
       run: dotnet build Pixel.Automation.sln -c Release --no-restore
       
     - name: Test
-      run: dotnet test Pixel.Automation.sln --no-build --verbosity normal
+      run: dotnet test Pixel.Automation.sln -c Release --no-build --verbosity normal
 
     - name: Upload Designer artifacts
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
**Description**
dotnet test fails to find the test assemblies as it looks in debug folder. We need to specify -c Release flag to run test on test assemblies that were previously built in release mode.