### PR TITLE
Clone and Publish are separate actions now for project and prefab manager

### DIFF
--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionManagerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionManagerView.xaml
@@ -51,18 +51,19 @@
                     <DataGridTemplateColumn Header="">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Button x:Name="CloneAndPublish" Content="Clone and Publish" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
-                                        cal:Message.Attach="[Event Click] = [Action CloneAndPublishAsync($dataContext)]" Margin="5,2,5,2" HorizontalAlignment="Center" ToolTip="Create a copy with incremented version and mark this version published."  />
+                                <Button x:Name="Publish" Content="Publish" IsEnabled="{Binding CanPublish}" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
+                                        cal:Message.Attach="[Event Click] = [Action PublishAsync($dataContext)]" Margin="5,2,5,2" HorizontalAlignment="Center" 
+                                        ToolTip="Set the state of version as published"  />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
                     <DataGridTemplateColumn Header="">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Button x:Name="Publish" Content="Publish" IsEnabled="{Binding CanPublish}"
+                                <Button x:Name="Clone" Content="Clone" IsEnabled="{Binding CanClone}"
                                         cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
-                                        cal:Message.Attach="[Event Click] = [Action PublishAsync($dataContext)]" Margin="5,2,5,2" HorizontalAlignment="Center"
-                                        ToolTip="Mark the version as published. Published versions can be used in automation."  />
+                                        cal:Message.Attach="[Event Click] = [Action CloneAsync($dataContext)]" Margin="5,2,5,2" HorizontalAlignment="Center"
+                                        ToolTip="Create an incremented version by cloning this version"  />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>

--- a/src/Pixel.Automation.Designer.Views/VersionManager/ProjectVersionManagerView.xaml
+++ b/src/Pixel.Automation.Designer.Views/VersionManager/ProjectVersionManagerView.xaml
@@ -50,18 +50,19 @@
                     <DataGridTemplateColumn Header="">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Button x:Name="CloneAndPublish" Content="Clone and Publish" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
-                                        cal:Message.Attach="[Event Click] = [Action CloneAndPublishAsync($dataContext)]" Margin="5,2,5,2" HorizontalAlignment="Center" ToolTip="Create a copy of this version and mark this version read only" />
+                                <Button x:Name="Publish" Content="Publish" IsEnabled="{Binding CanPublish}" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
+                                        cal:Message.Attach="[Event Click] = [Action PublishAsync($dataContext)]" Margin="5,2,5,2" HorizontalAlignment="Center" 
+                                        ToolTip="Set the state of version as published" />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
                     <DataGridTemplateColumn Header="">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Button x:Name="Publish" Content="Publish" IsEnabled="{Binding CanPublish}"
+                                <Button x:Name="Clone" Content="Clone" IsEnabled="{Binding CanClone}"
                                         cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
-                                        cal:Message.Attach="[Event Click] = [Action PublishAsync($dataContext)]" Margin="5,2,5,2" 
-                                        HorizontalAlignment="Center" ToolTip="Mark this version as read only" />
+                                        cal:Message.Attach="[Event Click] = [Action CloneAsync($dataContext)]" Margin="5,2,5,2" 
+                                        HorizontalAlignment="Center" ToolTip="Create an incremented version by cloning this version" />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>

--- a/src/Pixel.Persistence.Respository/PrefabsRepository.cs
+++ b/src/Pixel.Persistence.Respository/PrefabsRepository.cs
@@ -7,6 +7,7 @@ using Pixel.Persistence.Respository.Extensions;
 using Pixel.Persistence.Respository.Interfaces;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -95,6 +96,11 @@ namespace Pixel.Persistence.Respository
             
             await foreach (var file in this.prefabFilesRepossitory.GetFilesAsync(prefabId, cloneFrom.ToString(), new string[] { }))
             {
+                //when creating a copy from previous version, we don't want dll and pdb files to be brough in to new version.                
+                if(Path.GetExtension(file.FileName).Equals(".dll") || Path.GetExtension(file.FileName).Equals(".pdb"))
+                {                  
+                    continue;
+                }
                 await this.prefabFilesRepossitory.AddOrUpdateFileAsync(prefabId, newVersion.ToString(), file);
             }
 

--- a/src/Pixel.Persistence.Respository/ProjectsRepository.cs
+++ b/src/Pixel.Persistence.Respository/ProjectsRepository.cs
@@ -7,6 +7,7 @@ using Pixel.Persistence.Respository.Extensions;
 using Pixel.Persistence.Respository.Interfaces;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -130,6 +131,11 @@ namespace Pixel.Persistence.Respository
 
             await foreach (var file in this.projectFilesRepository.GetFilesAsync(projectId, cloneFrom.ToString(), new string[] { }))
             {
+                //when creating a copy from previous version, we don't want dll and pdb files to be brough in to new version.                
+                if (Path.GetExtension(file.FileName).Equals(".dll") || Path.GetExtension(file.FileName).Equals(".pdb"))
+                {
+                    continue;
+                }
                 await this.projectFilesRepository.AddOrUpdateFileAsync(projectId, newVersion.ToString(), file);
             }
             

--- a/src/Pixel.Persistence.Services.Client/DataManagers/PrefabDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/DataManagers/PrefabDataManager.cs
@@ -106,12 +106,12 @@ public class PrefabDataManager : IPrefabDataManager
                 return;
             }
             
-            //Download project references data
-            var projectReferences = await this.referencesRepositoryClient.GetProjectReferencesAsync(prefabProject.PrefabId, prefabVersion.ToString());
-            if (projectReferences != null)
+            //Download prefab references data
+            var prefabReferences = await this.referencesRepositoryClient.GetProjectReferencesAsync(prefabProject.PrefabId, prefabVersion.ToString());
+            if (prefabReferences != null)
             {
                 var prefabReferencesFile = Path.Combine(this.applicationFileSystem.GetPrefabProjectDirectory(prefabProject), prefabVersion.ToString(), Constants.ReferencesFileName);
-                this.serializer.Serialize(prefabReferencesFile, projectReferences);
+                this.serializer.Serialize(prefabReferencesFile, prefabReferences);
             }
             await DownloadFilesWithTagsAsync(prefabProject, prefabVersion, new[] { prefabProject.PrefabId });
             logger.Information("Download completed for version {0} of prefab project {1}", prefabVersion, prefabProject.PrefabName);
@@ -181,7 +181,7 @@ public class PrefabDataManager : IPrefabDataManager
                 await AddOrUpdateDataFileAsync(prefabProject, prefabProject.LatestActiveVersion, file, prefabProject.PrefabId);
             }
 
-            logger.Information("Prefab project {@prefabProject} was added.", prefabProject);
+            logger.Information("Prefab project {0} was added.", prefabProject.PrefabName);
         }
 
         ////when a new prefab is created , add it to the prefabs cache
@@ -236,8 +236,9 @@ public class PrefabDataManager : IPrefabDataManager
     public async Task AddPrefabVersionAsync(PrefabProject prefabProject, PrefabVersion newVersion, PrefabVersion cloneFrom)
     {
         if (IsOnlineMode)
-        {
+        {           
             await this.prefabsRepositoryClient.AddPrefabVersionAsync(prefabProject.PrefabId, newVersion, cloneFrom);
+            await DownloadPrefabDataAsync(prefabProject, newVersion);
         }
         else
         {


### PR DESCRIPTION
**Description**
Simplified the way publish and clone is done. These are separate steps now. When publishing most recent active version, an incremented version will still be cloned from version being published. 
Addressed some issues as well during refactoring :
1. Clone button would always stay disable after clone and publish action.
2.  Data model assembly did not have minor version in their name. As a result , two versions with same major but different minor will have same data model assembly name after publish.
3. Cloning was also creating a copy of data model assembly from last version , etc. which is not needed.