### PR TITLE
Add application drag source on control explorer and prefab explorer

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabExplorerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabExplorerViewModel.cs
@@ -22,10 +22,20 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
         private readonly IWindowManager windowManager;
         private readonly IEventAggregator eventAggregator;    
         private readonly IVersionManagerFactory versionManagerFactory;
-        private readonly IApplicationDataManager applicationDataManager;   
-        private ApplicationDescriptionViewModel activeApplication;
+        private readonly IApplicationDataManager applicationDataManager;          
         private IPrefabBuilderFactory prefabBuilderFactory;
-       
+
+        private ApplicationDescriptionViewModel activeApplication;
+        public ApplicationDescriptionViewModel ActiveApplication
+        {
+            get => this.activeApplication;
+            set
+            {
+                this.activeApplication = value;
+                NotifyOfPropertyChange();
+            }
+        }
+
         public BindableCollection<PrefabProjectViewModel> Prefabs { get; set; } = new ();
       
         public PrefabProjectViewModel SelectedPrefab { get; set; }
@@ -49,12 +59,12 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
         /// <inheritdoc/>
         public void SetActiveApplication(ApplicationDescriptionViewModel applicationDescriptionViewModel)
         {
-            this.activeApplication = applicationDescriptionViewModel;          
+            this.ActiveApplication = applicationDescriptionViewModel;          
             this.Prefabs.Clear();
-            if(this.activeApplication != null)
+            if(this.ActiveApplication != null)
             {
                 LoadPrefabs(applicationDescriptionViewModel);
-                this.Prefabs.AddRange(this.activeApplication.PrefabsCollection);
+                this.Prefabs.AddRange(this.ActiveApplication.PrefabsCollection);
             }                     
         }
 
@@ -82,15 +92,15 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
                 Guard.Argument(entity).NotNull();
 
                 var prefabBuilder = prefabBuilderFactory.CreatePrefabBuilder();
-                prefabBuilder.Initialize(this.activeApplication, entity);
+                prefabBuilder.Initialize(this.ActiveApplication, entity);
                 var result = await windowManager.ShowDialogAsync(prefabBuilder);
                 if (result.HasValue && result.Value)
                 {
                     var createdPrefab = await prefabBuilder.SavePrefabAsync();
                     var prefabViewModel = new PrefabProjectViewModel(createdPrefab);
                     this.Prefabs.Add(prefabViewModel);
-                    this.activeApplication.AddPrefab(prefabViewModel);
-                    await this.applicationDataManager.AddOrUpdateApplicationAsync(this.activeApplication.Model);
+                    this.ActiveApplication.AddPrefab(prefabViewModel);
+                    await this.applicationDataManager.AddOrUpdateApplicationAsync(this.ActiveApplication.Model);
                 }
             }
             catch (Exception ex)

--- a/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml
@@ -2,8 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"      
-             xmlns:local="clr-namespace:Pixel.Automation.AppExplorer.Views.Control"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"           
              xmlns:dd="clr-namespace:GongSolutions.Wpf.DragDrop;assembly=GongSolutions.Wpf.DragDrop"
              xmlns:cal="http://www.caliburnproject.org"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks" cal:Bind.AtDesignTime="True"
@@ -12,7 +11,7 @@
              d:DesignHeight="450" d:DesignWidth="800">
 
     <UserControl.Resources>
-
+        
         <Style x:Key="ControlLabel" TargetType="{x:Type TextBox}">
             <Setter Property="IsReadOnly" Value="True"></Setter>
             <Setter Property="HorizontalAlignment" Value="Center"></Setter>
@@ -120,6 +119,13 @@
         <DockPanel Grid.Row="0">
             <!-- SearchBox and Back button on left-->
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" DockPanel.Dock="Left">
+                <StackPanel DataContext="{Binding ActiveApplication}" IsHitTestVisible="True" dd:DragDrop.IsDragSource="True"
+                            Background="{DynamicResource MahApps.Brushes.Control.Background}" ToolTip="{Binding ApplicationName}" >
+                    <ContentControl x:Name="ApplicationIcon"  Foreground="{DynamicResource MahApps.Brushes.Accent}"                                
+                                Margin="2" Width="28" Height="28" Content="{StaticResource ApplicationIcon}" IsHitTestVisible="False">
+                    </ContentControl>
+                </StackPanel>
+               
                 <TextBox Name="Filter" Margin="6,1,0,1" Text="{Binding FilterText,UpdateSourceTrigger=PropertyChanged}" controls:TextBoxHelper.ClearTextButton="True"                      
                              controls:TextBoxHelper.UseFloatingWatermark="False"                     
                              controls:TextBoxHelper.Watermark="Search"   Grid.Column="0" HorizontalAlignment="Left"

--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml
@@ -140,6 +140,12 @@
         </Grid.RowDefinitions>
 
         <StackPanel Orientation="Horizontal" Grid.Row="0">
+            <StackPanel DataContext="{Binding ActiveApplication}" IsHitTestVisible="True" dd:DragDrop.IsDragSource="True"
+                            Background="{DynamicResource MahApps.Brushes.Control.Background}" ToolTip="{Binding ApplicationName}" >
+                <ContentControl x:Name="ApplicationIcon"  Foreground="{DynamicResource MahApps.Brushes.Accent}"                                
+                                Margin="2" Width="28" Height="28" Content="{StaticResource ApplicationIcon}" IsHitTestVisible="False">
+                </ContentControl>
+            </StackPanel>
             <TextBox Name="Filter" Margin="6,1,0,1" Text="{Binding FilterText,UpdateSourceTrigger=PropertyChanged}" controls:TextBoxHelper.ClearTextButton="True"                      
                              controls:TextBoxHelper.UseFloatingWatermark="False"                     
                              controls:TextBoxHelper.Watermark="Search"   Grid.Column="0" HorizontalAlignment="Left"

--- a/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
@@ -20,7 +20,7 @@
     <iconPacks:PackIconOcticons x:Key="IconInfo" Kind="Info"  x:Shared="false" />
     <iconPacks:Modern x:Key="GithubOctoCat" Kind="SocialGithubOctocat" Width="20" Height="20" />
     <iconPacks:Modern x:Key="Settings" Kind="Settings" Width="19" Height="19" />
-    
+    <iconPacks:Modern x:Key="ApplicationIcon" Kind="App" Width="26" Height="26" />
 
     <Style  x:Key="LinkButton"  TargetType="Button">
         <Setter Property="Template">


### PR DESCRIPTION
**Description**
When working with an automation project, we need to go back to application explorer -> application view to drag drop the application on editor. Given we will be spending most of the time on application explorer -> control explorer view or occasionally application explorer -> prefab explorer view , we need to avoid going to top view frequently as dropping application on editor is a frequent operation. There is a small application icon on the top left of control explorer and prefab explorer view which represents the active application and can be dropped on editor to add the application. Sadly, the icon choice is not that great :s