### PR TITLE
Fix incorrect tag asisgned while saving script files for test cases

### DIFF
--- a/src/Pixel.Persistence.Services.Client/DataManagers/ProjectDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/DataManagers/ProjectDataManager.cs
@@ -616,7 +616,7 @@ public class TestAndFixtureAndTestDataManager : IProjectAssetsDataManager
             await AddDataFileAsync(testCaseFiles.ProcessFile, testCase.TestCaseId);
             foreach (var scriptFile in Directory.EnumerateFiles(testCaseFiles.TestDirectory, "*.csx"))
             {
-                await AddDataFileAsync(scriptFile, testCase.FixtureId);
+                await AddDataFileAsync(scriptFile, testCase.TestCaseId);
             }
         }
         logger.Information("Saved data files for test case : '{0}' for version : '{1}' of automation project : '{2}'.", testCase.DisplayName, projectVersion, automationProject.Name);


### PR DESCRIPTION
**Description**
While saving data files for test cases, fixtureId is set as tag instead of testcaseId. As a result of this, files are missing while downloading later using tag for test case. This is fixed now.