### PR TITLE
Test cases, fixtures and data sources : Download only if we  don't have most recent copy and don't load if marked deleted

### DIFF
--- a/src/Pixel.Automation.Core/Constants.cs
+++ b/src/Pixel.Automation.Core/Constants.cs
@@ -99,14 +99,7 @@
         /// </summary>
         public static readonly string ApplicationsMeta = "Applications.meta";
 
-        /// <summary>
-        /// Meta data file name for projects
-        /// </summary>
-        public static readonly string ProjectsMeta = "Projects.meta";
-
-        /// <summary>
-        /// Meta data file name for project versions
-        /// </summary>
-        public static readonly string VersionsMeta = "Versions.meta";
+        public static readonly string LastUpdatedFileName = "lastupdated";
+     
     }
 }

--- a/src/Pixel.Automation.Core/FileSystem/ProjectFileSystem.cs
+++ b/src/Pixel.Automation.Core/FileSystem/ProjectFileSystem.cs
@@ -96,6 +96,10 @@ namespace Pixel.Automation.Core
             foreach (var dataSourceFile in dataSourceFiles)
             {
                 var testDataSource = serializer.Deserialize<TestDataSource>(dataSourceFile);
+                if(testDataSource.IsDeleted)
+                {
+                    continue;
+                }
                 yield return testDataSource;              
             }
             yield break;

--- a/src/Pixel.Automation.Core/TestData/TestCase.cs
+++ b/src/Pixel.Automation.Core/TestData/TestCase.cs
@@ -1,6 +1,7 @@
 ﻿using Pixel.Automation.Core.Attributes;
 using Pixel.Automation.Core.Enums;
 using System;
+using System.Diagnostics.SymbolStore;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
@@ -80,6 +81,12 @@ namespace Pixel.Automation.Core.TestData
         /// </summary>
         [DataMember(IsRequired = true, Order = 110)]
         public TagCollection Tags { get; private set; } = new TagCollection();
+
+        /// <summary>
+        /// Indicates if the TestCase is deleted. Deleted test cases are not loaded in explorer.
+        /// </summary>
+        [DataMember(IsRequired = false, Order = 1000)]
+        public bool IsDeleted { get; set; }
 
         /// <summary>
         /// Root entity for the test case

--- a/src/Pixel.Automation.Core/TestData/TestDataSource.cs
+++ b/src/Pixel.Automation.Core/TestData/TestDataSource.cs
@@ -40,6 +40,13 @@ namespace Pixel.Automation.Core.TestData
         /// </summary>
         [DataMember(IsRequired = true, Order = 50)]
         public DataSourceConfiguration MetaData { get; set; }
+
+
+        /// <summary>
+        /// Indicates if the TestDataSource is deleted. Deleted data sources are not loaded in explorer.
+        /// </summary>
+        [DataMember(IsRequired = false, Order = 1000)]
+        public bool IsDeleted { get; set; }
     }
 
     /// <summary>

--- a/src/Pixel.Automation.Core/TestData/TestFixture.cs
+++ b/src/Pixel.Automation.Core/TestData/TestFixture.cs
@@ -67,6 +67,12 @@ namespace Pixel.Automation.Core.TestData
         public TagCollection Tags { get; private set; } = new TagCollection();
 
         /// <summary>
+        /// Indicates if the fixture was deleted. Deleted fixtures are not loaded in explorer.
+        /// </summary>
+        [DataMember(IsRequired = false, Order = 1000)]
+        public bool IsDeleted { get; set; }
+
+        /// <summary>
         /// Collection of tests belonging to a fixture 
         /// </summary>
         [JsonIgnore]

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
@@ -118,12 +118,20 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                     foreach (var testFixtureDirectory in Directory.GetDirectories(this.fileSystem.TestCaseRepository))
                     {
                         var testFixture = this.fileSystem.LoadFiles<TestFixture>(testFixtureDirectory).Single();
+                        if(testFixture.IsDeleted)
+                        {
+                            continue; 
+                        }
                         TestFixtureViewModel testFixtureVM = new TestFixtureViewModel(testFixture);
                         this.TestFixtures.Add(testFixtureVM);
 
                         foreach (var testCaseDirectory in Directory.GetDirectories(Path.Combine(this.fileSystem.TestCaseRepository, testFixture.FixtureId)))
                         {
                             var testCase = this.fileSystem.LoadFiles<TestCase>(testCaseDirectory).Single();
+                            if(testCase.IsDeleted)
+                            {
+                                continue;
+                            }
                             TestCaseViewModel testCaseVM = new TestCaseViewModel(testCase);
                             testFixtureVM.Tests.Add(testCaseVM);
                         }

--- a/src/Pixel.Persistence.Respository/Interfaces/ITestCaseRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/ITestCaseRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Pixel.Persistence.Core.Models;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,13 +9,13 @@ namespace Pixel.Persistence.Respository.Interfaces;
 public interface ITestCaseRepository
 {
     /// <summary>
-    /// Get all test cases for a given project version
+    /// Get all test cases for a given project version which were modified after specified datetime
     /// </summary>
     /// <param name="projectId"></param>
     /// <param name="projectVersion"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task<IEnumerable<TestCase>> GetTestCasesAsync(string projectId, string projectVersion, CancellationToken cancellationToken);
+    Task<IEnumerable<TestCase>> GetTestCasesAsync(string projectId, string projectVersion, DateTime laterThan, CancellationToken cancellationToken);
 
     /// <summary>
     /// Get test cases by Id for a given version of project

--- a/src/Pixel.Persistence.Respository/Interfaces/ITestDataRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/ITestDataRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Pixel.Persistence.Core.Models;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,36 @@ namespace Pixel.Persistence.Respository.Interfaces
 {
     public interface ITestDataRepository
     {
+        /// <summary>
+        /// Get TestDataSource by Id for a given version of project
+        /// </summary>
+        /// <param name="projectId"></param>
+        /// <param name="projectVersion"></param>
+        /// <param name="fixtureId"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<TestDataSource> FindByIdAsync(string projectId, string projectVersion, string fixtureId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get TestDataSource by name for a given version of project
+        /// </summary>
+        /// <param name="projectId"></param>
+        /// <param name="projectVersion"></param>
+        /// <param name="name"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<TestDataSource> FindByNameAsync(string projectId, string projectVersion, string name, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get all the TestDataSources available for a given version of project that were modified since specified datetime
+        /// </summary>
+        /// <param name="projectId"></param>
+        /// <param name="projectVersion"></param>
+        /// <param name="laterThan"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<IEnumerable<TestDataSource>> GetDataSourcesAsync(string projectId, string projectVersion, DateTime laterThan, CancellationToken cancellationToken);
+
         /// <summary>
         /// Add a TestDataSource to a given version of project
         /// </summary>
@@ -33,37 +64,8 @@ namespace Pixel.Persistence.Respository.Interfaces
         /// <param name="dataSourceId"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task DeleteDataSourceAsync(string projectId, string projectVersion, string dataSourceId, CancellationToken cancellationToken);
-       
-        /// <summary>
-        /// Get TestDataSource by Id for a given version of project
-        /// </summary>
-        /// <param name="projectId"></param>
-        /// <param name="projectVersion"></param>
-        /// <param name="fixtureId"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        Task<TestDataSource> FindByIdAsync(string projectId, string projectVersion, string fixtureId, CancellationToken cancellationToken);
-       
-        /// <summary>
-        /// Get TestDataSource by name for a given version of project
-        /// </summary>
-        /// <param name="projectId"></param>
-        /// <param name="projectVersion"></param>
-        /// <param name="name"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        Task<TestDataSource> FindByNameAsync(string projectId, string projectVersion, string name, CancellationToken cancellationToken);
-        
-        /// <summary>
-        /// Get all the TestDataSources available for a given version of project
-        /// </summary>
-        /// <param name="projectId"></param>
-        /// <param name="projectVersion"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        Task<IEnumerable<TestDataSource>> GetDataSourcesAsync(string projectId, string projectVersion, CancellationToken cancellationToken);
-      
+        Task DeleteDataSourceAsync(string projectId, string projectVersion, string dataSourceId, CancellationToken cancellationToken);   
+             
         /// <summary>
         /// Update a TestDataSource for a given version of project
         /// </summary>

--- a/src/Pixel.Persistence.Respository/Interfaces/ITestFixtureRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/ITestFixtureRepository.cs
@@ -9,12 +9,13 @@ namespace Pixel.Persistence.Respository.Interfaces;
 public interface ITestFixtureRepository
 {
     /// <summary>
-    /// Get all test fixtures for a given project version
+    /// Get all test fixtures for a given project version which have been modified since specified datetime
     /// </summary>
     /// <param name="projectId">Identifier of the automation project</param>
     /// <param name="projectVersion">Version of the automation project</param>
     /// <returns></returns>
-    Task<IEnumerable<TestFixture>> GetFixturesAsync(string projectId, string projectVersion, CancellationToken cancellationToken);
+    Task<IEnumerable<TestFixture>> GetFixturesAsync(string projectId, string projectVersion, DateTime laterThan, CancellationToken cancellationToken);
+
 
     /// <summary>
     /// Get a test fixture given it's Id

--- a/src/Pixel.Persistence.Respository/ProjectsRepository.cs
+++ b/src/Pixel.Persistence.Respository/ProjectsRepository.cs
@@ -105,21 +105,23 @@ namespace Pixel.Persistence.Respository
             projectReference.Id = ObjectId.Empty;
             await this.referencesRepository.AddProjectReferences(projectId, newVersion.ToString(), projectReference);
 
-            var fixtures = await this.fixturesRepository.GetFixturesAsync(projectId, cloneFrom.ToString(), cancellationToken);
+
+            DateTime laterThan = DateTime.MinValue.ToUniversalTime();
+            var fixtures = await this.fixturesRepository.GetFixturesAsync(projectId, cloneFrom.ToString(), laterThan, cancellationToken);
             foreach(var fixture in fixtures)
             {
                 fixture.Id = ObjectId.Empty;
             }
             await this.fixturesRepository.AddFixturesAsync(projectId, newVersion.ToString(), fixtures, cancellationToken);
 
-            var tests = await this.testCaseRepository.GetTestCasesAsync(projectId, cloneFrom.ToString(), cancellationToken);
+            var tests = await this.testCaseRepository.GetTestCasesAsync(projectId, cloneFrom.ToString(), laterThan, cancellationToken);
             foreach(var test in tests)
             {
                 test.Id = ObjectId.Empty;
             }
             await this.testCaseRepository.AddTestCasesAsync(projectId, newVersion.ToString(), tests, cancellationToken);
 
-            var dataSources = await this.testDataRepository.GetDataSourcesAsync(projectId, cloneFrom.ToString(), cancellationToken);
+            var dataSources = await this.testDataRepository.GetDataSourcesAsync(projectId, cloneFrom.ToString(), laterThan, cancellationToken);
             foreach(var dataSource in dataSources)
             {
                 dataSource.Id = ObjectId.Empty;

--- a/src/Pixel.Persistence.Respository/TestCaseRepository.cs
+++ b/src/Pixel.Persistence.Respository/TestCaseRepository.cs
@@ -52,10 +52,10 @@ public class TestCaseRepository : ITestCaseRepository
     }
 
     /// <inheritdoc/>  
-    public async Task<IEnumerable<TestCase>> GetTestCasesAsync(string projectId, string projectVersion, CancellationToken cancellationToken)
+    public async Task<IEnumerable<TestCase>> GetTestCasesAsync(string projectId, string projectVersion, DateTime laterThan, CancellationToken cancellationToken)
     {
-        var filter = Builders<TestCase>.Filter.Eq(x => x.ProjectId, projectId) & Builders<TestCase>.Filter.Eq(x => x.ProjectVersion, projectVersion)
-            & Builders<TestCase>.Filter.Eq(x => x.IsDeleted, false);
+        var filter = Builders<TestCase>.Filter.Eq(x => x.ProjectId, projectId) & Builders<TestCase>.Filter.Eq(x => x.ProjectVersion, projectVersion) &
+            Builders<TestCase>.Filter.Gt(x => x.LastUpdated, laterThan);
         var tests = await testsCollection.FindAsync(filter, FindOptions, cancellationToken);
         return await tests.ToListAsync();
     }

--- a/src/Pixel.Persistence.Respository/TestDataRepository.cs
+++ b/src/Pixel.Persistence.Respository/TestDataRepository.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Collections.Generic;
 using System;
 using Pixel.Persistence.Respository.Interfaces;
-using static System.Net.Mime.MediaTypeNames;
 using System.Linq;
 
 namespace Pixel.Persistence.Respository
@@ -54,10 +53,11 @@ namespace Pixel.Persistence.Respository
         }
 
         /// <inheritdoc/>  
-        public async Task<IEnumerable<TestDataSource>> GetDataSourcesAsync(string projectId, string projectVersion, CancellationToken cancellationToken)
+        public async Task<IEnumerable<TestDataSource>> GetDataSourcesAsync(string projectId, string projectVersion, DateTime laterThan, CancellationToken cancellationToken)
         {
             var filter = Builders<TestDataSource>.Filter.And(Builders<TestDataSource>.Filter.Eq(x => x.ProjectId, projectId),
-                Builders<TestDataSource>.Filter.Eq(x => x.ProjectVersion, projectVersion));
+                Builders<TestDataSource>.Filter.Eq(x => x.ProjectVersion, projectVersion)) &
+                Builders<TestDataSource>.Filter.Eq(x => x.LastUpdated, laterThan);
             var dataSources = await testDataCollection.FindAsync(filter, FindOptions, cancellationToken);
             return await dataSources.ToListAsync();
         }

--- a/src/Pixel.Persistence.Respository/TestFixtureRepository.cs
+++ b/src/Pixel.Persistence.Respository/TestFixtureRepository.cs
@@ -55,10 +55,10 @@ public class TestFixtureRepository : ITestFixtureRepository
     }
 
     /// <inheritdoc/>  
-    public async Task<IEnumerable<TestFixture>> GetFixturesAsync(string projectId, string projectVersion, CancellationToken cancellationToken)
+    public async Task<IEnumerable<TestFixture>> GetFixturesAsync(string projectId, string projectVersion, DateTime laterThan, CancellationToken cancellationToken)
     {
         var filter = Builders<TestFixture>.Filter.Eq(x => x.ProjectId, projectId) & Builders<TestFixture>.Filter.Eq(x => x.ProjectVersion, projectVersion) &
-             Builders<TestFixture>.Filter.Eq(x => x.IsDeleted, false);
+             Builders<TestFixture>.Filter.Gt(x => x.LastUpdated, laterThan);
         var fixtures = await fixturesCollection.FindAsync(filter, FindOptions, cancellationToken);
         return await fixtures.ToListAsync();       
     }

--- a/src/Pixel.Persistence.Services.Api/Controllers/FixturesController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/FixturesController.cs
@@ -67,15 +67,16 @@ namespace Pixel.Persistence.Services.Api.Controllers
                 return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
             }
         }
+        
 
         [HttpGet("{projectId}/{projectVersion}")]
-        public async Task<ActionResult<List<TestFixture>>> GetAllForProjectAsync(string projectId, string projectVersion)
+        public async Task<ActionResult<List<TestFixture>>> GetAllForProjectAsync(string projectId, string projectVersion, [FromBody] DateTime laterThan)
         {
             try
             {
                 Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
-                Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();               
-                var result = await fixturesRepository.GetFixturesAsync(projectId, projectVersion, CancellationToken.None) ?? Enumerable.Empty<TestFixture>();
+                Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
+                var result = await fixturesRepository.GetFixturesAsync(projectId, projectVersion, laterThan, CancellationToken.None) ?? Enumerable.Empty<TestFixture>();
                 return Ok(result);
             }
             catch (Exception ex)

--- a/src/Pixel.Persistence.Services.Api/Controllers/TestDataController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/TestDataController.cs
@@ -69,13 +69,13 @@ namespace Pixel.Persistence.Services.Api.Controllers
         }
 
         [HttpGet("{projectId}/{projectVersion}")]
-        public async Task<ActionResult<List<TestDataSource>>> GetAllForProjectAsync(string projectId, string projectVersion)
+        public async Task<ActionResult<List<TestDataSource>>> GetAllForProjectAsync(string projectId, string projectVersion, [FromBody] DateTime laterThan)
         {
             try
             {
                 Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
                 Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
-                var result = await testDataRepository.GetDataSourcesAsync(projectId, projectVersion, CancellationToken.None) ?? Enumerable.Empty<TestDataSource>();
+                var result = await testDataRepository.GetDataSourcesAsync(projectId, projectVersion, laterThan, CancellationToken.None) ?? Enumerable.Empty<TestDataSource>();
                 return Ok(result);
             }
             catch (Exception ex)

--- a/src/Pixel.Persistence.Services.Api/Controllers/TestsController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/TestsController.cs
@@ -69,13 +69,13 @@ namespace Pixel.Persistence.Services.Api.Controllers
         }
 
         [HttpGet("{projectId}/{projectVersion}")]
-        public async Task<ActionResult<List<TestCase>>> GetAllForProjectAsync(string projectId, string projectVersion)
+        public async Task<ActionResult<List<TestCase>>> GetAllForProjectAsync(string projectId, string projectVersion, [FromBody] DateTime laterThan)
         {
             try
             {
                 Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
                 Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
-                var result = await testsRespository.GetTestCasesAsync(projectId, projectVersion, CancellationToken.None) ?? Enumerable.Empty<TestCase>();
+                var result = await testsRespository.GetTestCasesAsync(projectId, projectVersion, laterThan, CancellationToken.None) ?? Enumerable.Empty<TestCase>();
                 return Ok(result);
             }
             catch (Exception ex)

--- a/src/Pixel.Persistence.Services.Client/FixturesRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/FixturesRepositoryClient.cs
@@ -4,6 +4,7 @@ using Pixel.Automation.Core.TestData;
 using Pixel.Persistence.Services.Client.Interfaces;
 using RestSharp;
 using Serilog;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -69,12 +70,13 @@ public class FixturesRepositoryClient : IFixturesRepositoryClient
     }
 
     /// <inheritdoc/>  
-    public async Task<IEnumerable<TestFixture>> GetAllForProjectAsync(string projectId, string projectVersion)
+    public async Task<IEnumerable<TestFixture>> GetAllForProjectAsync(string projectId, string projectVersion, DateTime laterThan)
     {
         Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
         Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
     
         RestRequest restRequest = new RestRequest($"fixtures/{projectId}/{projectVersion}");
+        restRequest.AddBody(laterThan);
         var client = this.clientFactory.GetOrCreateClient();
         var result = await client.ExecuteGetAsync(restRequest);
         result.EnsureSuccess();

--- a/src/Pixel.Persistence.Services.Client/Interfaces/IFixturesRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/IFixturesRepositoryClient.cs
@@ -1,4 +1,5 @@
 ﻿using Pixel.Automation.Core.TestData;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -25,12 +26,13 @@ public interface IFixturesRepositoryClient
     Task<TestFixture> GetByNameAsync(string projectId, string projectVersion, string displayName);
 
     /// <summary>
-    /// Get all TestFixtures for a given version of project
+    /// Get all TestFixtures for a given version of project which were modified since specified time
     /// </summary>
     /// <param name="projectId"></param>
     /// <param name="projectVersion"></param>
+    /// <param name="laterThan"></param>
     /// <returns></returns>
-    Task<IEnumerable<TestFixture>> GetAllForProjectAsync(string projectId, string projectVersion);
+    Task<IEnumerable<TestFixture>> GetAllForProjectAsync(string projectId, string projectVersion, DateTime laterThan);
 
     /// <summary>
     /// Add a new TestFixture for a given version of project

--- a/src/Pixel.Persistence.Services.Client/Interfaces/ITestDataRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/ITestDataRepositoryClient.cs
@@ -1,4 +1,5 @@
 ﻿using Pixel.Automation.Core.TestData;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -25,12 +26,13 @@ namespace Pixel.Persistence.Services.Client
         Task<TestDataSource> GetByNameAsync(string projectId, string projectVersion, string name);
 
         /// <summary>
-        /// Get all the TestDataSources belonging to a given version of project
+        /// Get all the TestDataSources belonging to a given version of project which were updated since specified time
         /// </summary>
         /// <param name="projectId"></param>
         /// <param name="projectVersion"></param>
+        /// <param name="laterThan"></param>
         /// <returns></returns>
-        Task<IEnumerable<TestDataSource>> GetAllForProjectAsync(string projectId, string projectVersion);
+        Task<IEnumerable<TestDataSource>> GetAllForProjectAsync(string projectId, string projectVersion, DateTime laterThan);
 
         /// <summary>
         /// Add a TestDataSource to a given version of project

--- a/src/Pixel.Persistence.Services.Client/Interfaces/ITestsRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/ITestsRepositoryClient.cs
@@ -1,4 +1,5 @@
 ﻿using Pixel.Automation.Core.TestData;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -25,12 +26,13 @@ public interface ITestsRepositoryClient
     Task<TestCase> GetByNameAsync(string projectId, string projectVersion, string displayName);
 
     /// <summary>
-    /// Get all the TestCase for a given version of project
+    /// Get all the TestCase for a given version of project which were modified since specified time
     /// </summary>
     /// <param name="projectId"></param>
     /// <param name="projectVersion"></param>
+    /// <param name="laterThan"></param>
     /// <returns></returns>
-    Task<IEnumerable<TestCase>> GetAllForProjectAsync(string projectId, string projectVersion);
+    Task<IEnumerable<TestCase>> GetAllForProjectAsync(string projectId, string projectVersion, DateTime laterThan);
 
     /// <summary>
     /// Add a new TestCase to a given version of project

--- a/src/Pixel.Persistence.Services.Client/TestDataRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/TestDataRepositoryClient.cs
@@ -4,6 +4,7 @@ using Pixel.Automation.Core.TestData;
 using Pixel.Persistence.Services.Client.Interfaces;
 using RestSharp;
 using Serilog;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -70,12 +71,13 @@ public class TestDataRepositoryClient : ITestDataRepositoryClient
     }
 
     /// <inheritdoc/>
-    public async Task<IEnumerable<TestDataSource>> GetAllForProjectAsync(string projectId, string projectVersion)
+    public async Task<IEnumerable<TestDataSource>> GetAllForProjectAsync(string projectId, string projectVersion, DateTime laterThan)
     {
         Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
         Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
 
         RestRequest restRequest = new RestRequest($"testdata/{projectId}/{projectVersion}");
+        restRequest.AddBody(laterThan);
         var client = this.clientFactory.GetOrCreateClient();
         var result = await client.ExecuteGetAsync(restRequest);
         result.EnsureSuccess();

--- a/src/Pixel.Persistence.Services.Client/TestsRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/TestsRepositoryClient.cs
@@ -4,6 +4,7 @@ using Pixel.Automation.Core.TestData;
 using Pixel.Persistence.Services.Client.Interfaces;
 using RestSharp;
 using Serilog;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -69,12 +70,13 @@ public class TestsRepositoryClient : ITestsRepositoryClient
     }
   
     /// <inheritdoc/>
-    public async Task<IEnumerable<TestCase>> GetAllForProjectAsync(string projectId, string projectVersion)
+    public async Task<IEnumerable<TestCase>> GetAllForProjectAsync(string projectId, string projectVersion, DateTime laterThan)
     {
         Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
         Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
-
+   
         RestRequest restRequest = new RestRequest($"tests/{projectId}/{projectVersion}");
+        restRequest.AddBody(laterThan);
         var client = this.clientFactory.GetOrCreateClient();
         var result = await client.ExecuteGetAsync(restRequest);
         result.EnsureSuccess();


### PR DESCRIPTION
**Description**
1. We load all the fixtures, test casess and test data source when opening a specific version of automation project. We don't want to download data if we already have the most recent version. Each version of automation project will have a lastsupdated file that stores a universal datetime for when was this version updated last. We will pass on this value to service to return only those data that have been modified after this datetime.
2. If a fixture or test case or test data source is deleted, we don't want to load it next time the project is loaded. To achieve this , we now have a IsDeleted flag on fixtures, test cases and test data source. Deleted fixtures, test cases and test data source are still retrieve from server so that we have the latest state indicating if they have been marked as deleted. However, test explorer and test data repository will skip creating a view model for these to show them.