### PR TITLE
Test execution progress and results on console

### DIFF
--- a/src/Pixel.Automation.Test.Runner/Commands/ExecuteAdhocTestCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/ExecuteAdhocTestCommand.cs
@@ -79,7 +79,7 @@ internal sealed class ExecuteAdhocTestCommand : AsyncCommand<AdhocTestSettings>
         }
         else
         {
-            await projectManager.RunAllAsync(sessionTemplate.Selector);
+            await projectManager.RunAllAsync(sessionTemplate.Selector, console);
         }
         return 0;
     }

--- a/src/Pixel.Automation.Test.Runner/Commands/ExecuteTestFromTemplateCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/ExecuteTestFromTemplateCommand.cs
@@ -53,7 +53,7 @@ internal sealed class ExecuteTestFromTemplateCommand : AsyncCommand<ExecuteTestF
         }
         else
         {
-            await projectManager.RunAllAsync(sessionTemplate.Selector);
+            await projectManager.RunAllAsync(sessionTemplate.Selector, console);
         }
         return 0;
     }


### PR DESCRIPTION
**Description**
While working with test-runner manually, we dont' get any idea of test progresss and result. We need to go on portal and check the details. Console will now immediately print details of fixture and test being executed along with result for the test for an interactive fee.