### PR TITLE
Multiple active versions for project

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabExplorerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabExplorerViewModel.cs
@@ -117,10 +117,21 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
                     }                   
                     prefabToEdit.IsOpenInEditor = true;
                 }
-                var editorFactory = IoC.Get<IEditorFactory>();
-                var prefabEditor = editorFactory.CreatePrefabEditor();
-                prefabEditor.DoLoad(prefabToEdit.PrefabProject);
-                await this.eventAggregator.PublishOnUIThreadAsync(new ActivateScreenNotification() { ScreenToActivate = prefabEditor as IScreen });                
+
+                var versionPicker = new PrefabVersionPickerViewModel(prefabToEdit.PrefabProject);
+                var result = await windowManager.ShowDialogAsync(versionPicker);
+                if (result.HasValue && result.Value)
+                {
+                    var versionToEdit = versionPicker.SelectedVersion;
+                    var editorFactory = IoC.Get<IEditorFactory>();
+                    var prefabEditor = editorFactory.CreatePrefabEditor();
+                    prefabEditor.DoLoad(prefabToEdit.PrefabProject, versionToEdit);
+                    await this.eventAggregator.PublishOnUIThreadAsync(new ActivateScreenNotification() { ScreenToActivate = prefabEditor as IScreen });
+                }
+                else
+                {
+                    prefabToEdit.IsOpenInEditor = false;
+                }
             }
             catch (Exception ex)
             {

--- a/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabProjectViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabProjectViewModel.cs
@@ -57,6 +57,21 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
             get => this.prefabProject.PublishedVersions; 
         }
 
+        private bool isOpenInEditor;
+        /// <summary>
+        /// Indicate if the project is open in editor
+        /// </summary>
+        public bool IsOpenInEditor
+        {
+            get => this.isOpenInEditor;
+            set
+            {
+                this.isOpenInEditor = value;
+                OnPropertyChanged();
+            }
+        }
+
+
         public PrefabProjectViewModel(PrefabProject prefabProject)
         {
             this.prefabProject = Guard.Argument(prefabProject).NotNull();

--- a/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabProjectViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabProjectViewModel.cs
@@ -52,9 +52,9 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
             }
         }
 
-        public IEnumerable<PrefabVersion> DeployedVersions 
-        { 
-            get => this.prefabProject.AvailableVersions.Where(a => a.IsDeployed).ToList(); 
+        public IEnumerable<PrefabVersion> PublishedVersion 
+        {
+            get => this.prefabProject.PublishedVersions; 
         }
 
         public PrefabProjectViewModel(PrefabProject prefabProject)

--- a/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabVersionPickerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabVersionPickerViewModel.cs
@@ -1,0 +1,55 @@
+﻿using Caliburn.Micro;
+using Dawn;
+using Pixel.Automation.Core.Models;
+
+namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
+{
+    /// <summary>
+    /// View model that handles selecting the version of prefab to be edited
+    /// </summary>
+    public class PrefabVersionPickerViewModel : Screen
+    {
+        /// <summary>
+        /// Collection of PrefabVersion that can be edited.
+        /// </summary>
+        public BindableCollection<PrefabVersion> EditableVersions { get; private set; } = new();
+
+        /// <summary>
+        /// Selected Version to be edited on the UI
+        /// </summary>
+        public PrefabVersion SelectedVersion { get; set; }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="prefabProject"></param>
+        public PrefabVersionPickerViewModel(PrefabProject prefabProject)
+        {
+            Guard.Argument(prefabProject, nameof(prefabProject)).NotNull();
+            this.DisplayName = "Select version to edit";
+            foreach(var version in prefabProject.ActiveVersions)
+            {
+                this.EditableVersions.Add(version);
+            }
+            this.SelectedVersion = prefabProject.LatestActiveVersion;
+        }
+
+        /// <summary>
+        /// Close the screen with true result
+        /// </summary>
+        /// <returns></returns>
+        public async Task OpenAsync()
+        {
+            await this.TryCloseAsync(true);
+        }
+
+        /// <summary>
+        /// Close the screen with false result
+        /// </summary>
+        /// <returns></returns>
+        public async Task CloseAsync()
+        {
+            await this.TryCloseAsync(false);
+        }
+    }
+}

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabVersionSelectorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabVersionSelectorViewModel.cs
@@ -100,7 +100,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
             {
                 this.prefabReferences = new PrefabReferences();
             }
-            this.AvailableVersions = prefabProject.DeployedVersions;
+            this.AvailableVersions = prefabProject.PublishedVersions;
             this.CanChangeVersion = !prefabReferences.HasReference(prefabProject);
             if(!this.CanChangeVersion)
             {

--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml
@@ -2,8 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Pixel.Automation.AppExplorer.Views.Prefab"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"             
              xmlns:dd="clr-namespace:GongSolutions.Wpf.DragDrop;assembly=GongSolutions.Wpf.DragDrop"
              xmlns:cal="http://www.caliburnproject.org"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks" cal:Bind.AtDesignTime="True"
@@ -107,7 +106,8 @@
                             <ControlTemplate>
                                 <StackPanel>
                                     <MenuItem x:Name="Edit" Header="Edit" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action EditPrefab($dataContext)]" ></MenuItem>
-                                    <MenuItem x:Name="Manage" Header="Manage" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action ManagePrefab($dataContext)]" ></MenuItem>
+                                    <MenuItem x:Name="Manage" Header="Manage" IsEnabled="{Binding IsOpenInEditor, Converter={StaticResource InverseBoolConverter}}"
+                                              cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action ManagePrefab($dataContext)]" ></MenuItem>
                                     <MenuItem x:Name="ShowUsage" Header="Show Usage" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action ShowUsage($dataContext)]" ></MenuItem>
                                 </StackPanel>
                             </ControlTemplate>

--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionManagerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionManagerView.xaml
@@ -41,20 +41,28 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTemplateColumn Header="Is Deployed">
+                    <DataGridTemplateColumn Header="Is Published ?">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <CheckBox x:Name="Deployed" IsChecked="{Binding IsDeployed, Mode=OneWay}" IsEnabled="False" Margin="5,2,5,2" HorizontalAlignment="Center"  />
+                                <CheckBox x:Name="IsPublished" IsChecked="{Binding IsPublished, Mode=OneWay}" IsEnabled="False" Margin="5,2,5,2" HorizontalAlignment="Center"  />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTemplateColumn Header="Deploy">
+                    <DataGridTemplateColumn Header="">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <StackPanel Visibility="{Binding IsActive, Converter={StaticResource boolToVisConverter}}">
-                                    <Button x:Name="Deploy" Content="DEPLOY" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
-                                        cal:Message.Attach="[Event Click] = [Action Deploy($dataContext)]" Margin="5,2,5,2" HorizontalAlignment="Center" ToolTip="Deploy this version and create an incremented cloned version"  />
-                                </StackPanel>                                
+                                <Button x:Name="CloneAndPublish" Content="Clone and Publish" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
+                                        cal:Message.Attach="[Event Click] = [Action CloneAndPublishAsync($dataContext)]" Margin="5,2,5,2" HorizontalAlignment="Center" ToolTip="Create a copy with incremented version and mark this version published."  />
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn Header="">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button x:Name="Publish" Content="Publish" IsEnabled="{Binding CanPublish}"
+                                        cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
+                                        cal:Message.Attach="[Event Click] = [Action PublishAsync($dataContext)]" Margin="5,2,5,2" HorizontalAlignment="Center"
+                                        ToolTip="Mark the version as published. Published versions can be used in automation."  />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>

--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionPickerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionPickerView.xaml
@@ -1,0 +1,27 @@
+﻿<controls:MetroWindow x:Class="Pixel.Automation.AppExplorer.Views.Prefab.PrefabVersionPickerView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"            
+             xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             mc:Ignorable="d" ResizeMode="NoResize" SizeToContent="WidthAndHeight"
+             WindowStartupLocation="CenterScreen"  ShowCloseButton="False" IsMinButtonEnabled="False"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+        </Grid.RowDefinitions>
+        <DockPanel LastChildFill="True" MinWidth="320" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="0" Margin="10,20,10,20">
+            <Label Content="Version" DockPanel.Dock="Left" MinWidth="80"></Label>
+            <ComboBox ItemsSource="{Binding EditableVersions}" DockPanel.Dock="Right" SelectedItem="{Binding SelectedVersion}" ToolTip="Select version to edit"/>
+        </DockPanel>
+        <DockPanel Grid.Row="1" LastChildFill="False">
+            <Border DockPanel.Dock="Top" BorderThickness="1" Height="1" HorizontalAlignment="Stretch" 
+                    Width="{Binding Path=Width,RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type DockPanel}}}" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+            <Button x:Name="CloseAsync" Content="CLOSE" Width="100" DockPanel.Dock="Right"   Margin="10" Style="{DynamicResource MahApps.Styles.Button.Square}"/>
+            <Button x:Name="OpenAsync" Content="EDIT" Width="100" DockPanel.Dock="Right"   Margin="0,10,0,10" Style="{DynamicResource MahApps.Styles.Button.Square.Accent}"/>
+        </DockPanel>
+    </Grid>
+   
+</controls:MetroWindow>

--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionPickerView.xaml.cs
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionPickerView.xaml.cs
@@ -1,0 +1,12 @@
+﻿namespace Pixel.Automation.AppExplorer.Views.Prefab;
+
+/// <summary>
+/// Interaction logic for PrefabVersionPickerView.xaml
+/// </summary>
+public partial class PrefabVersionPickerView
+{
+    public PrefabVersionPickerView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Pixel.Automation.Core/Models/AutomationProject.cs
+++ b/src/Pixel.Automation.Core/Models/AutomationProject.cs
@@ -32,18 +32,23 @@ namespace Pixel.Automation.Core.Models
       
         [DataMember(IsRequired = true, Order = 50)]
         public List<ProjectVersion> AvailableVersions { get; } = new List<ProjectVersion>();
+       
+        /// <summary>
+        /// Get all the versions that are active.
+        /// </summary>
+        public IEnumerable<ProjectVersion> ActiveVersions { get => AvailableVersions.Where(a => a.IsActive).ToList(); }
 
         /// <summary>
-        /// Get all the versions that are deployed.
+        /// Get all the versions that are published.
         /// </summary>
-        public IEnumerable<ProjectVersion> DeployedVersions { get => AvailableVersions.Where(a => a.IsDeployed).ToList(); }
-
+        public IEnumerable<ProjectVersion> PublishedVersions { get => AvailableVersions.Where(a => a.IsPublished).ToList(); }
+       
         /// <summary>
-        /// Active version of the project
+        /// Latest Active version of the project
         /// </summary>
-        public ProjectVersion ActiveVersion
+        public ProjectVersion LatestActiveVersion
         {
-            get => this.AvailableVersions.FirstOrDefault(a => a.IsActive);
+            get => this.ActiveVersions.OrderBy(a => a.Version).LastOrDefault();
         }
 
         /// <summary>

--- a/src/Pixel.Automation.Core/Models/PrefabProject.cs
+++ b/src/Pixel.Automation.Core/Models/PrefabProject.cs
@@ -49,13 +49,21 @@ namespace Pixel.Automation.Core.Models
         public string GroupName { get; set; } = "Default";
 
         /// <summary>
-        /// Get all the versions that are deployed. Deployed Prefabs can be used in an automation.
+        /// Get all the versions that are active.
         /// </summary>
-        public IEnumerable<PrefabVersion> DeployedVersions { get => AvailableVersions.Where(a => a.IsDeployed).ToList(); }
+        public IEnumerable<PrefabVersion> ActiveVersions { get => AvailableVersions.Where(a => a.IsActive).ToList(); }
 
-        public PrefabVersion ActiveVersion
+        /// <summary>
+        /// Get all the versions that are published. Published Prefabs can be used in an automation.
+        /// </summary>
+        public IEnumerable<PrefabVersion> PublishedVersions { get => AvailableVersions.Where(a => a.IsPublished).ToList(); }             
+       
+        /// <summary>
+        /// Latest Active version of the project
+        /// </summary>
+        public PrefabVersion LatestActiveVersion
         {
-            get => this.AvailableVersions.FirstOrDefault(a => a.IsActive);
+            get => this.ActiveVersions.OrderBy(a => a.Version).LastOrDefault();
         }
 
         public Interfaces.IComponent PrefabRoot { get; set; }

--- a/src/Pixel.Automation.Core/Models/VersionInfo.cs
+++ b/src/Pixel.Automation.Core/Models/VersionInfo.cs
@@ -15,30 +15,26 @@ namespace Pixel.Automation.Core.Models
         /// </summary>
         [DataMember(IsRequired = true, Order = 10)]
         public Version Version { get; set; }
-
-        /// <summary>
-        /// Indicates if the version is deployed
-        /// </summary>
-        [DataMember(IsRequired = true, Order = 20)]
-        public bool IsDeployed { get; set; } = false;
-
+      
         /// <summary>
         /// Indicates if the version is active
         /// </summary>
-        [DataMember(IsRequired = true, Order = 30)]
+        [DataMember(IsRequired = true, Order = 20)]
         public bool IsActive { get; set; } = true;
 
         /// <summary>
         /// Data model assembly name for the automation or prefab project
         /// </summary>
-        [DataMember(IsRequired = false, Order = 40)]
+        [DataMember(IsRequired = false, Order = 30)]
         public string DataModelAssembly { get; set; }
 
         /// <summary>
         /// Description 
         /// </summary>
-        [DataMember(IsRequired = false, Order = 50)]
+        [DataMember(IsRequired = false, Order = 40)]
         public string Description { get; set; }
+
+        public bool IsPublished => !this.IsActive;
 
         ///</inheritdoc>
         public override bool Equals(object obj)

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
@@ -77,7 +77,7 @@ namespace Pixel.Automation.Designer.ViewModels
             this.DisplayName = project.Name;
 
             //Always open the most recent non-deployed version if no version is specified
-            var targetVersion = versionToLoad ?? project.ActiveVersion;
+            var targetVersion = versionToLoad ?? project.LatestActiveVersion;
             logger.Information($"Version : {targetVersion} will be loaded.");
             if(targetVersion != null)
             {

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
@@ -235,27 +235,7 @@ namespace Pixel.Automation.Designer.ViewModels
                 logger.Error(ex, ex.Message);
             }
         }
-
-        /// <inheritdoc/>  
-        public async override Task ManageProjectVersionAsync()
-        {
-            try
-            {
-                await DoSave();
-                var versionManager = this.versionManagerFactory.CreateProjectVersionManager(this.CurrentProject);
-                var result = await this.windowManager.ShowDialogAsync(versionManager);
-                if (result.HasValue && result.Value)
-                {                   
-                    await CloseAsync();
-                    MessageBox.Show($"Project \"{this.CurrentProject.Name}\" is closed now. Please open the new version.", "New Version Created");
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex, ex.Message);
-            }
-        }
-
+      
         /// <inheritdoc/>  
         public async Task ManagePrefabReferencesAsync()
         {
@@ -305,7 +285,7 @@ namespace Pixel.Automation.Designer.ViewModels
             }
             await this.testExplorerHost.DeactivateItemAsync(this.testExplorer, true);
             await this.testDataRepositoryHost.DeactivateItemAsync(this.testDataRepository, true);              
-            await this.globalEventAggregator.PublishOnUIThreadAsync(new EditorClosedNotification(this.CurrentProject));
+            await this.globalEventAggregator.PublishOnUIThreadAsync(new EditorClosedNotification<AutomationProject>(this.CurrentProject));
             await this.TryCloseAsync(true);
            
             this.Dispose();

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
@@ -209,8 +209,6 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 
         public abstract Task DoSave();
 
-        public abstract Task ManageProjectVersionAsync();
-
         public abstract Task EditDataModelAsync();
 
         protected void UpdateWorkFlowRoot()

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
@@ -41,7 +41,7 @@ namespace Pixel.Automation.Designer.ViewModels
             this.PrefabProject = prefabProject;
             this.DisplayName = prefabProject.PrefabName;
 
-            var targetVersion = versionToLoad ?? PrefabProject.ActiveVersion;
+            var targetVersion = versionToLoad ?? PrefabProject.LatestActiveVersion;
             if (targetVersion != null)
             {
                 this.projectManager.Load(prefabProject, targetVersion);
@@ -100,7 +100,7 @@ namespace Pixel.Automation.Designer.ViewModels
             if(result.HasValue && result.Value)
             {
                 var fileSystem = this.projectManager.GetProjectFileSystem() as IVersionedFileSystem;
-                fileSystem.SwitchToVersion(this.PrefabProject.ActiveVersion);
+                fileSystem.SwitchToVersion(this.PrefabProject.LatestActiveVersion);
 
                 //This will update Code editor and script editor to point to the new workspace directory
                 //This will update Code editor and script editor to point to the new workspace directory

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
@@ -89,34 +89,15 @@ namespace Pixel.Automation.Designer.ViewModels
         public override async Task DoSave()
         {
             await projectManager.Save();           
-        }
-
-        public async override Task ManageProjectVersionAsync()
-        {
-            await DoSave();
-
-            var versionManager = this.versionManagerFactory.CreatePrefabVersionManager(this.PrefabProject);          
-            var result  = await this.windowManager.ShowDialogAsync(versionManager);
-            if(result.HasValue && result.Value)
-            {
-                var fileSystem = this.projectManager.GetProjectFileSystem() as IVersionedFileSystem;
-                fileSystem.SwitchToVersion(this.PrefabProject.LatestActiveVersion);
-
-                //This will update Code editor and script editor to point to the new workspace directory
-                //This will update Code editor and script editor to point to the new workspace directory
-                var codeEditorFactory = this.EntityManager.GetServiceOfType<ICodeEditorFactory>();
-                codeEditorFactory.SwitchWorkingDirectory(fileSystem.DataModelDirectory);
-                var scriptEditorFactory = this.EntityManager.GetServiceOfType<IScriptEditorFactory>();
-                scriptEditorFactory.SwitchWorkingDirectory(fileSystem.WorkingDirectory);
-            }         
-        }
+        }      
 
         #endregion Save project
 
         protected override async Task CloseAsync()
         {
             this.Dispose();         
-            await this.TryCloseAsync(true);        
+            await this.TryCloseAsync(true);
+            await this.globalEventAggregator.PublishOnUIThreadAsync(new EditorClosedNotification<PrefabProject>(this.PrefabProject));
         }
 
         protected override void Dispose(bool isDisposing)

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -199,8 +199,8 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             prefabParent.AddComponent(this.prefabbedEntity);
 
             //push the changes to database
-            await this.applicationDataManager.AddOrUpdatePrefabAsync(this.prefabProject, this.prefabProject.ActiveVersion);
-            await this.applicationDataManager.AddOrUpdatePrefabDataFilesAsync(this.prefabProject, this.prefabProject.ActiveVersion);
+            await this.applicationDataManager.AddOrUpdatePrefabAsync(this.prefabProject, this.prefabProject.LatestActiveVersion);
+            await this.applicationDataManager.AddOrUpdatePrefabDataFilesAsync(this.prefabProject, this.prefabProject.LatestActiveVersion);
         }
 
 

--- a/src/Pixel.Automation.Designer.ViewModels/DragDropHandlers/ComponentDragHandler.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/DragDropHandlers/ComponentDragHandler.cs
@@ -118,7 +118,7 @@ namespace Pixel.Automation.Designer.ViewModels.DragDropHandlers
                 {
                     if (dropInfo.VisualTarget is FrameworkElement fe && fe.DataContext.GetType() == typeof(AutomationEditorViewModel))
                     {
-                        if (prefabProject.DeployedVersions.Any())
+                        if (prefabProject.PublishedVersion.Any())
                         {
                             dropInfo.DropTargetAdorner = DropTargetAdorners.Highlight;
                             dropInfo.Effects = DragDropEffects.Copy;

--- a/src/Pixel.Automation.Designer.ViewModels/Screen/AutomationProjectViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Screen/AutomationProjectViewModel.cs
@@ -71,8 +71,8 @@ namespace Pixel.Automation.Designer.ViewModels
         public AutomationProjectViewModel(AutomationProject automationProject)
         {
             this.automationProject = automationProject;
-            this.EditableVersions.AddRange(automationProject.AvailableVersions.Where(a => !a.IsDeployed));
-            this.SelectedVersion = automationProject.ActiveVersion;
+            this.EditableVersions.AddRange(automationProject.ActiveVersions);
+            this.SelectedVersion = automationProject.LatestActiveVersion;
         }
     }
 }

--- a/src/Pixel.Automation.Designer.ViewModels/Screen/AutomationProjectViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Screen/AutomationProjectViewModel.cs
@@ -71,8 +71,15 @@ namespace Pixel.Automation.Designer.ViewModels
         public AutomationProjectViewModel(AutomationProject automationProject)
         {
             this.automationProject = automationProject;
+            this.RefreshVersions();
+        }
+
+        public void RefreshVersions()
+        {
+            this.EditableVersions.Clear();
             this.EditableVersions.AddRange(automationProject.ActiveVersions);
             this.SelectedVersion = automationProject.LatestActiveVersion;
+            this.Refresh();
         }
     }
 }

--- a/src/Pixel.Automation.Designer.ViewModels/Screen/HomeViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Screen/HomeViewModel.cs
@@ -190,6 +190,8 @@ namespace Pixel.Automation.Designer.ViewModels
                 if(project != null)
                 {
                     project.IsOpenInEditor = false;
+                    this.Projects.Clear();
+                    this.LoadProjects();
                 }
             }
             catch (Exception ex)

--- a/src/Pixel.Automation.Designer.ViewModels/Screen/HomeViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Screen/HomeViewModel.cs
@@ -15,7 +15,7 @@ namespace Pixel.Automation.Designer.ViewModels
     /// <summary>
     /// Screen for showing available projects and creating new projects when the application is launched
     /// </summary>
-    public class HomeViewModel : ScreenBase, IHome, IHandle<EditorClosedNotification>
+    public class HomeViewModel : ScreenBase, IHome, IHandle<EditorClosedNotification<AutomationProject>>
     {
         private readonly ILogger logger = Log.ForContext<HomeViewModel>();
 
@@ -24,7 +24,8 @@ namespace Pixel.Automation.Designer.ViewModels
         private readonly IWindowManager windowManager;     
         private readonly IApplicationDataManager applicationDataManager;
         private readonly IApplicationFileSystem fileSystem;
-        
+        private readonly IVersionManagerFactory versionManagerFactory;
+
         /// <summary>
         /// Collection of availalbe projects
         /// </summary>
@@ -61,15 +62,17 @@ namespace Pixel.Automation.Designer.ViewModels
         /// <param name="fileSystem"></param>
 
         public HomeViewModel(IEventAggregator eventAggregator, ISerializer serializer, IWindowManager windowManager, IApplicationDataManager applicationDataManager,
-            IApplicationFileSystem fileSystem)
+            IApplicationFileSystem fileSystem, IVersionManagerFactory versionManagerFactory)
         {
             this.DisplayName = "Home";
             this.eventAggregator = Guard.Argument(eventAggregator, nameof(eventAggregator)).NotNull().Value;
             this.eventAggregator.SubscribeOnBackgroundThread(this);
             this.serializer = Guard.Argument(serializer, nameof(serializer)).NotNull().Value;
-            this.windowManager = Guard.Argument(windowManager, nameof(windowManager)).NotNull().Value;       
+            this.windowManager = Guard.Argument(windowManager, nameof(windowManager)).NotNull().Value;
             this.applicationDataManager = Guard.Argument(applicationDataManager, nameof(applicationDataManager)).NotNull().Value;
             this.fileSystem = Guard.Argument(fileSystem, nameof(fileSystem)).NotNull().Value;
+            this.versionManagerFactory = Guard.Argument(versionManagerFactory, nameof(versionManagerFactory)).NotNull().Value;
+
             LoadProjects();
             CreateCollectionView();
         }
@@ -147,16 +150,38 @@ namespace Pixel.Automation.Designer.ViewModels
                     automationProjectViewModel.IsOpenInEditor = true;
                     logger.Information($"Project : {automationProject.Name} is open now.");
                     return;
-                }
-                throw new Exception("Failed to activate automation editor after loading project");           
+                }                   
 
             }
             catch (Exception ex)
-            {               
-                logger.Error(ex, "There was an error trying to open project.");
+            {         
                 automationProjectViewModel.IsOpenInEditor = false;
+                logger.Error(ex, "There was an error trying to open project.");
             }
         }
+
+        /// <summary>
+        /// Open manager window to manage available version of the automation project
+        /// </summary>
+        /// <param name="automationProjectViewModel"></param>
+        /// <returns></returns>
+        public async Task ManageProjectVersionAsync(AutomationProjectViewModel automationProjectViewModel)
+        {
+            try
+            {                
+                var versionManager = this.versionManagerFactory.CreateProjectVersionManager(automationProjectViewModel.Project);
+                var result = await this.windowManager.ShowDialogAsync(versionManager);
+                if(result.HasValue && result.Value)
+                {
+                    automationProjectViewModel.RefreshVersions();
+                }                
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, ex.Message);
+            }
+        }
+
 
         #region Close Screen
 
@@ -182,16 +207,14 @@ namespace Pixel.Automation.Designer.ViewModels
         /// <param name="message"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task HandleAsync(EditorClosedNotification message, CancellationToken cancellationToken)
+        public async Task HandleAsync(EditorClosedNotification<AutomationProject> message, CancellationToken cancellationToken)
         {
             try
             {
-                var project = this.Projects.FirstOrDefault(a => a.ProjectId.Equals(message.AutomationProject.ProjectId));
+                var project = this.Projects.FirstOrDefault(a => a.ProjectId.Equals(message.Project.ProjectId));
                 if(project != null)
                 {
-                    project.IsOpenInEditor = false;
-                    this.Projects.Clear();
-                    this.LoadProjects();
+                    project.IsOpenInEditor = false;                  
                 }
             }
             catch (Exception ex)

--- a/src/Pixel.Automation.Designer.ViewModels/Screen/NewProjectViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Screen/NewProjectViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using Dawn;
-using Newtonsoft.Json.Linq;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.Models;
@@ -44,7 +43,7 @@ namespace Pixel.Automation.Designer.ViewModels
 
             Version defaultVersion = new Version(1, 0, 0, 0);
             this.NewProject = new AutomationProject();
-            this.NewProject.AvailableVersions.Add(new ProjectVersion(defaultVersion) { IsActive = true, IsDeployed = false});
+            this.NewProject.AvailableVersions.Add(new ProjectVersion(defaultVersion) { IsActive = true});
 
             this.existingProjects.AddRange(this.applicationDataManager.GetAllProjects());
         

--- a/src/Pixel.Automation.Designer.ViewModels/Shell/DesignerWindowViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Shell/DesignerWindowViewModel.cs
@@ -187,25 +187,6 @@ namespace Pixel.Automation.Designer.ViewModels
             await activeItem.EditScriptAsync();
         }
 
-        public bool CanManageProjectVersion
-        {
-            get
-            {
-                return this.ActiveItem is IEditor;
-            }
-
-        }
-
-        public async Task ManageProjectVersionAsync()
-        {
-            var activeItem = this.ActiveItem as IEditor;
-            if (activeItem != null)
-            {
-                await activeItem.ManageProjectVersionAsync();
-            }
-        }
-
-
         public bool CanManagePrefabReferences
         {
             get
@@ -274,8 +255,7 @@ namespace Pixel.Automation.Designer.ViewModels
                 NotifyOfPropertyChange(() => CanEditDataModel);
                 NotifyOfPropertyChange(() => CanEditScript);
                 NotifyOfPropertyChange(() => CanSave);
-                NotifyOfPropertyChange(() => CanSaveAll);
-                NotifyOfPropertyChange(() => CanManageProjectVersion);
+                NotifyOfPropertyChange(() => CanSaveAll);                
                 NotifyOfPropertyChange(() => CanManagePrefabReferences);
                 NotifyOfPropertyChange(() => CanManageControlReferences);
                 NotifyOfPropertyChange(() => CanManageAssemblyReferences);

--- a/src/Pixel.Automation.Designer.ViewModels/VersionManager/PrefabReferenceViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/VersionManager/PrefabReferenceViewModel.cs
@@ -34,7 +34,7 @@ namespace Pixel.Automation.Designer.ViewModels.VersionManager
             this.prefabReference = Guard.Argument(prefabReference).NotNull();
             this.PrefabName = prefabProject.PrefabName;
             this.VersionInUse = prefabReference.Version.ToString();
-            foreach (var version in prefabProject.DeployedVersions)
+            foreach (var version in prefabProject.PublishedVersions)
             {
                 this.AvailableVersions.Add(version);
             }

--- a/src/Pixel.Automation.Designer.Views/Screen/HomeView.xaml
+++ b/src/Pixel.Automation.Designer.Views/Screen/HomeView.xaml
@@ -5,8 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
-             xmlns:core="clr-namespace:Pixel.Automation.Editor.Core.Converters;assembly=Pixel.Automation.Editor.Core"
-             xmlns:local="clr-namespace:Pixel.Automation.Designer.Views"
+             xmlns:core="clr-namespace:Pixel.Automation.Editor.Core.Converters;assembly=Pixel.Automation.Editor.Core"           
              xmlns:cal="http://www.caliburnproject.org" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
@@ -38,8 +37,8 @@
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>                
-            </Style>            
-       
+            </Style>
+            
             <Style TargetType="{x:Type ListBoxItem}" x:Key="ProjectItemStyle">
                 <Setter Property="Template">
                     <Setter.Value>
@@ -51,14 +50,21 @@
                                     <ComboBox x:Name="EditableVersions" FontSize="12" BorderThickness="0,0,0,0"
                                                   VerticalAlignment="Center" DockPanel.Dock="Left" Margin="12,2,0,0"
                                                   ToolTip="Select version to open"
-                                                  ItemsSource="{Binding EditableVersions}" SelectedItem="{Binding SelectedVersion}"/>
-                                    <Button x:Name="OpenProject" HorizontalAlignment="Right" VerticalAlignment="Center" 
+                                                  ItemsSource="{Binding EditableVersions}" SelectedItem="{Binding SelectedVersion}"/>                                    
+                                    <Button x:Name="OpenProject" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5,0,0,0" 
                                                 DockPanel.Dock="Right" IsEnabled="{Binding IsOpenInEditor, Converter={StaticResource inverseBooleanConverter}}"
                                                 Height="20" Width="20" ToolTip="Open selected version of project"                                 
                                                 Style="{StaticResource EditControlButtonStyle}" Visibility="Hidden"
                                                 cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"
                                                 cal:Message.Attach="[Event Click] = [Action OpenProject($dataContext)]"
                                                 Content="{iconPacks:FontAwesome Kind=EditRegular}"/>
+                                    <Button x:Name="ManageVersion" HorizontalAlignment="Right" VerticalAlignment="Center" 
+                                                DockPanel.Dock="Right" IsEnabled="{Binding IsOpenInEditor, Converter={StaticResource inverseBooleanConverter}}"
+                                                Height="20" Width="20" ToolTip="Manage available versions of project."                                 
+                                                Style="{StaticResource EditControlButtonStyle}" Visibility="Hidden"
+                                                cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"
+                                                cal:Message.Attach="[Event Click] = [Action ManageProjectVersionAsync($dataContext)]"
+                                                Content="{iconPacks:FontAwesome Kind=CogSolid}"/>
                                 </DockPanel>
                             </Border>
                             <ControlTemplate.Triggers>
@@ -66,11 +72,13 @@
                                     <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent2}"/>
                                     <Setter TargetName="EditableVersions" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent2}"/>
                                     <Setter TargetName="OpenProject" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="ManageVersion" Property="Visibility" Value="Visible"/>
                                 </Trigger>
                                 <Trigger Property="IsSelected" Value="True">
                                     <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Highlight}"/>
                                     <Setter TargetName="EditableVersions" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Highlight}"/>
                                     <Setter TargetName="OpenProject" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="ManageVersion" Property="Visibility" Value="Visible"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>

--- a/src/Pixel.Automation.Designer.Views/Shell/DesignerWindowView.xaml
+++ b/src/Pixel.Automation.Designer.Views/Shell/DesignerWindowView.xaml
@@ -65,8 +65,7 @@
             </MenuItem>
             
             <MenuItem x:Name="Project" Header="Project"  Style="{StaticResource MahApps.Styles.MenuItem}">
-                <MenuItem x:Name="Manage" Header="Manage">
-                    <MenuItem x:Name="ManageProjectVersionAsync" Header="Project Version" ToolTip="Manage versions and their deployment"/>
+                <MenuItem x:Name="Manage" Header="Manage">                   
                     <MenuItem x:Name="ManagePrefabReferencesAsync" Header="Prefab References" ToolTip="Manage prefab versions in use"/>
                     <MenuItem x:Name="ManageControlReferencesAsync" Header="Control References" ToolTip="Manage control versions in use"/>
                     <MenuItem x:Name="ManageAssemblyReferencesAsync" Header="Assembly References" ToolTip="Manage assembly references and imports for code editor, script editor and script engine"/>

--- a/src/Pixel.Automation.Designer.Views/VersionManager/ProjectVersionManagerView.xaml
+++ b/src/Pixel.Automation.Designer.Views/VersionManager/ProjectVersionManagerView.xaml
@@ -2,12 +2,10 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Pixel.Automation.Designer.Views.VersionManager"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"            
              xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
              xmlns:converters="clr-namespace:Pixel.Automation.Editor.Core.Converters;assembly=Pixel.Automation.Editor.Core"
-             xmlns:cal="http://www.caliburnproject.org" cal:Bind.AtDesignTime="True"
-             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             xmlns:cal="http://www.caliburnproject.org" cal:Bind.AtDesignTime="True"          
              mc:Ignorable="d"  ResizeMode="NoResize" SizeToContent="WidthAndHeight"
              WindowStartupLocation="CenterScreen"  GlowBrush="{DynamicResource AccentColorBrush}"
              MinHeight="400" MaxHeight="600" ShowCloseButton="False"
@@ -42,20 +40,28 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTemplateColumn Header="Is Deployed">
+                    <DataGridTemplateColumn Header="Is Published ?">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <CheckBox x:Name="Deployed" IsChecked="{Binding IsDeployed, Mode=OneWay}" IsEnabled="False" Margin="5,2,5,2" HorizontalAlignment="Center"  />
+                                <CheckBox x:Name="IsPublished" IsChecked="{Binding IsPublished, Mode=OneWay}" IsEnabled="False" Margin="5,2,5,2" HorizontalAlignment="Center"  />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTemplateColumn Header="Deploy">
+                    <DataGridTemplateColumn Header="">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <StackPanel Visibility="{Binding IsActive, Converter={StaticResource boolToVisConverter}}">
-                                    <Button x:Name="Deploy" Content="DEPLOY" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
-                                        cal:Message.Attach="[Event Click] = [Action Deploy($dataContext)]" Margin="5,2,5,2" HorizontalAlignment="Center" ToolTip="Deploy this version and create an incremented cloned version"  />
-                                </StackPanel>
+                                <Button x:Name="CloneAndPublish" Content="Clone and Publish" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
+                                        cal:Message.Attach="[Event Click] = [Action CloneAndPublishAsync($dataContext)]" Margin="5,2,5,2" HorizontalAlignment="Center" ToolTip="Create a copy of this version and mark this version read only" />
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn Header="">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button x:Name="Publish" Content="Publish" IsEnabled="{Binding CanPublish}"
+                                        cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
+                                        cal:Message.Attach="[Event Click] = [Action PublishAsync($dataContext)]" Margin="5,2,5,2" 
+                                        HorizontalAlignment="Center" ToolTip="Mark this version as read only" />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IEditor.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IEditor.cs
@@ -9,13 +9,8 @@ namespace Pixel.Automation.Editor.Core.Interfaces
         /// <summary>
         /// Save the project state in the current workspace
         /// </summary>
-        Task DoSave();      
-
-        /// <summary>
-        /// Manage different versions of project and their deployment
-        /// </summary>
-        Task ManageProjectVersionAsync();
-
+        Task DoSave();  
+               
         /// <summary>
         /// Remove a component from view
         /// </summary>

--- a/src/Pixel.Automation.Editor.Notifications/Notfications/EditorClosedNotification.cs
+++ b/src/Pixel.Automation.Editor.Notifications/Notfications/EditorClosedNotification.cs
@@ -1,14 +1,13 @@
 ﻿using Dawn;
-using Pixel.Automation.Core.Models;
 
 namespace Pixel.Automation.Editor.Notifications;
 
-public class EditorClosedNotification
+public class EditorClosedNotification<T> where T: class
 {
-    public AutomationProject AutomationProject { get; }
+    public T Project { get; }
 
-    public EditorClosedNotification(AutomationProject automationProject)
+    public EditorClosedNotification(T project)
     {
-        this.AutomationProject = Guard.Argument(automationProject).NotNull();            
+        this.Project = Guard.Argument(project).NotNull();            
     }
 }

--- a/src/Pixel.Automation.Test.Runner/ProjectManager.cs
+++ b/src/Pixel.Automation.Test.Runner/ProjectManager.cs
@@ -101,7 +101,7 @@ namespace Pixel.Automation.Test.Runner
 
             object dataModel;
             //Load the setup data model for the project.
-            if(this.targetVersion.IsDeployed)
+            if(this.targetVersion.IsPublished)
             {
                 Assembly dataModelAssembly = Assembly.LoadFrom(Path.Combine(projectFileSystem.ReferencesDirectory, targetVersion.DataModelAssembly));
                 Type setupDataModel = dataModelAssembly.GetTypes().FirstOrDefault(t => t.Name.Equals(Constants.AutomationProcessDataModelName)) ?? throw new Exception($"Data model assembly {dataModelAssembly.GetName().Name} doesn't contain  type : {Constants.AutomationProcessDataModelName}");

--- a/src/Pixel.Persistence.Core/Models/ApplicationMetaData.cs
+++ b/src/Pixel.Persistence.Core/Models/ApplicationMetaData.cs
@@ -28,16 +28,16 @@ namespace Pixel.Persistence.Core.Models
         [DataMember]
         public List<PrefabMetaDataCompact> PrefabsMeta { get; set; } = new List<PrefabMetaDataCompact>();
 
-        public void AddOrUpdatePrefabMetaData(string prefabId, string version, bool isDeployed)
+        public void AddOrUpdatePrefabMetaData(string prefabId, string version, bool isActive)
         {
             var prefabMetaDataEntry = PrefabsMeta.FirstOrDefault(p => p.PrefabId.Equals(prefabId));
             if(prefabMetaDataEntry != null)
             {
-                prefabMetaDataEntry.AddOrUpdateVersionMetaData(new PrefabVersionMetaData() { Version = version, IsDeployed = isDeployed, IsActive = !isDeployed, LastUpdated = DateTime.UtcNow });
+                prefabMetaDataEntry.AddOrUpdateVersionMetaData(new PrefabVersionMetaData() { Version = version, IsActive = isActive, LastUpdated = DateTime.UtcNow });
                 return;
             }
             var prefabMetaData = new PrefabMetaDataCompact() { PrefabId = prefabId };
-            prefabMetaData.AddOrUpdateVersionMetaData(new PrefabVersionMetaData() { Version = version, IsDeployed = isDeployed, IsActive = !isDeployed, LastUpdated = DateTime.UtcNow });
+            prefabMetaData.AddOrUpdateVersionMetaData(new PrefabVersionMetaData() { Version = version, IsActive = isActive, LastUpdated = DateTime.UtcNow });
             this.PrefabsMeta.Add(prefabMetaData);
         }
                

--- a/src/Pixel.Persistence.Core/Models/PrefabMetaData.cs
+++ b/src/Pixel.Persistence.Core/Models/PrefabMetaData.cs
@@ -26,9 +26,6 @@ namespace Pixel.Persistence.Core.Models
         [DataMember]
         public bool IsActive { get; set; }
 
-        [DataMember]
-        public bool IsDeployed { get; set; }
-
     }
 
     [DataContract]
@@ -67,9 +64,6 @@ namespace Pixel.Persistence.Core.Models
 
         [DataMember]
         public bool IsActive { get; set; }
-
-        [DataMember]
-        public bool IsDeployed { get; set; }
 
         [DataMember]
         public DateTime LastUpdated { get; set; }

--- a/src/Pixel.Persistence.Core/Models/ProjectMetaData.cs
+++ b/src/Pixel.Persistence.Core/Models/ProjectMetaData.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Text;
 
 namespace Pixel.Persistence.Core.Models
 {
@@ -15,8 +13,6 @@ namespace Pixel.Persistence.Core.Models
         public string Type { get; set; }
 
         public bool IsActive { get; set; }
-
-        public bool IsDeployed { get; set; }
 
         public DateTime LastUpdated { get; set; }
     }

--- a/src/Pixel.Persistence.Respository/PrefabRepository.cs
+++ b/src/Pixel.Persistence.Respository/PrefabRepository.cs
@@ -81,8 +81,7 @@ namespace Pixel.Persistence.Respository
                             {"applicationId", prefab.ApplicationId},
                             {"version", prefab.Version},
                             {"type", prefab.Type},
-                            {"isActive", prefab.IsActive},
-                            {"isDeployed", prefab.IsDeployed}
+                            {"isActive", prefab.IsActive}
                         }
                     });
                     break;
@@ -176,7 +175,6 @@ namespace Pixel.Persistence.Respository
                     {
                         Version = file.Metadata["version"].AsString,
                         IsActive = file.Metadata["isActive"].AsBoolean,
-                        IsDeployed = file.Metadata["isDeployed"].AsBoolean,
                         LastUpdated = file.UploadDateTime
                     });
                 }

--- a/src/Pixel.Persistence.Respository/ProjectRepository.cs
+++ b/src/Pixel.Persistence.Respository/ProjectRepository.cs
@@ -79,8 +79,7 @@ namespace Pixel.Persistence.Respository
                             {"projectId" , project.ProjectId},
                             {"version", project.Version},
                             {"type", project.Type},
-                            {"isActive", project.IsActive},
-                            {"isDeployed", project.IsDeployed}
+                            {"isActive", project.IsActive}
                         }
                     });
                     break;
@@ -176,7 +175,6 @@ namespace Pixel.Persistence.Respository
                         Version = file.Metadata["version"].AsString,
                         Type = file.Metadata["type"].AsString,
                         IsActive = file.Metadata["isActive"].AsBoolean,
-                        IsDeployed = file.Metadata["isDeployed"].AsBoolean,
                         LastUpdated = file.UploadDateTime
                     };
 

--- a/src/Pixel.Persistence.Services.Client/PrefabRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/PrefabRepositoryClient.cs
@@ -97,8 +97,7 @@ namespace Pixel.Persistence.Services.Client
                 ApplicationId = prefabProject.ApplicationId,
                 Type = "PrefabDataFiles",
                 Version = version.ToString(),
-                IsActive = version.IsActive,
-                IsDeployed = version.IsDeployed
+                IsActive = version.IsActive
             };
             restRequest.AddParameter(nameof(PrefabMetaData), serializer.Serialize<PrefabMetaData>(prefabMetaData), ParameterType.RequestBody);
             restRequest.AddFile("file", zippedDataFile);

--- a/src/Pixel.Persistence.Services.Client/ProjectRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/ProjectRepositoryClient.cs
@@ -95,8 +95,7 @@ namespace Pixel.Persistence.Services.Client
                 ProjectId = automationProject.ProjectId,
                 Type = "ProjectDataFiles",
                 Version = version.ToString(),
-                IsActive = version.IsActive,
-                IsDeployed = version.IsDeployed
+                IsActive = version.IsActive
             };
             restRequest.AddParameter(nameof(ProjectMetaData), serializer.Serialize<ProjectMetaData>(projectMetaData), ParameterType.RequestBody);
             restRequest.AddFile("file", zippedDataFile);

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/AutomationProjectFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/AutomationProjectFixture.cs
@@ -14,24 +14,24 @@ namespace Pixel.Automation.Core.Tests.Models
             Assert.IsEmpty(automationProject.Name);
             Assert.IsNotNull(automationProject.AvailableVersions);
             Assert.IsTrue(!automationProject.AvailableVersions.Any());
-            Assert.IsNotNull(automationProject.DeployedVersions);
-            Assert.IsTrue(!automationProject.DeployedVersions.Any());
-            Assert.IsNull(automationProject.ActiveVersion);          
+            Assert.IsNotNull(automationProject.PublishedVersions);
+            Assert.IsTrue(!automationProject.PublishedVersions.Any());
+            Assert.IsNull(automationProject.LatestActiveVersion);          
         }
 
         [Test]
         public void ValidateThatNewVersionCanBeAddedToAutomationProject()
         {
             var automationProject = new AutomationProject();
-            var deployedVersion = new ProjectVersion(new System.Version(1, 0)) { IsDeployed = true };
+            var deployedVersion = new ProjectVersion(new System.Version(1, 0)) { IsActive = false };
             var activeVersion = new ProjectVersion(new System.Version(1, 0)) { IsActive = true };
             automationProject.AvailableVersions.Add(deployedVersion);
             automationProject.AvailableVersions.Add(activeVersion);
 
             Assert.AreEqual(2, automationProject.AvailableVersions.Count());
-            Assert.AreEqual(1, automationProject.DeployedVersions.Count());
-            Assert.AreEqual(deployedVersion, automationProject.DeployedVersions.First());
-            Assert.AreEqual(activeVersion, automationProject.ActiveVersion);
+            Assert.AreEqual(1, automationProject.PublishedVersions.Count());
+            Assert.AreEqual(deployedVersion, automationProject.PublishedVersions.First());
+            Assert.AreEqual(activeVersion, automationProject.LatestActiveVersion);
         }
     }
 }

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/PrefabDescriptionFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/PrefabDescriptionFixture.cs
@@ -20,8 +20,8 @@ namespace Pixel.Automation.Core.Tests.Models
             Assert.AreEqual(null, prefabProject.PrefabName);
             Assert.AreEqual(null, prefabProject.Namespace);
             Assert.NotNull(prefabProject.AvailableVersions);
-            Assert.NotNull(prefabProject.DeployedVersions);
-            Assert.IsNull(prefabProject.ActiveVersion);
+            Assert.NotNull(prefabProject.PublishedVersions);
+            Assert.IsNull(prefabProject.LatestActiveVersion);
             Assert.AreEqual(null, prefabProject.Description);
             Assert.AreEqual("Default", prefabProject.GroupName);
 
@@ -30,7 +30,7 @@ namespace Pixel.Automation.Core.Tests.Models
             prefabProject.PrefabId = "PrefabId";
             prefabProject.PrefabName = "PrefabName";
             prefabProject.Namespace = $"{Constants.PrefabNameSpacePrefix}.PrefabName";
-            prefabProject.AvailableVersions.Add(new PrefabVersion() { IsDeployed = true, Version = new Version(1, 0) });
+            prefabProject.AvailableVersions.Add(new PrefabVersion() { IsActive = false, Version = new Version(1, 0) });
             prefabProject.AvailableVersions.Add(new PrefabVersion() { IsActive = true, Version = new Version(2, 0) });
             prefabProject.Description = "Description";
             prefabProject.GroupName = "GroupName";
@@ -41,8 +41,8 @@ namespace Pixel.Automation.Core.Tests.Models
             Assert.AreEqual("PrefabName", prefabProject.PrefabName);
             Assert.AreEqual($"{Constants.PrefabNameSpacePrefix}.PrefabName", prefabProject.Namespace);
             Assert.AreEqual(2, prefabProject.AvailableVersions.Count());
-            Assert.AreEqual(1, prefabProject.DeployedVersions.Count());
-            Assert.NotNull(prefabProject.ActiveVersion);
+            Assert.AreEqual(1, prefabProject.PublishedVersions.Count());
+            Assert.NotNull(prefabProject.LatestActiveVersion);
             Assert.AreEqual("Description", prefabProject.Description);
             Assert.AreEqual("GroupName", prefabProject.GroupName);
         }

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/VersionInfoFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/VersionInfoFixture.cs
@@ -12,7 +12,7 @@ namespace Pixel.Automation.Core.Tests.Models
             var projectVersion = new ProjectVersion("1.0.0.0");
 
             Assert.IsTrue(projectVersion.IsActive);
-            Assert.IsFalse(projectVersion.IsDeployed);
+            Assert.IsFalse(projectVersion.IsPublished);
             Assert.IsTrue(string.IsNullOrEmpty(projectVersion.DataModelAssembly));
             Assert.IsTrue(string.IsNullOrEmpty(projectVersion.Description));
             Assert.AreEqual("1.0.0.0", projectVersion.ToString());
@@ -23,14 +23,13 @@ namespace Pixel.Automation.Core.Tests.Models
         {
             var projectVersion = new ProjectVersion(new Version(1, 0, 0, 0))
             {
-                IsActive = false,
-                IsDeployed = true,
+                IsActive = false,               
                 DataModelAssembly = "Assembly",
                 Description = "Description"
             };
 
             Assert.IsFalse(projectVersion.IsActive);
-            Assert.IsTrue(projectVersion.IsDeployed);
+            Assert.IsTrue(projectVersion.IsPublished);
             Assert.AreEqual("Assembly", projectVersion.DataModelAssembly);
             Assert.AreEqual("Description", projectVersion.Description);
             Assert.AreEqual("1.0.0.0", projectVersion.ToString());
@@ -45,7 +44,7 @@ namespace Pixel.Automation.Core.Tests.Models
             var prefabVersion = new PrefabVersion("1.0.0.0");
 
             Assert.IsTrue(prefabVersion.IsActive);
-            Assert.IsFalse(prefabVersion.IsDeployed);
+            Assert.IsFalse(prefabVersion.IsPublished);
             Assert.IsTrue(string.IsNullOrEmpty(prefabVersion.DataModelAssembly));
             Assert.IsTrue(string.IsNullOrEmpty(prefabVersion.Description));
             Assert.AreEqual("1.0.0.0", prefabVersion.ToString());
@@ -56,14 +55,13 @@ namespace Pixel.Automation.Core.Tests.Models
         {
             var prefabVersion = new PrefabVersion(new Version(1, 0, 0, 0))
             {
-                IsActive = false,
-                IsDeployed = true,
+                IsActive = false,              
                 DataModelAssembly = "Assembly",
                 Description = "Description"
             };
 
             Assert.IsFalse(prefabVersion.IsActive);
-            Assert.IsTrue(prefabVersion.IsDeployed);
+            Assert.IsTrue(prefabVersion.IsPublished);
             Assert.AreEqual("Assembly", prefabVersion.DataModelAssembly);
             Assert.AreEqual("Description", prefabVersion.Description);
             Assert.AreEqual("1.0.0.0", prefabVersion.ToString());


### PR DESCRIPTION
**Description**
1. [Allow multiple active version of project and prefabs](https://github.com/Nfactor26/pixel-automation/commit/b2aaac5b28ede67372f3961febae0951ebf5767a) 
 Automation project version will usually follow along the release version of target application being automated. It is possible that there can be a patch on top of an existing version of the application. This situation might require to patch the subsequent version of the automation project as well. To handle this scenario, it is now possible for projects and prefabs to have multiple active versions.
2. [Allow version management only when project is not open in editor](https://github.com/Nfactor26/pixel-automation/commit/d416ded21b44bbd5b0e05a8196ae511acc02db85)
 If a version is published while still open in editor, we need to re-configure everything so that editor starts using the newer version. However, re-configuration is not trivial and prone to lots of issues as observed so far. To simplify things, version management is only allowed when the project is not open in editor for both automation project and prefab project.
3. [Allow users to pick prefab version to edit](https://github.com/Nfactor26/pixel-automation/commit/07f74a263aaa9b6a29172b12e43f5b0222420767)
We can have multiple active version of prefab now. It should be possible to select the version that user wants to edit.