### PR TITLE
Allow searching for controls and prefabs on control and prefab reference manager screen

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/VersionManager/ControlReferenceViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/VersionManager/ControlReferenceViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Dawn;
 using Pixel.Automation.Core;
+using Pixel.Automation.Core.Controls;
 using Pixel.Automation.Core.Models;
 using System.Collections.ObjectModel;
 
@@ -10,7 +11,7 @@ namespace Pixel.Automation.Designer.ViewModels.VersionManager
     /// </summary>
     public class ControlReferenceViewModel : NotifyPropertyChanged
     {
-        internal readonly ControlReference controlReference;
+        internal readonly ControlReference controlReference;       
 
         /// <summary>
         /// Name of the Control
@@ -41,6 +42,9 @@ namespace Pixel.Automation.Designer.ViewModels.VersionManager
             }
         }
 
+        // <summary>
+        /// Indicate if version was changed
+        /// </summary>
         public bool IsDirty { get; private set; }
 
         /// <summary>
@@ -55,16 +59,18 @@ namespace Pixel.Automation.Designer.ViewModels.VersionManager
         /// <param name="controlName"></param>
         /// <param name="versionInUse"></param>
         /// <param name="availableVersions"></param>
-        public ControlReferenceViewModel(ControlReference controlReference, string controlName, string versionInUse, IEnumerable<Version> availableVersions)
+        public ControlReferenceViewModel(ControlReference controlReference, IEnumerable<ControlDescription> controls)
         {
-            this.controlReference = Guard.Argument(controlReference).NotNull();         
-            this.ControlName = controlName;
-            this.VersionInUse = versionInUse;
-            foreach (var version in availableVersions)
+            Guard.Argument(controls, nameof(controls)).NotNull().NotEmpty();
+            this.controlReference = Guard.Argument(controlReference, nameof(controlReference)).NotNull();
+            var controlInUse = controls.FirstOrDefault(a => a.Version.Equals(controlReference.Version));          
+            this.ControlName = controlInUse.ControlName;
+            this.VersionInUse = controlReference.Version.ToString();
+            foreach (var version in controls.Select(s => s.Version))
             {
                 this.AvailableVersions.Add(version);
             }
-            this.SelectedVersion = this.AvailableVersions.FirstOrDefault(a => a.ToString().Equals(versionInUse)) ?? this.AvailableVersions.First();
+            this.SelectedVersion = this.AvailableVersions.FirstOrDefault(a => a.ToString().Equals(this.VersionInUse)) ?? this.AvailableVersions.First();
             this.IsDirty = false;
         }
     }

--- a/src/Pixel.Automation.Designer.ViewModels/VersionManager/PrefabReferenceViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/VersionManager/PrefabReferenceViewModel.cs
@@ -4,16 +4,28 @@ using Pixel.Automation.Core.Models;
 using System.Collections.ObjectModel;
 
 namespace Pixel.Automation.Designer.ViewModels.VersionManager
-{
+{ 
+    /// <summary>
+    /// View Model wrapper for <see cref="PrefabReference"/>
+    /// </summary>
     public class PrefabReferenceViewModel : NotifyPropertyChanged
     {
         internal readonly PrefabReference prefabReference;
 
+        /// <summary>
+        /// Name of the Prefab
+        /// </summary>
         public string PrefabName { get; private set; }
 
+        /// <summary>
+        /// Version of prefaab used in current version of project
+        /// </summary>
         public string VersionInUse { get; private set; }
 
         private PrefabVersion selectedVersion;
+        /// <summary>
+        /// Select version of prefab on view
+        /// </summary>
         public PrefabVersion SelectedVersion
         {
             get => this.selectedVersion;
@@ -29,10 +41,21 @@ namespace Pixel.Automation.Designer.ViewModels.VersionManager
             }
         }
 
+        /// <summary>
+        /// Indicate if version was changed
+        /// </summary>
         public bool IsDirty { get; private set; }
 
+        /// <summary>
+        /// Available versions of Prefab
+        /// </summary>
         public ObservableCollection<PrefabVersion> AvailableVersions { get; private set; } = new();
 
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="prefabProject"></param>
+        /// <param name="prefabReference"></param>
         public PrefabReferenceViewModel(PrefabProject prefabProject, PrefabReference prefabReference)
         {
             Guard.Argument(prefabProject).NotNull();

--- a/src/Pixel.Automation.Designer.Views/VersionManager/ControlReferenceManagerView.xaml
+++ b/src/Pixel.Automation.Designer.Views/VersionManager/ControlReferenceManagerView.xaml
@@ -11,16 +11,21 @@
     </controls:MetroWindow.Resources>
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="*"></RowDefinition>
-            <RowDefinition Height="90"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="*"></RowDefinition>          
             <RowDefinition Height="60"></RowDefinition>
         </Grid.RowDefinitions>
 
-        <DataGrid Grid.Row="0" x:Name="References" ItemsSource="{Binding References}" MaxHeight="600"
+        <TextBox x:Name="Filter" Grid.Row="0" Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                 controls:TextBoxHelper.ClearTextButton="True" controls:TextBoxHelper.UseFloatingWatermark="True"                     
+                 controls:TextBoxHelper.Watermark="Search"  HorizontalAlignment="Left" MinWidth="400"
+                 VerticalAlignment="Top" Margin="15,20,10,10"></TextBox>
+
+        <DataGrid Grid.Row="1" x:Name="References" ItemsSource="{Binding References}" MaxHeight="600"
                   CanUserSortColumns="True" CanUserAddRows="False" CanUserResizeRows="False" CanUserResizeColumns="True"                 
                   Grid.Column="1" GridLinesVisibility="All"
                   Margin="10" Padding="5" ScrollViewer.HorizontalScrollBarVisibility="Disabled"    
-                  AutoGenerateColumns="False"           
+                  AutoGenerateColumns="False"  EnableRowVirtualization="True"         
                   RowHeaderWidth="0" HorizontalAlignment="Center" VerticalAlignment="Top">
             <DataGrid.Columns>
                 <DataGridTemplateColumn Header="Control Name">

--- a/src/Pixel.Automation.Designer.Views/VersionManager/PrefabReferenceManagerView.xaml
+++ b/src/Pixel.Automation.Designer.Views/VersionManager/PrefabReferenceManagerView.xaml
@@ -3,8 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
-             xmlns:local="clr-namespace:Pixel.Automation.Designer.Views.VersionManager"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"           
              xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
              mc:Ignorable="d" WindowStartupLocation="CenterScreen" SizeToContent="WidthAndHeight"
              d:DesignHeight="450" d:DesignWidth="800" MinHeight="450">
@@ -13,16 +12,22 @@
     </controls:MetroWindow.Resources>
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="*"></RowDefinition>
             <RowDefinition Height="60"></RowDefinition>
             <RowDefinition Height="60"></RowDefinition>
         </Grid.RowDefinitions>
 
-        <DataGrid Grid.Row="0" x:Name="PrefabReferences" ItemsSource="{Binding PrefabReferences}" MaxHeight="600"
+        <TextBox x:Name="Filter" Grid.Row="0" Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                 controls:TextBoxHelper.ClearTextButton="True" controls:TextBoxHelper.UseFloatingWatermark="True"                     
+                 controls:TextBoxHelper.Watermark="Search"  HorizontalAlignment="Left" MinWidth="400"
+                 VerticalAlignment="Top" Margin="15,20,10,10"></TextBox>
+
+        <DataGrid Grid.Row="1" x:Name="PrefabReferences" ItemsSource="{Binding PrefabReferences}" MaxHeight="600"
                   CanUserSortColumns="True" CanUserAddRows="False" CanUserResizeRows="False" CanUserResizeColumns="True"                 
                   Grid.Column="1" GridLinesVisibility="All"
                   Margin="10" Padding="5" ScrollViewer.HorizontalScrollBarVisibility="Disabled"    
-                  AutoGenerateColumns="False"           
+                  AutoGenerateColumns="False"  EnableRowVirtualization="True"            
                   RowHeaderWidth="0" HorizontalAlignment="Center" VerticalAlignment="Top">
             <DataGrid.Columns>
                 <DataGridTemplateColumn Header="Prefab Name">
@@ -53,13 +58,13 @@
             </DataGrid.Columns>
         </DataGrid>
         
-        <StackPanel Grid.Row="1" x:Name="WarningPanel" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="{StaticResource ControlMargin}" 
+        <StackPanel Grid.Row="2" x:Name="WarningPanel" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="{StaticResource ControlMargin}" 
                             Background="{DynamicResource MahApps.Brushes.ValidationSummary3}" Orientation="Horizontal">
             <iconPacks:PackIconMaterial Kind="Alert" Margin="10,0,0,0" VerticalAlignment="Center"/>
             <TextBlock x:Name="WarningMessage" Margin="10,0,0,0" VerticalAlignment="Center"
                                Text="Upgrading Prefab version can be a breaking change. You might need to redo input and output mapping script for Prefab."/>
         </StackPanel>
-        <DockPanel Grid.Row="2" LastChildFill="False">
+        <DockPanel Grid.Row="3" LastChildFill="False">
             <Border DockPanel.Dock="Top" BorderThickness="1" Height="1" HorizontalAlignment="Stretch" Width="{Binding Path=Width,RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type DockPanel}}}" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
             <Button x:Name="CloseAsync" Content="CANCEL" Width="100" DockPanel.Dock="Right"  Margin="{StaticResource ControlMargin}" Style="{DynamicResource MahApps.Styles.Button.Square}"/>
             <Button x:Name="SaveAsync" Content="Save" DockPanel.Dock="Right" Width="100"  Margin="{StaticResource ControlMargin}" Style="{DynamicResource MahApps.Styles.Button.Square.Accent}"/>


### PR DESCRIPTION
**Description**
For a large project, there can be thousands of controls and prefabs in use. Although, data grid should be able to handle these number of records without requiring pagination, we still need to allow users to search for controls and prefabs on reference manager screen.