### PR TITLE
Allow to configure if form fields should be encoded

### DIFF
--- a/src/Pixel.Automation.HttpRequest.Editor/RequestBody/FormDataBodyConfigurationView.xaml
+++ b/src/Pixel.Automation.HttpRequest.Editor/RequestBody/FormDataBodyConfigurationView.xaml
@@ -70,6 +70,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
+                <DataGridCheckBoxColumn Binding="{Binding Encode}" Header="Encode"/>
                 <DataGridTemplateColumn Header="Description">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>

--- a/src/Pixel.Automation.RestApi.Components/Components/HttpRequestActorComponent.cs
+++ b/src/Pixel.Automation.RestApi.Components/Components/HttpRequestActorComponent.cs
@@ -235,7 +235,7 @@ namespace Pixel.Automation.RestApi.Components
                         switch (formField.DataType)
                         {
                             case FormDataType.Text:
-                                restRequest.AddParameter(formField.DataKey, formFieldValue, ParameterType.RequestBody);
+                                restRequest.AddParameter(formField.DataKey, formFieldValue, ParameterType.RequestBody, formField.Encode);
                                 break;
                             case FormDataType.File:
                                 if (!File.Exists(formFieldValue))

--- a/src/Pixel.Automation.RestApi.Shared/Data/RequestBody.cs
+++ b/src/Pixel.Automation.RestApi.Shared/Data/RequestBody.cs
@@ -107,9 +107,15 @@ public class FormField : NotifyPropertyChanged
     public string ContentType { get; set; }
 
     /// <summary>
-    /// Description of the FormField
+    /// Indicates if the form parameter should be encoded
     /// </summary>
     [DataMember(Order = 60)]
+    public bool Encode { get; set; } = true;
+
+    /// <summary>
+    /// Description of the FormField
+    /// </summary>
+    [DataMember(Order = 70)]
     public string Description { get; set; }
     
     /// <summary>


### PR DESCRIPTION
**Description**
It is possible now to configure if the form field should be encoded.