### PR TITLE
Set shared attribute to false for icons

### DIFF
--- a/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
@@ -18,9 +18,9 @@
     <iconPacks:PackIconMaterial x:Key="CloudOffline" Width="20" Height="20" Kind="CloudOffOutline" />
     <iconPacks:PackIconModern x:Key="IconPageEdit" Kind="PageEdit" x:Shared="false" />
     <iconPacks:PackIconOcticons x:Key="IconInfo" Kind="Info"  x:Shared="false" />
-    <iconPacks:Modern x:Key="GithubOctoCat" Kind="SocialGithubOctocat" Width="20" Height="20" />
-    <iconPacks:Modern x:Key="Settings" Kind="Settings" Width="19" Height="19" />
-    <iconPacks:Modern x:Key="ApplicationIcon" Kind="App" Width="26" Height="26" />
+    <iconPacks:Modern x:Key="GithubOctoCat" Kind="SocialGithubOctocat" Width="20" Height="20" x:Shared="false" />
+    <iconPacks:Modern x:Key="Settings" Kind="Settings" Width="19" Height="19" x:Shared="false" />
+    <iconPacks:Modern x:Key="ApplicationIcon" Kind="App" Width="26" Height="26" x:Shared="false" />
 
     <Style  x:Key="LinkButton"  TargetType="Button">
         <Setter Property="Template">


### PR DESCRIPTION
**Description**
If the shared attribute is not set to false, the application icon disappears from control explorer after prefab explorer is activated.