### PR TITLE
Changing prefab version should not require application restart

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabVersionManagerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabVersionManagerViewModel.cs
@@ -22,8 +22,6 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
         private readonly PrefabProject prefabProject;
         private readonly ApplicationSettings applicationSettings;
 
-        private bool wasPublished = false;
-
         public BindableCollection<PrefabVersionViewModel> AvailableVersions { get; set; } = new BindableCollection<PrefabVersionViewModel>();
        
 
@@ -84,9 +82,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
                 await this.applicationDataManager.AddOrUpdatePrefabDataFilesAsync(this.prefabProject, new PrefabVersion(prefabVersionViewModel.Version) { IsActive = false });
                 await this.applicationDataManager.AddOrUpdatePrefabDataFilesAsync(this.prefabProject, newVersion);
 
-                this.AvailableVersions.Insert(indexToInsert, new PrefabVersionViewModel(this.prefabProject, newVersion, fileSystem, referenceManagerFactory));
-                this.wasPublished = true;
-
+                this.AvailableVersions.Insert(indexToInsert, new PrefabVersionViewModel(this.prefabProject, newVersion, fileSystem, referenceManagerFactory));                
             }
             catch (Exception ex)
             {
@@ -118,7 +114,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
 
         public async Task CloseAsync()
         {
-            await this.TryCloseAsync(this.wasPublished);
+            await this.TryCloseAsync(false);
         }
     }
 }

--- a/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabVersionViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/PrefabVersionViewModel.cs
@@ -152,7 +152,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
                     }
                 }
 
-                string assemblyName = this.prefabProject.Namespace;
+                string assemblyName = $"{this.prefabProject.Namespace}.v{Version.Major}";
                 using (var compilationResult = workspaceManager.CompileProject(prefabProjectName, assemblyName))
                 {
                     compilationResult.SaveAssemblyToDisk(this.fileSystem.ReferencesDirectory);
@@ -164,10 +164,10 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
                 this.PrefabAssembly = $"{assemblyName}.dll";
 
                 //Replace the assemly name in the process and template file
-                UpdateAssemblyReference(this.fileSystem.PrefabFile, assemblyName);
+                UpdateAssemblyReference(this.fileSystem.PrefabFile, this.prefabProject.Namespace, assemblyName);
                 if (File.Exists(this.fileSystem.TemplateFile))
                 {
-                    UpdateAssemblyReference(this.fileSystem.TemplateFile, assemblyName);
+                    UpdateAssemblyReference(this.fileSystem.TemplateFile, this.prefabProject.Namespace, assemblyName);
                 }
 
                 logger.Information($"Assembly references updated in process and template files.");
@@ -181,13 +181,13 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Prefab
         /// </summary>
         /// <param name="processFile"></param>
         /// <param name="assemblyName"></param>
-        private void UpdateAssemblyReference(string processFile, string assemblyName)
+        private void UpdateAssemblyReference(string processFile, string assemblyName, string replaceWith)
         {
             string fileContents = File.ReadAllText(processFile);
             Regex regex = new Regex($"({assemblyName})(_\\d+)");
             fileContents = regex.Replace(fileContents, (m) =>
             {
-                return assemblyName;
+                return replaceWith;
             });
             File.WriteAllText(processFile, fileContents);
 

--- a/src/Pixel.Automation.Designer.Views/VersionManager/PrefabReferenceManagerView.xaml
+++ b/src/Pixel.Automation.Designer.Views/VersionManager/PrefabReferenceManagerView.xaml
@@ -14,7 +14,7 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
-            <RowDefinition Height="90"></RowDefinition>
+            <RowDefinition Height="60"></RowDefinition>
             <RowDefinition Height="60"></RowDefinition>
         </Grid.RowDefinitions>
 
@@ -54,17 +54,10 @@
         </DataGrid>
         
         <StackPanel Grid.Row="1" x:Name="WarningPanel" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="{StaticResource ControlMargin}" 
-                            Background="{DynamicResource MahApps.Brushes.ValidationSummary3}" Orientation="Vertical">
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="5">
-                <iconPacks:PackIconMaterial Kind="Alert" Margin="5" VerticalAlignment="Center"/>
-                <TextBlock x:Name="WarningMessage" Margin="5" VerticalAlignment="Center"
+                            Background="{DynamicResource MahApps.Brushes.ValidationSummary3}" Orientation="Horizontal">
+            <iconPacks:PackIconMaterial Kind="Alert" Margin="10,0,0,0" VerticalAlignment="Center"/>
+            <TextBlock x:Name="WarningMessage" Margin="10,0,0,0" VerticalAlignment="Center"
                                Text="Upgrading Prefab version can be a breaking change. You might need to redo input and output mapping script for Prefab."/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="5">
-                <iconPacks:PackIconMaterial Kind="Alert" Margin="5" VerticalAlignment="Center"/>
-                <TextBlock x:Name="RestartMessage" Margin="5" VerticalAlignment="Center"
-                               Text="Any changes will take effect after application restart."/>
-            </StackPanel>
         </StackPanel>
         <DockPanel Grid.Row="2" LastChildFill="False">
             <Border DockPanel.Dock="Top" BorderThickness="1" Height="1" HorizontalAlignment="Stretch" Width="{Binding Path=Width,RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type DockPanel}}}" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>


### PR DESCRIPTION
**Description**
All the published prefabs have same data model assembly name. As a result, if we change the version, we can't load the assembly with same name from different path. While publishing the prefab, we compile the assembly with major version included in the name. This avoids the issue with loading when changing version.