### PR TITLE
Load test cases only when the fixture is expanded

### DIFF
--- a/src/Pixel.Automation.TestExplorer.Views/TestExplorerView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/TestExplorerView.xaml
@@ -181,8 +181,9 @@
                     <ControlTemplate TargetType="TreeViewItem">
                         <StackPanel Orientation="Vertical">
                             <Expander x:Name="TestCategory" Header="{Binding DisplayName, Converter={StaticResource trimmedTextConverter}, ConverterParameter = 20}" 
-                                     Tag="{Binding DataContext, ElementName=TestExplorerTreeView}"
-                                     Background="{DynamicResource MahApps.Brushes.Window.Background}"   
+                                     Tag="{Binding DataContext, ElementName=TestExplorerTreeView}" Background="{DynamicResource MahApps.Brushes.Window.Background}" 
+                                     cal:Action.TargetWithoutContext="{Binding DataContext, ElementName=TestExplorerTreeView}"    
+                                     cal:Message.Attach="[Event Expanded] = [Action OnFixtureExpanded($dataContext)]"
                                      controls:HeaderedControlHelper.HeaderBackground="{DynamicResource MahApps.Brushes.Window.Background}"
                                      BorderThickness="0" Margin="5,0,0,0" FontSize="11">
                                 <ItemsPresenter x:Name="ItemsHost"/>


### PR DESCRIPTION
**Description**
As the number of fixture and test cases will grow, it doesn't make sense to load all tests at start. Instead we load only test fixtures now. Test cases will be loaded as the fixture is expanded.