### PR TITLE
Fix build issues with on demand workflow for pixel designer and pixel runner

### DIFF
--- a/.github/workflows/build-pixel-designer.yml
+++ b/.github/workflows/build-pixel-designer.yml
@@ -73,5 +73,5 @@ jobs:
     - name: Upload pixel-designer artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: pixel-designer-${{ matrix.os }}
+        name: pixel-designer-${{ inputs.target-os }}
         path: .builds/release/designer/${{ inputs.target-framework }}/${{ inputs.target-runtime }}

--- a/.github/workflows/build-pixel-designer.yml
+++ b/.github/workflows/build-pixel-designer.yml
@@ -74,4 +74,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: pixel-designer-${{ matrix.os }}
-        path: .builds/release/designer/${{ inputs.target-runtime }}
+        path: .builds/release/designer/${{ inputs.target-framework }}/${{ inputs.target-runtime }}

--- a/.github/workflows/build-pixel-runner.yml
+++ b/.github/workflows/build-pixel-runner.yml
@@ -73,5 +73,5 @@ jobs:
     - name: Upload pixel-runner artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: pixel-runner-${{ matrix.os }}
+        name: pixel-runner-${{ inputs.target-os }}
         path: .builds/release/runner/${{ inputs.target-framework }}/${{ inputs.target-runtime }}

--- a/.github/workflows/build-pixel-runner.yml
+++ b/.github/workflows/build-pixel-runner.yml
@@ -74,4 +74,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: pixel-runner-${{ matrix.os }}
-        path: .builds/release/runner/${{ inputs.target-runtime }}
+        path: .builds/release/runner/${{ inputs.target-framework }}/${{ inputs.target-runtime }}

--- a/.github/workflows/on-demand-build-with-artifact.yml
+++ b/.github/workflows/on-demand-build-with-artifact.yml
@@ -27,7 +27,7 @@ jobs:
   build-pixel-runner-for-linux-x64:
     uses: ./.github/workflows/build-pixel-runner.yml
     with:
-      target-os: ubuntu-latest
+      target-os: windows-latest
       target-runtime: linux-x64
       target-framework: net6.0
       self-contained: false


### PR DESCRIPTION
1. For linux-x64 , build pixel runner on windows-latest os. We are getting an error while building on linux-latest - error NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true. We could build on linux-latest by passisng /p:EnableWindowsTargeting to true alternatively.
2. Fixed artifiact path for designer and runner