### PR TITLE
Fix issue with service failing to save project data on publish

### DIFF
--- a/src/Pixel.Persistence.Respository/PrefabRepository.cs
+++ b/src/Pixel.Persistence.Respository/PrefabRepository.cs
@@ -67,9 +67,9 @@ namespace Pixel.Persistence.Respository
                     using (var cursor = await bucket.FindAsync(filter, options))
                     {
                         var fileInfo = (await cursor.ToListAsync()).FirstOrDefault();
-                        if (fileInfo?.Metadata["isDeployed"].AsBoolean ?? false)
+                        if (!(fileInfo?.Metadata["isActive"].AsBoolean ?? true))
                         {
-                            throw new InvalidOperationException($"Version : {prefab.Version} for prefab with id : {prefab.PrefabId} is deployed. Can't update a deployed version");
+                            throw new InvalidOperationException($"Version : {prefab.Version} for prefab with id : {prefab.PrefabId} is not active. Can't update a published version");
                         }
                     }
 
@@ -235,9 +235,8 @@ namespace Pixel.Persistence.Respository
                     //Delete all the revisions that exceed max allowed number of revisions
                     foreach (var fileRevision in fileRevisions.Skip(policy.MaxNumberOfRevisions))
                     {
-                        //don't delete the deployed version as there will be a single
-                        //entry per version with isDeployed = true
-                        if (fileRevision.Metadata["isDeployed"].AsBoolean)
+                        //don't delete the published version as there will be a single entry per version with isActive = false
+                        if (!fileRevision.Metadata["isActive"].AsBoolean)
                         {
                             continue;
                         }
@@ -250,9 +249,8 @@ namespace Pixel.Persistence.Respository
                     //Delete all the revisions that are older then the allowed age
                     foreach (var fileRevision in fileRevisions.Skip(1))
                     {
-                        //don't delete the deployed version as there will be a single
-                        //entry per version with isDeployed = true
-                        if (fileRevision.Metadata["isDeployed"].AsBoolean)
+                        //don't delete the published version as there will be a single entry per version with isActive = false
+                        if (!fileRevision.Metadata["isActive"].AsBoolean)
                         {
                             continue;
                         }

--- a/src/Pixel.Persistence.Respository/ProjectRepository.cs
+++ b/src/Pixel.Persistence.Respository/ProjectRepository.cs
@@ -66,9 +66,9 @@ namespace Pixel.Persistence.Respository
                     using (var cursor = await bucket.FindAsync(filter, options))
                     {
                         var fileInfo = (await cursor.ToListAsync()).FirstOrDefault();
-                        if (fileInfo?.Metadata["isDeployed"].AsBoolean ?? false)
+                        if (!(fileInfo?.Metadata["isActive"].AsBoolean ?? true))
                         {
-                            throw new InvalidOperationException($"Version : {project.Version} for project with id : {project.ProjectId} is deployed. Can't update a deployed version");
+                            throw new InvalidOperationException($"Version : {project.Version} for project with id : {project.ProjectId} is not active. Can't update a published version");
                         }
                     }
 
@@ -235,9 +235,8 @@ namespace Pixel.Persistence.Respository
                     //Delete all the revisions that exceed max allowed number of revisions
                     foreach (var fileRevision in fileRevisions.Skip(policy.MaxNumberOfRevisions))
                     {
-                        //don't delete the deployed version as there will be a single
-                        //entry per version with isDeployed = true
-                        if(fileRevision.Metadata["isDeployed"].AsBoolean)
+                        //don't delete the published version as there will be a single entry per version with isActive = false
+                        if(!fileRevision.Metadata["isActive"].AsBoolean)
                         {
                             continue;
                         }
@@ -250,9 +249,8 @@ namespace Pixel.Persistence.Respository
                     //Delete all the revisions that are older then the allowed age
                     foreach (var fileRevision in fileRevisions.Skip(1))
                     {
-                        //don't delete the deployed version as there will be a single
-                        //entry per version with isDeployed = true
-                        if (fileRevision.Metadata["isDeployed"].AsBoolean)
+                        //don't delete the published version as there will be a single entry per version with isActive = false
+                        if (!fileRevision.Metadata["isActive"].AsBoolean)
                         {
                             continue;
                         }                        


### PR DESCRIPTION
**Description**
When publishing project, service fails to save project data correctly as there is no isDeployed field anymore. Updated code to use isActive fields instead.