### PR TITLE
Download published prefab version only if data is not locally available

### DIFF
--- a/src/Pixel.Automation.Core/Models/VersionInfo.cs
+++ b/src/Pixel.Automation.Core/Models/VersionInfo.cs
@@ -29,6 +29,12 @@ namespace Pixel.Automation.Core.Models
         public string DataModelAssembly { get; set; }
 
         /// <summary>
+        /// DateTime when the version was publisheds
+        /// </summary>
+        [DataMember(IsRequired = false, Order = 40)]
+        public DateTime? PublishedOn { get; set; }
+
+        /// <summary>
         /// Description 
         /// </summary>
         [DataMember(IsRequired = false, Order = 40)]
@@ -44,6 +50,12 @@ namespace Pixel.Automation.Core.Models
                 return this.Version.Equals(other.Version);
             }
             return false;
+        }
+
+        ///</inheritdoc>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.Version, this.IsActive);
         }
 
         ///</inheritdoc>

--- a/src/Pixel.Automation.Designer.ViewModels/AppBootStrapper.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AppBootStrapper.cs
@@ -63,8 +63,7 @@ namespace Pixel.Automation.Designer.ViewModels
                             logger.Information("Downloading project information now");
                             await projectDataManager.DownloadProjectsAsync();
                             logger.Information("Download of project information completed");
-                            await prefabDataManager.DownloadPrefabsAsync();
-                            logger.Information("Download of prefabs completed");
+                            await prefabDataManager.DownloadPrefabsAsync();                           
                         }
                         catch (Exception ex)
                         {

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -53,8 +53,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 
             foreach(var prefabReference in this.referenceManager.GetPrefabReferences().References)
             {
-                await this.prefabDataManager.DownloadPrefabDataAsync(new PrefabProject() { ApplicationId = prefabReference.ApplicationId, PrefabId = prefabReference.PrefabId },
-                    prefabReference.Version);
+                await this.prefabDataManager.DownloadPrefabDataAsync(prefabReference.ApplicationId, prefabReference.PrefabId, prefabReference.Version.ToString());
             }
 
             this.entityManager.SetCurrentFileSystem(this.fileSystem);

--- a/src/Pixel.Automation.Test.Runner/ProjectManager.cs
+++ b/src/Pixel.Automation.Test.Runner/ProjectManager.cs
@@ -107,12 +107,7 @@ namespace Pixel.Automation.Test.Runner
 
             foreach (var prefabReference in this.referenceManager.GetPrefabReferences().References)
             {
-                await this.prefabDataManager.DownloadPrefabDataAsync(new Core.Models.PrefabProject()
-                {
-                    ApplicationId = prefabReference.ApplicationId,
-                    PrefabId = prefabReference.PrefabId
-                },
-                prefabReference.Version);
+                await this.prefabDataManager.DownloadPrefabDataAsync( prefabReference.ApplicationId, prefabReference.PrefabId, prefabReference.Version.ToString());
             }
          
             this.entityManager.SetCurrentFileSystem(this.projectFileSystem);

--- a/src/Pixel.Persistence.Core/Models/VersionInfo.cs
+++ b/src/Pixel.Persistence.Core/Models/VersionInfo.cs
@@ -27,6 +27,11 @@ public abstract class VersionInfo
     [DataMember(IsRequired = false, Order = 30)]
     public string DataModelAssembly { get; set; }
 
+
+    [DataMember(IsRequired = false, Order = 40)]
+    public DateTime? PublishedOn { get; set; }
+
+
     public override bool Equals(object obj)
     {
         if(obj is VersionInfo versionInfo)
@@ -38,7 +43,7 @@ public abstract class VersionInfo
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Version, IsActive, DataModelAssembly);
+        return HashCode.Combine(Version, IsActive);
     }
 
     public override string ToString()

--- a/src/Pixel.Persistence.Respository/PrefabsRepository.cs
+++ b/src/Pixel.Persistence.Respository/PrefabsRepository.cs
@@ -80,7 +80,9 @@ namespace Pixel.Persistence.Respository
             var projectVersions = (await this.prefabsCollection.FindAsync<List<PrefabVersion>>(filter, new FindOptions<PrefabProject, List<PrefabVersion>>()
             {
                 Projection = Builders<PrefabProject>.Projection.Expression(u => u.AvailableVersions)
-            })).ToList().FirstOrDefault();
+            }))
+            .ToList().FirstOrDefault();
+            
             if (projectVersions?.Contains(newVersion) ?? false)
             {
                 throw new InvalidOperationException($"Version {newVersion} already exists for prefab {prefabId}");
@@ -113,6 +115,10 @@ namespace Pixel.Persistence.Respository
 
             if (prefabVersions?.Contains(prefabVersion) ?? false)
             {
+                if(!prefabVersion.IsActive && prefabVersion.PublishedOn is null)
+                {
+                    prefabVersion.PublishedOn = DateTime.UtcNow;
+                }
                 var update = Builders<PrefabProject>.Update.Set(x => x.AvailableVersions[-1], prefabVersion);
                 await this.prefabsCollection.UpdateOneAsync(filter, update);
                 logger.LogInformation("Project version {0} was updated for project : {1}", prefabVersion, prefabId);

--- a/src/Pixel.Persistence.Respository/ProjectsRepository.cs
+++ b/src/Pixel.Persistence.Respository/ProjectsRepository.cs
@@ -146,10 +146,15 @@ namespace Pixel.Persistence.Respository
             var projectVersions = (await this.projectsCollection.FindAsync<List<ProjectVersion>>(filter, new FindOptions<AutomationProject, List<ProjectVersion>>()
             {
                 Projection = Builders<AutomationProject>.Projection.Expression(u => u.AvailableVersions)
-            })).ToList().FirstOrDefault();
+            }))
+            .ToList().FirstOrDefault();
 
             if (projectVersions?.Contains(projectVersion) ?? false)
             {
+                if (!projectVersion.IsActive && projectVersion.PublishedOn is null)
+                {
+                    projectVersion.PublishedOn = DateTime.UtcNow;
+                }
                 var update = Builders<AutomationProject>.Update.Set(x => x.AvailableVersions[-1], projectVersion);
                 await this.projectsCollection.UpdateOneAsync(filter, update);
                 logger.LogInformation("Project version {0} was updated for project : {1}", projectVersion, projectId);

--- a/src/Pixel.Persistence.Services.Client/DataManagers/ProjectDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/DataManagers/ProjectDataManager.cs
@@ -11,7 +11,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Pixel.Persistence.Services.Client;
 

--- a/src/Pixel.Persistence.Services.Client/Interfaces/IPrefabDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/IPrefabDataManager.cs
@@ -28,6 +28,15 @@ public interface IPrefabDataManager
     Task DownloadPrefabsAsync();
 
     /// <summary>
+    /// Download data files for a given version of prefab
+    /// </summary>
+    /// <param name="applicationId"></param>
+    /// <param name="prefabId"></param>
+    /// <param name="prefabVersion"></param>
+    /// <returns></returns>
+    Task DownloadPrefabDataAsync(string applicationId, string prefabId, string prefabVersion);
+
+    /// <summary>
     /// Download data files for a given version of Prefab
     /// </summary>
     /// <param name="prefabProject"></param>


### PR DESCRIPTION
**Description**
1. Added Published Date for VersionInfo  of a given automation project or prefab project
2. When loading an automation project, we need to download all the prefab versions used by automation project. We will now skip downloading of prefab version if latest data is already available. This can be locally determined because a published version of prefab project can't be edited.