### PR TITLE
Fix issue with component Description not showing up in tooltip

### DIFF
--- a/src/Pixel.Automation.Core/Attributes/ToolBoxItemAttribute.cs
+++ b/src/Pixel.Automation.Core/Attributes/ToolBoxItemAttribute.cs
@@ -9,20 +9,52 @@ namespace Pixel.Automation.Core.Attributes
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class ToolBoxItemAttribute : Attribute
     {
+        /// <summary>
+        /// Name of the ToolBox Item
+        /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// Category to which ToolBox Item belongs
+        /// </summary>
         public string Category { get; }
+
+        /// <summary>
+        /// SubCategory within Category
+        /// </summary>
         public string SubCategory { get; }
+
+        /// <summary>
+        /// Custom Icon for the ToolBoxItem
+        /// </summary>
         public string IconSource { get; }
+
+        /// <summary>
+        /// Description for the ToolBox Item
+        /// </summary>
         public string Description { get; }
+
+        /// <summary>
+        /// Tags associated with ToolBox Item that can be used to filter items
+        /// </summary>
         public List<string> Tags { get; }
 
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="category"></param>
+        /// <param name="subCategory"></param>
+        /// <param name="iconSource"></param>
+        /// <param name="description"></param>
+        /// <param name="tags"></param>
         public ToolBoxItemAttribute(string name, string category, string subCategory = "", string iconSource = null, string description = null, params string[] tags)
         {
             Name = name;
             Category = category;
             SubCategory = subCategory;
             IconSource = iconSource;
-            Description = null;
+            Description = description;
             this.Tags = new List<string>();
             this.Tags.AddRange(tags);
         }

--- a/src/Pixel.Automation.Designer.Views/ToolBox/Component/ComponentToolBoxView.xaml
+++ b/src/Pixel.Automation.Designer.Views/ToolBox/Component/ComponentToolBoxView.xaml
@@ -80,8 +80,9 @@
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal" Margin="5 0 0 0">
-                        <iconPacks:PackIconMaterial Kind="Circle" Width="8" Height="8" Margin="0,2,2,0" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="{DynamicResource MahApps.Brushes.Accent}" />
-                        <TextBlock Text="{Binding Name}" ToolTip="{Binding Description}" Padding="2" FontSize="11" />
+                        <iconPacks:PackIconMaterial Kind="Circle" Width="10" Height="10"  ToolTip="{Binding Description}" ToolTipService.InitialShowDelay="500"
+                                                    Margin="0,2,2,0" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="{DynamicResource MahApps.Brushes.Accent}" />
+                        <TextBlock Text="{Binding Name}" Padding="2" FontSize="11" />
                     </StackPanel>
                 </DataTemplate>
             </ListBox.ItemTemplate>


### PR DESCRIPTION
**Description**
Component description should show up when hovering mouse on icon to the left of each component in the component toolbox.