### PR TITLE
Correctly generate Prefab mapping script file locations

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabDropHandlerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabDropHandlerViewModel.cs
@@ -45,12 +45,16 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
                 PrefabId = prefabProjectViewModel.PrefabId,
                 ApplicationId = prefabProjectViewModel.ApplicationId
             };
+
+            //We add and remove prefab entity to drop target so that the ScriptInitializer can correctly generate input and output mapping script location
+            dropTarget.AddComponent(this.prefabEntity);
             var initializers = prefabEntity.GetType().GetCustomAttributes(typeof(InitializerAttribute), true).OfType<InitializerAttribute>();
             foreach (var intializer in initializers)
             {
                 IComponentInitializer componentInitializer = Activator.CreateInstance(intializer.Initializer) as IComponentInitializer;
-                componentInitializer.IntializeComponent(prefabEntity, dropTarget.Model.EntityManager);
+                componentInitializer.IntializeComponent(prefabEntity, entityManager);
             }
+            dropTarget.RemoveComponent(this.prefabEntity);
 
             this.stagedScreens.Clear();
 

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabVersionSelectorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabVersionSelectorViewModel.cs
@@ -208,10 +208,11 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         private bool ValidateScriptPath(string propertyName, string scriptFile)
         {
             ClearErrors(propertyName);
-            if (!Path.GetDirectoryName(Path.Combine(this.projectFileSystem.WorkingDirectory, scriptFile)).Equals(this.projectFileSystem.ScriptsDirectory))
+            string scriptDirectory = Path.GetDirectoryName(Path.Combine(this.projectFileSystem.WorkingDirectory, scriptFile));
+            if (!(scriptDirectory.Contains(this.projectFileSystem.ScriptsDirectory) || scriptDirectory.Contains(this.projectFileSystem.TestCaseRepository)))
             {
-                AddOrAppendErrors(propertyName, $"{propertyName} file must be located in 'Scripts' directory");
-                AddOrAppendErrors("", $"{propertyName} file must be located in 'Scripts' directory");               
+                AddOrAppendErrors(propertyName, $"{propertyName} file must be located in a subdirectory of '{this.projectFileSystem.WorkingDirectory}' directory");
+                AddOrAppendErrors("", $"{propertyName} file must be located in a subdirectory of '{this.projectFileSystem.WorkingDirectory}' directory");               
                 return false;
             }
             return true;


### PR DESCRIPTION
**Description** 
If a Prefab is added to a test case or a test fixture, the mapping script location should be generated to test case directory or fixture directory instead of Script directory similar to scripts belonging to other components.