### PR TITLE
Exclude deleted fixtures when retrieving fixtures for a given version of project

### DIFF
--- a/src/Pixel.Persistence.Respository/TestFixtureRepository.cs
+++ b/src/Pixel.Persistence.Respository/TestFixtureRepository.cs
@@ -57,8 +57,8 @@ public class TestFixtureRepository : ITestFixtureRepository
     /// <inheritdoc/>  
     public async Task<IEnumerable<TestFixture>> GetFixturesAsync(string projectId, string projectVersion, CancellationToken cancellationToken)
     {
-        var filter = Builders<TestFixture>.Filter.And(Builders<TestFixture>.Filter.Eq(x => x.ProjectId, projectId),
-            Builders<TestFixture>.Filter.Eq(x => x.ProjectVersion, projectVersion));
+        var filter = Builders<TestFixture>.Filter.Eq(x => x.ProjectId, projectId) & Builders<TestFixture>.Filter.Eq(x => x.ProjectVersion, projectVersion) &
+             Builders<TestFixture>.Filter.Eq(x => x.IsDeleted, false);
         var fixtures = await fixturesCollection.FindAsync(filter, FindOptions, cancellationToken);
         return await fixtures.ToListAsync();       
     }


### PR DESCRIPTION
**Description**
Deleted fixtures should not be retrieved when getting fixtures for a given version of project