### PR TITLE
Correct file path when downloading data file by name

### DIFF
--- a/src/Pixel.Persistence.Services.Client/DataManagers/ProjectDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/DataManagers/ProjectDataManager.cs
@@ -114,9 +114,10 @@ public class ProjectDataManager : IProjectDataManager
         if (IsOnlineMode)
         {
             var file = await this.filesClient.DownProjectDataFile(automationProject.ProjectId, projectVersion.ToString(), fileName);
+            var projectDirectory = Path.Combine(this.applicationFileSystem.GetAutomationProjectWorkingDirectory(automationProject, projectVersion));
             using (MemoryStream ms = new MemoryStream(file.Bytes))
             {
-                using (FileStream fs = new FileStream(file.FilePath, FileMode.CreateNew))
+                using (FileStream fs = new FileStream(Path.Combine(projectDirectory, file.FilePath), FileMode.Create))
                 {
                     ms.Seek(0, SeekOrigin.Begin);
                     ms.CopyTo(fs);


### PR DESCRIPTION
**Description**
There is an issue with downloading the initialization script file for automation projects when trying to edit this file due to incorrect path. This is fixed now.