### PR TITLE
Allow controls to be deleted

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Application/ApplicationExplorerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Application/ApplicationExplorerViewModel.cs
@@ -206,7 +206,13 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Application
 
         public async Task EditApplicationAsync(ApplicationDescriptionViewModel applicationDescriptionViewModel)
         {
-            await this.eventAggregator.PublishOnUIThreadAsync(new PropertyGridObjectEventArgs(applicationDescriptionViewModel.ApplicationDetails, () => { _ = SaveApplicationAsync(applicationDescriptionViewModel); }, () => { return true; }));
+            await this.eventAggregator.PublishOnUIThreadAsync(new PropertyGridObjectEventArgs(applicationDescriptionViewModel.ApplicationDetails, 
+                async () => {
+                    await SaveApplicationAsync(applicationDescriptionViewModel);
+                }, 
+                () => { 
+                    return true; 
+                }));
         }
 
         public async Task SaveApplicationAsync(ApplicationDescriptionViewModel applicationDescriptionViewModel)

--- a/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml
@@ -76,6 +76,7 @@
                                     <MenuItem x:Name="CreateRevision" Header="Create Revision" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action CreateRevision($dataContext)]"></MenuItem>
                                     <MenuItem x:Name="ChangeImage" Header="Change Image" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action ChangeImageFromExistingAsync($dataContext)]"></MenuItem>
                                     <MenuItem x:Name="MoveToScreen" Header="Move To Screen" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action MoveToScreen($dataContext)]"></MenuItem>
+                                    <MenuItem x:Name="Delete" Header="Delete" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action DeleteControlAsync($dataContext)]" ></MenuItem>
                                 </StackPanel>
                             </ControlTemplate>
                         </ContextMenu.Template>

--- a/src/Pixel.Automation.Core/Controls/ControlDescription.cs
+++ b/src/Pixel.Automation.Core/Controls/ControlDescription.cs
@@ -55,6 +55,12 @@ namespace Pixel.Automation.Core.Controls
         public IControlIdentity ControlDetails { get; set; }
 
         /// <summary>
+        /// Indicates if the Control was deleted.
+        /// </summary>
+        [DataMember(Order = 1000)]
+        public bool IsDeleted { get; set; }
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         public ControlDescription()

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
@@ -411,9 +411,17 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
         /// <returns></returns>
         public async Task HandleAsync(ControlAddedEventArgs control, CancellationToken cancellationToken)
         {
-            var controlDescription = control.Control;            
-            var referenceManager = this.projectManager.GetReferenceManager();
-            await referenceManager.AddControlReferenceAsync(new ControlReference(controlDescription.ApplicationId, controlDescription.ControlId, controlDescription.Version));      
+            var controlDescription = control.Control;
+            try
+            {             
+                var referenceManager = this.projectManager.GetReferenceManager();
+                await referenceManager.AddControlReferenceAsync(new ControlReference(controlDescription.ApplicationId, controlDescription.ControlId, controlDescription.Version));
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "There was an error while trying to add control reference for control : {0}", controlDescription.ControlName);
+                MessageBox.Show(ex.Message, $"Error while adding control : {controlDescription.ControlName}");
+            }  
         }
 
 

--- a/src/Pixel.Automation.Designer.ViewModels/PropertyGrid/PropertyGridViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/PropertyGrid/PropertyGridViewModel.cs
@@ -33,11 +33,11 @@ namespace Pixel.Automation.Designer.ViewModels
             this.SaveCommand = new RelayCommand(p => Save(), p => CanSave());
         }
 
-        public void SetState(object selectedObject, bool isReadOnly, Action saveCommand, Func<bool> canSave)
+        public void SetState(object selectedObject, bool isReadOnly, Func<Task> saveCommand, Func<bool> canSave)
         {
             this.selectedObject = selectedObject;
             this.isReadOnly = isReadOnly;
-            this.onSave = saveCommand;
+            this.onSave = () => saveCommand();
             this.canSave = canSave;
             NotifyOfPropertyChange(() => SelectedObject);
             NotifyOfPropertyChange(() => IsReadOnly);

--- a/src/Pixel.Automation.Editor.Notifications/EventArgs/PropertyGridObjectEventArgs.cs
+++ b/src/Pixel.Automation.Editor.Notifications/EventArgs/PropertyGridObjectEventArgs.cs
@@ -6,7 +6,7 @@ public class PropertyGridObjectEventArgs : EventArgs
 
     public bool IsReadOnly { get; private set; }
 
-    public Action SaveCommand { get; private set; }
+    public Func<Task> SaveCommand { get; private set; }
 
     public Func<bool> CanSaveCommand { get; private set; }
 
@@ -21,7 +21,7 @@ public class PropertyGridObjectEventArgs : EventArgs
         this.IsReadOnly = isReadOnly;
     }
 
-    public PropertyGridObjectEventArgs(Object objectToDisplay, Action saveCommand, Func<bool> canSaveCommand) : this(objectToDisplay, false)
+    public PropertyGridObjectEventArgs(Object objectToDisplay, Func<Task> saveCommand, Func<bool> canSaveCommand) : this(objectToDisplay, false)
     {
         this.SaveCommand = saveCommand;
         this.CanSaveCommand = canSaveCommand;

--- a/src/Pixel.Automation.Reference.Manager/ReferenceManager.cs
+++ b/src/Pixel.Automation.Reference.Manager/ReferenceManager.cs
@@ -127,11 +127,11 @@ internal class ReferenceManager : IReferenceManager
         Guard.Argument(controlReference, nameof(controlReference)).NotNull();
         if (!this.controlReferences.HasReference(controlReference))
         {
-            this.controlReferences.AddControlReference(controlReference);
             if (IsOnlineMode)
             {
                 await this.referencesRepositoryClient.AddOrUpdateControlReferences(this.projectId, this.projectVersion, controlReference);
             }
+            this.controlReferences.AddControlReference(controlReference);
             SaveLocal();
         }
     }

--- a/src/Pixel.Persistence.Respository/Interfaces/IControlRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/IControlRepository.cs
@@ -44,6 +44,23 @@ public interface IControlRepository
     Task AddOrUpdateControl(string controlDataJson);
 
     /// <summary>
+    /// Check if a control is marked deleted.
+    /// </summary>
+    /// <param name="applicationId"></param>
+    /// <param name="controlId"></param>
+    /// <returns></returns>
+    Task<bool> IsControlDeleted(string applicationId, string controlId);
+
+    /// <summary>
+    /// Set IsDeleted flag on all versionf of control to true.
+    /// </summary>
+    /// <param name="applicationId"></param>
+    /// <param name="controlId"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">Thrown if the control is in use acrosss any project</exception>
+    Task DeleteControlAsync(string applicationId, string controlId);
+
+    /// <summary>
     /// Add or Update Control image
     /// </summary>
     /// <param name="imageMetaData"><see cref="ControlImageMetaData"/> of the Control Image</param>

--- a/src/Pixel.Persistence.Respository/Interfaces/IReferencesRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/IReferencesRepository.cs
@@ -31,15 +31,34 @@ public interface IReferencesRepository
     /// <returns></returns>
     Task SetEditorReferences(string projectId, string projectVersion, EditorReferences editorReferences);
 
+
     /// <summary>
-    /// Add or update ControlReference for a given version of project
+    /// Check if a given version of project has an existing reference to specified control
     /// </summary>
     /// <param name="projectId"></param>
     /// <param name="projectVersion"></param>
     /// <param name="controlReference"></param>
     /// <returns></returns>
-    Task AddOrUpdateControlReference(string projectId, string projectVersion, ControlReference controlReference);
-   
+    Task<bool> HasControlReference(string projectId, string projectVersion, ControlReference controlReference);
+
+    /// <summary>
+    /// Add a new ControlReference to a given version of project
+    /// </summary>
+    /// <param name="projectId"></param>
+    /// <param name="projectVersion"></param>
+    /// <param name="controlReference"></param>
+    /// <returns></returns>
+    Task AddControlReference(string projectId, string projectVersion, ControlReference controlReference);
+
+    /// <summary>
+    /// Update existing ControlReference for a given version of project
+    /// </summary>
+    /// <param name="projectId"></param>
+    /// <param name="projectVersion"></param>
+    /// <param name="controlReference"></param>
+    /// <returns></returns>
+    Task UpdateControlReference(string projectId, string projectVersion, ControlReference controlReference);
+
     /// <summary>
     /// Add or update PrefabReferences for a given version of project
     /// </summary>

--- a/src/Pixel.Persistence.Services.Api/Controllers/ReferencesController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/ReferencesController.cs
@@ -1,7 +1,9 @@
 ﻿using Dawn;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
 using Pixel.Persistence.Core.Models;
+using Pixel.Persistence.Respository;
 using Pixel.Persistence.Respository.Interfaces;
 using System.Threading.Tasks;
 
@@ -13,16 +15,18 @@ namespace Pixel.Persistence.Services.Api.Controllers
     {
         private readonly ILogger<ReferencesController> logger;
         private readonly IReferencesRepository referencesRepository;
+        private readonly IControlRepository controlsRepository;
 
         /// <summary>
         /// constructor
         /// </summary>
         /// <param name="logger"></param>
         /// <param name="projectRepository"></param>
-        public ReferencesController(ILogger<ReferencesController> logger, IReferencesRepository referencesRepository)
+        public ReferencesController(ILogger<ReferencesController> logger, IReferencesRepository referencesRepository, IControlRepository controlsRepository)
         {
-            this.logger = Guard.Argument(logger).NotNull().Value;
-            this.referencesRepository = Guard.Argument(referencesRepository).NotNull().Value;
+            this.logger = Guard.Argument(logger, nameof(logger)).NotNull().Value;
+            this.referencesRepository = Guard.Argument(referencesRepository, nameof(referencesRepository)).NotNull().Value;
+            this.controlsRepository = Guard.Argument(controlsRepository, nameof(controlsRepository)).NotNull().Value;
         }
 
         [HttpGet("{projectId}/{projectVersion}")]
@@ -41,7 +45,19 @@ namespace Pixel.Persistence.Services.Api.Controllers
         [HttpPost("controls/{projectId}/{projectVersion}")]
         public async Task<IActionResult> AddOrUpdateControlReference(string projectId, string projectVersion, [FromBody] ControlReference controlReference)
         {
-            await this.referencesRepository.AddOrUpdateControlReference(projectId, projectVersion, controlReference);
+            var hasExistingReference = await this.referencesRepository.HasControlReference(projectId, projectVersion, controlReference);
+            if(hasExistingReference)
+            {
+                await this.referencesRepository.UpdateControlReference(projectId, projectVersion, controlReference);
+                return Ok();
+            }
+
+            if(await this.controlsRepository.IsControlDeleted(controlReference.ApplicationId, controlReference.ControlId))
+            {
+                logger.LogWarning("Can't add control reference to project : {0}, version : {1}. Control {@2} is marked deleted.", projectId, projectVersion, controlReference);
+                return Conflict("Can't add control reference. Control is marked deleted.");
+            }
+            await this.referencesRepository.AddControlReference(projectId, projectVersion, controlReference);
             return Ok();
         }
 

--- a/src/Pixel.Persistence.Services.Client/DataManagers/ApplicationDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/DataManagers/ApplicationDataManager.cs
@@ -219,6 +219,18 @@ namespace Pixel.Persistence.Services.Client
         }
 
         /// <inheritdoc/>      
+        public async Task DeleteControlAsync(ControlDescription controlDescription)
+        {         
+            if (IsOnlineMode)
+            {
+                await controlRepositoryClient.DeleteControl(controlDescription);
+            }
+            controlDescription.IsDeleted = true;
+            SaveControlToDisk(controlDescription);
+            logger.Information("Control {0} was deleted", controlDescription.ControlName);
+        }
+
+        /// <inheritdoc/>      
         public async Task<string> AddOrUpdateControlImageAsync(ControlDescription controlDescription, Stream stream)
         {
             Directory.CreateDirectory(GetControlDirectory(controlDescription));

--- a/src/Pixel.Persistence.Services.Client/Helpers/RestExtensions.cs
+++ b/src/Pixel.Persistence.Services.Client/Helpers/RestExtensions.cs
@@ -13,7 +13,13 @@ namespace Pixel.Persistence.Services.Client
         {
             if (!response.IsSuccessful)
             {
-                throw new Exception(response.ErrorMessage, response.ErrorException);
+                switch(response.StatusCode)
+                {
+                    case System.Net.HttpStatusCode.Conflict:
+                        throw new Exception(response.Content, response.ErrorException);
+                    default:
+                        throw new Exception(response.ErrorMessage, response.ErrorException);
+                }
             }
         }
     }

--- a/src/Pixel.Persistence.Services.Client/Interfaces/IApplicationDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/IApplicationDataManager.cs
@@ -77,7 +77,14 @@ namespace Pixel.Persistence.Services.Client
         /// <param name="controlDescription"></param>
         /// <returns></returns>
         Task AddOrUpdateControlAsync(ControlDescription controlDescription);
-      
+
+        /// <summary>
+        /// Delete a given control
+        /// </summary>
+        /// <param name="controlDescription"></param>
+        /// <returns></returns>
+        Task DeleteControlAsync(ControlDescription controlDescription);
+
         /// <summary>
         /// Add or update control image for control
         /// </summary>

--- a/src/Pixel.Persistence.Services.Client/Interfaces/IControlRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/IControlRepositoryClient.cs
@@ -29,7 +29,14 @@ namespace Pixel.Persistence.Services.Client
         /// <param name="controlDescription"></param>     
         /// <returns></returns>
         Task AddOrUpdateControl(ControlDescription controlDescription);
-    
+
+        /// <summary>
+        /// Delete control
+        /// </summary>
+        /// <param name="controlDescription"></param>
+        /// <returns></returns>
+        Task DeleteControl(ControlDescription controlDescription);
+
         /// <summary>
         /// Add or update control image  at a given resolution for a control
         /// </summary>

--- a/src/Pixel.Persistence.Services.Client/ReferencesRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/ReferencesRepositoryClient.cs
@@ -69,7 +69,8 @@ public class ReferencesRepositoryClient : IReferencesRepositoryClient
         RestRequest restRequest = new RestRequest($"references/controls/{projectId}/{projectVersion}");
         restRequest.AddJsonBody(controlReference);
         var client = this.clientFactory.GetOrCreateClient();
-        await client.PostAsync<ControlReference>(restRequest);
+        var result = await client.ExecuteAsync<ControlReference>(restRequest, Method.Post);
+        result.EnsureSuccess();
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
**Description**
Control can be deleted now if they don't have an existing reference in any of the project. Additional validations are now in place to prevent editing or using a control if that is marked deleted. This can happen if a client has marked control to be deleted and another client with stale data is trying to use or edit the control.