### PR TITLE
Pre post delay changes and mutex removal from sequence entity

### DIFF
--- a/src/Pixel.Automation.Core.Components/Processors/SequentialEntityProcessor.cs
+++ b/src/Pixel.Automation.Core.Components/Processors/SequentialEntityProcessor.cs
@@ -15,14 +15,15 @@ namespace Pixel.Automation.Core.Components.Processors
     public class SequentialEntityProcessor : EntityProcessor
     {
         [DataMember]
-        [Display(Name = "Pre Processing Delay", GroupName = "Delay", Order = 10)]
-        [Description("Delay before execution of an actor")]
-        public Argument PreDelay { get; set; } = new InArgument<int>() { DefaultValue = 300, CanChangeType = false };
+        [Display(Name = "Post Processing Delay", GroupName = "Delay", Order = 10)]
+        [Description("Delay after execution of an actor")]
+        public Argument PostDelay { get; set; } = new InArgument<int>() { DefaultValue = 100, CanChangeType = false };
 
         [DataMember]
-        [Display(Name = "Post Processing Delay", GroupName = "Delay", Order = 20)]
-        [Description("Delay after execution of an actor")]
-        public Argument PostDelay { get; set; } = new InArgument<int>() { DefaultValue = 300, CanChangeType = false };
+        [Display(Name = "Delay Factor", GroupName = "Delay", Order = 20)]
+        [Description("Scaling factor for Post delay")]
+        public Argument DelayFactor { get; set; } = new InArgument<int>() { DefaultValue = 3, CanChangeType = false };
+
 
         /// <summary>
         /// constructor
@@ -43,14 +44,16 @@ namespace Pixel.Automation.Core.Components.Processors
         private async Task ConfigureDelay()
         {
             var argumentProcessor = this.ArgumentProcessor;
-            if(this.PreDelay.IsConfigured())
+            int delayFactor = 1;
+            if (this.DelayFactor.IsConfigured())
             {
-                this.preDelayAmount = await argumentProcessor.GetValueAsync<int>(this.PreDelay);
+                delayFactor = await argumentProcessor.GetValueAsync<int>(this.DelayFactor);
             }
             if (this.PostDelay.IsConfigured())
             {
-                this.postDelayAmount = await argumentProcessor.GetValueAsync<int>(this.PostDelay);
+                this.postDelayAmount = delayFactor * await argumentProcessor.GetValueAsync<int>(this.PostDelay);
             }           
+           
         }
     }
 }

--- a/src/Pixel.Automation.Core.Components/Sequences/SequenceEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Sequences/SequenceEntity.cs
@@ -5,15 +5,13 @@ using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
-using System.Threading;
 using System.Threading.Tasks;
-using IComponent = Pixel.Automation.Core.Interfaces.IComponent;
 
 namespace Pixel.Automation.Core.Components.Sequences
 {
     [DataContract]
     [Serializable]
-    public class SequenceEntity : Entity , IApplicationContext , IDisposable
+    public class SequenceEntity : Entity , IApplicationContext
     {
         private readonly ILogger logger = Log.ForContext<SequenceEntity>();
 
@@ -40,92 +38,26 @@ namespace Pixel.Automation.Core.Components.Sequences
         public bool RequiresFocus { get; set; } = false;
 
 
-        double acquireFocusTimeout = 3;
-        [DataMember(Order = 210)]
-        [Display(Name = "Timeout", Order = 30, GroupName = "Application Details")]
-        [Description("Timeout(seconds) for acquiring lock on mutex in order to set window as foregroud window")]
-        /// <summary>
-        /// Timeout(seconds) for acquiring lock on mutex in order to set window as foregroud window
-        /// </summary>
-        public double AcquireFocusTimeout
-        {
-            get => acquireFocusTimeout;
-            set
-            {
-                if (value > 0)
-                {
-                    acquireFocusTimeout = value;
-                }
-            }
-        }
-
-        [NonSerialized]
-        Mutex mutex = default;
-    
-        private readonly string mutexName = "Local\\Pixel.AppFocus";
-        private bool wasMutexAcquired = false;
-
         public SequenceEntity() : base("Sequence", "Sequence")
         {
 
         }
 
-
         public override async Task BeforeProcessAsync()
         {
             if (!string.IsNullOrEmpty(this.targetAppId) && RequiresFocus)
-            {
-                if(mutex==null)
-                {                           
-                    mutex = new Mutex(false, mutexName);
-                }
-
-                logger.Debug($"Waiting to acquire lock on Mutex : {this}");
-                if (mutex.WaitOne(TimeSpan.FromSeconds(acquireFocusTimeout)))
+            {      
+                IApplication targetApp = this.EntityManager.GetOwnerApplication(this);
+                IntPtr hWnd = targetApp.Hwnd;
+                if (hWnd != IntPtr.Zero)
                 {
-                    logger.Debug($"Mutex lock acquired by {this}");
-                    wasMutexAcquired = true;
-                    IApplication targetApp = this.EntityManager.GetOwnerApplication(this);
-                    IntPtr hWnd = targetApp.Hwnd;
-                    if (hWnd != IntPtr.Zero)
-                    {
-                        IApplicationWindowManager windowManager = this.EntityManager.GetServiceOfType<IApplicationWindowManager>();
-                        ApplicationWindow appWindow = windowManager.FromHwnd(hWnd);
-                        windowManager.SetForeGroundWindow(appWindow);
-                        logger.Information($"Window with hWnd : {hWnd} is set to foreground window");
-                        return;
-                    }
-                   
-                    throw new InvalidOperationException($"hWnd of the application window is 0. Can't set foreground window");                    
+                    IApplicationWindowManager windowManager = this.EntityManager.GetServiceOfType<IApplicationWindowManager>();
+                    ApplicationWindow appWindow = windowManager.FromHwnd(hWnd);
+                    windowManager.SetForeGroundWindow(appWindow);
+                    logger.Information($"Window with hWnd : {hWnd} is set to foreground window");
+                    return;
                 }
-                else
-                {
-                    wasMutexAcquired = false;
-                    throw new TimeoutException($"Failed to acquire mutex lock  within configured timeout of  {this.acquireFocusTimeout} ms.");
-                }
-            }
-            await Task.CompletedTask;
-        }
-
-        public override async Task OnCompletionAsync()
-        {
-            if(mutex!=null && wasMutexAcquired)
-            {               
-                mutex.ReleaseMutex();
-                wasMutexAcquired = false;
-                logger.Information($"Mutex lock released by {this}");
-            }
-            await Task.CompletedTask;
-        }
-
-
-        public override async Task OnFaultAsync(IComponent faultingComponent)
-        {
-            if (mutex != null && wasMutexAcquired)
-            {
-                mutex.ReleaseMutex();
-                wasMutexAcquired = false;
-                logger.Information($"Mutex lock released by {this}");
+                throw new InvalidOperationException($"hWnd of the application window is 0. Can't set foreground window");
             }
             await Task.CompletedTask;
         }
@@ -139,21 +71,6 @@ namespace Pixel.Automation.Core.Components.Sequences
         public string GetAppContext()
         {
             return this.targetAppId;
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);         
-        }
-
-        protected virtual void Dispose(bool isDisposing)
-        {
-            if (isDisposing && mutex != null)
-            {
-                mutex.Dispose();
-                mutex = null;              
-            }
-            wasMutexAcquired = false;
         }
     }
 }

--- a/src/Pixel.Automation.Core/ApplicationSettings.cs
+++ b/src/Pixel.Automation.Core/ApplicationSettings.cs
@@ -51,13 +51,7 @@ namespace Pixel.Automation.Core
                 OnPropertyChanged();
             }
         }      
-                
-        /// <summary>
-        /// Default amound of delay in ms before actor is executed
-        /// </summary>
-        [DataMember]
-        public int PreDelay { get; set; }
-
+                       
         /// <summary>
         /// Default amount of delay in ms after actor is executed
         /// </summary>

--- a/src/Pixel.Automation.Core/Interfaces/IApplicationWindowManager.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IApplicationWindowManager.cs
@@ -29,6 +29,13 @@ namespace Pixel.Automation.Core.Interfaces
         IEnumerable<ApplicationWindow> FindAllChildWindows(ApplicationWindow parentWindow, string titleToMatch, MatchType matchType, bool visibleOnly);
 
         /// <summary>
+        /// Check if application window is foreground window
+        /// </summary>
+        /// <param name="hWnd"></param>
+        /// <returns></returns>
+        bool IsForeGroundWindow(ApplicationWindow window);
+
+        /// <summary>
         /// Get the foreground window
         /// </summary>
         /// <returns></returns>

--- a/src/Pixel.Automation.Core/Interfaces/IEntityProcessor.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IEntityProcessor.cs
@@ -9,15 +9,14 @@ namespace Pixel.Automation.Core.Interfaces
     public interface IEntityProcessor : IComponent
     {
         /// <summary>
-        /// Configure the pre and post delay amount that should be introduced 
-        /// before and after executiong of each actor respectively.
-        /// </summary>
-        /// <param name="preDelayAmount"></param>
+        /// Configure post delay amount that should be introduced 
+        /// after executiong of each actor.
+        /// </summary>       
         /// <param name="postDelayAmount"></param>
-        void ConfigureDelay(int preDelayAmount, int postDelayAmount);
+        void ConfigureDelay(int postDelayAmount);
 
         /// <summary>
-        /// Reset pre and post delay values to 0
+        /// Reset post delay values to 0
         /// </summary>
         void ResetDelay();
 

--- a/src/Pixel.Automation.Core/TestData/TestCase.cs
+++ b/src/Pixel.Automation.Core/TestData/TestCase.cs
@@ -52,47 +52,53 @@ namespace Pixel.Automation.Core.TestData
         public bool IsMuted { get; set; }
 
         /// <summary>
-        /// Controls the delay for pre and post run of actors.
+        /// Amount of delay in ms after each actor is executed
         /// </summary>
         [DataMember(IsRequired = true, Order = 70)]
-        public int DelayFactor { get; set; } = 3;
+        public int PostDelay { get; set; } = 100;
 
+        /// <summary>
+        /// Scaling factor for post delay amount.       
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 80)]
+        public int DelayFactor { get; set; } = 3;            
+     
         /// <summary>
         /// Priority for the test case. This can be used for filtering test cases during execution.
         /// </summary>
-        [DataMember(IsRequired = true, Order = 80)]
+        [DataMember(IsRequired = true, Order = 90)]
         public Priority Priority { get; set; }
 
         /// <summary>
         /// Script file for the test case. This script file can be used for any temporary variables required 
         /// during test execution.
         /// </summary>
-        [DataMember(IsRequired = true, Order = 90)]
+        [DataMember(IsRequired = true, Order = 100)]
         public string ScriptFile { get; set; }     
 
         /// <summary>
         /// Description for the test case
         /// </summary>
-        [DataMember(IsRequired = false, Order = 100)]
+        [DataMember(IsRequired = false, Order = 110)]
         public string Description { get; set; }
 
         /// <summary>
         /// User defined key value pair that can be associated with test case.
         /// This can be used for filtering test cases during execution..
         /// </summary>
-        [DataMember(IsRequired = true, Order = 110)]
+        [DataMember(IsRequired = true, Order = 120)]
         public TagCollection Tags { get; private set; } = new TagCollection();
 
         /// <summary>
         /// Collection of Identifiers of controls used by the test case
         /// </summary>
-        [DataMember(IsRequired = true, Order = 120)]
+        [DataMember(IsRequired = true, Order = 130)]
         public List<ControlUsage> ControlsUsed { get; private set; } = new();
 
         /// <summary>
         /// Collection of Identifiers of Prefabs used by the test case
         /// </summary>
-        [DataMember(IsRequired = true, Order = 130)]
+        [DataMember(IsRequired = true, Order = 140)]
         public List<PrefabUsage> PrefabsUsed { get; private set; } = new();
 
         /// <summary>

--- a/src/Pixel.Automation.Core/TestData/TestFixture.cs
+++ b/src/Pixel.Automation.Core/TestData/TestFixture.cs
@@ -55,10 +55,16 @@ namespace Pixel.Automation.Core.TestData
         public string Category { get; set; } = "Default";
 
         /// <summary>
-        /// Controls the delay for pre and post run of actors.
+        /// Amount of delay in ms after each actor is executed.      
         /// </summary>
         [DataMember(IsRequired = true, Order = 80)]
-        public int DelayFactor { get; set; } = 3;
+        public int PostDelay { get; set; } = 100;
+
+        /// <summary>
+        /// Scaling factor for post delay amount.       
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 90)]
+        public int DelayFactor { get; set; } = 3;            
 
         /// <summary>
         /// User defined key value pair that can be associated with test fixture.

--- a/src/Pixel.Automation.Designer.Views/Flyouts/SettingsView.xaml
+++ b/src/Pixel.Automation.Designer.Views/Flyouts/SettingsView.xaml
@@ -38,22 +38,12 @@
             </Controls:MetroTabItem>
             
             <Controls:MetroTabItem Controls:HeaderedControlHelper.HeaderFontSize="18" Header="Fixture" ToolTip="Application settings for Test Fixture">
-                <StackPanel Margin="10,5,5,5">
-                    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch">
-                        <StackPanel Orientation="Horizontal">
-                            <Label Content="Delay Before" Padding="0,0,0,5" VerticalContentAlignment="Center"></Label>
-                            <Button x:Name="InfoPreDelay" Style="{StaticResource InfoButtonStyle}" Margin="5,0,0,5"
-                                    ToolTip="Amount of delay in ms before executing an actor inside a test case."/>
-                        </StackPanel>
-                        <TextBox x:Name="PreDelay" Controls:TextBoxHelper.Watermark="Delay Before" 
-                                 Text="{Binding ApplicationSettings.PreDelay}" Width="250" HorizontalAlignment="Left"
-                                 Controls:TextBoxHelper.ClearTextButton="True"></TextBox>
-                    </StackPanel>
+                <StackPanel Margin="10,5,5,5">                   
                     <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Margin="{StaticResource MarginTop}">
                         <StackPanel Orientation="Horizontal">
                             <Label Content="Delay After" Padding="0,0,0,5" VerticalContentAlignment="Center"></Label>
                             <Button x:Name="InfoPostDelay" Style="{StaticResource InfoButtonStyle}" Margin="5,0,0,5"                                   
-                                    ToolTip="Amount of delay in ms after executing an actor inside a test case."/>
+                                    ToolTip="Default PostDelay amount of delay in ms after executing an actor inside a test case."/>
                         </StackPanel>
                         <TextBox x:Name="PostDelay" Controls:TextBoxHelper.Watermark="Delay After" 
                                  Text="{Binding ApplicationSettings.PostDelay}" Width="250" HorizontalAlignment="Left"
@@ -63,7 +53,7 @@
                         <StackPanel Orientation="Horizontal">
                             <Label Content="Delay Factor" Padding="0,0,0,5" VerticalContentAlignment="Center"></Label>
                             <Button x:Name="InfoDelayFactor" Style="{StaticResource InfoButtonStyle}" Margin="5,0,0,5"
-                                    ToolTip="Default scaling factor for pre and post delay that can be used to control the actual applied delay"/>
+                                    ToolTip="Default scaling factor for post delay that can be used to control the actual applied delay"/>
                         </StackPanel>
                         <TextBox x:Name="DelayFactor" Controls:TextBoxHelper.Watermark="Delay Factor" 
                                  Text="{Binding ApplicationSettings.DelayFactor}" Width="250" HorizontalAlignment="Left"

--- a/src/Pixel.Automation.Designer.Views/appsettings.json
+++ b/src/Pixel.Automation.Designer.Views/appsettings.json
@@ -1,7 +1,7 @@
 {
   "userSettings": {
     "theme": "Light",
-    "accent": "Olive"
+    "accent": "Crimson"
   },
   "applicationSettings": {
     "applicationDirectory": "Applications",

--- a/src/Pixel.Automation.Native.Windows/ApplicationWindowManager.cs
+++ b/src/Pixel.Automation.Native.Windows/ApplicationWindowManager.cs
@@ -151,6 +151,12 @@ namespace Pixel.Automation.Native.Windows
             return matchingWindows;
         }
 
+        public bool IsForeGroundWindow(ApplicationWindow window)
+        {
+            HWND hWnd = User32.GetForegroundWindow();
+            return !hWnd.IsNull && hWnd.Equals(window.HWnd);
+        }
+
         public ApplicationWindow GetForeGroundWindow()
         {
             HWND hWnd = User32.GetForegroundWindow();

--- a/src/Pixel.Automation.TestExplorer.ViewModels/EditTestCaseViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/EditTestCaseViewModel.cs
@@ -61,6 +61,16 @@ namespace Pixel.Automation.TestExplorer.ViewModels
             set => CopyOfTestCase.IsMuted = value;
         }
 
+
+        /// <summary>
+        /// Amount of delay in ms after each actor is executed.      
+        /// </summary>
+        public int PostDelay
+        {
+            get => CopyOfTestCase.PostDelay;
+            set => CopyOfTestCase.PostDelay = value;
+        }
+
         /// <summary>
         /// Controls the execution speed of the TestCase
         /// </summary>

--- a/src/Pixel.Automation.TestExplorer.ViewModels/EditTestFixtureViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/EditTestFixtureViewModel.cs
@@ -77,6 +77,15 @@ namespace Pixel.Automation.TestExplorer.ViewModels
         }
 
         /// <summary>
+        /// Amount of delay in ms after each actor is executed.      
+        /// </summary>
+        public int PostDelay
+        {
+            get => CopyOfTestFixture.PostDelay;
+            set => CopyOfTestFixture.PostDelay = value;
+        }
+
+        /// <summary>
         /// Controls the execution speed of the TestCases belonging to a TestFixture
         /// </summary>
         public int DelayFactor

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestCaseViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestCaseViewModel.cs
@@ -102,7 +102,17 @@ namespace Pixel.Automation.TestExplorer.ViewModels
         }
 
         /// <summary>
-        /// Controls the execution speed of the TestCase
+        /// Amount of delay in ms after each actor is executed.      
+        /// </summary>
+        public int PostDelay
+        {
+            get => TestCase.PostDelay;
+            set => TestCase.PostDelay = value;
+        }
+
+        /// <summary>
+        /// Scaling factor for post delay amount.
+        /// This will eventually control the delay introduced between execution of each actor.
         /// </summary>
         public int DelayFactor
         {

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
@@ -247,6 +247,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                 };
                 TestFixtureViewModel testFixtureVM = new TestFixtureViewModel(newTestFixture)
                 {
+                    PostDelay = applicationSettings.PostDelay,
                     DelayFactor = applicationSettings.DelayFactor
                 };
                 var testFixtureEditor = new EditTestFixtureViewModel(newTestFixture, this.TestFixtures.Select(s => s.DisplayName));
@@ -590,7 +591,8 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                 {
                     TestCaseViewModel testCaseVM = new TestCaseViewModel(testCase)
                     {
-                        DelayFactor = fixtureVM.DelayFactor
+                        PostDelay = applicationSettings.PostDelay,
+                        DelayFactor = applicationSettings.DelayFactor
                     };
 
                     await this.testCaseManager.AddTestCaseAsync(testCase);

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestFixtureViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestFixtureViewModel.cs
@@ -106,7 +106,16 @@ namespace Pixel.Automation.TestExplorer.ViewModels
         }
 
         /// <summary>
-        /// Controls the execution speed of the TestCases belonging to a TestFixture
+        /// Amount of delay in ms after each actor is executed.      
+        /// </summary>
+        public int PostDelay
+        {
+            get => TestFixture.PostDelay;
+            set => TestFixture.PostDelay = value;
+        }
+
+        /// <summary>
+        /// Scaling factor for post delay amount.      
         /// </summary>
         public int DelayFactor
         {

--- a/src/Pixel.Automation.TestExplorer.Views/EditTestCaseView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/EditTestCaseView.xaml
@@ -50,6 +50,8 @@
                 <Label Content="Priority" DockPanel.Dock="Left" Margin="4,0,0,0"></Label>
                 <ComboBox ItemsSource="{Binding Source={editorCore:EnumBindingSource {x:Type models:Priority}}}" DockPanel.Dock="Right"
                         SelectedItem="{Binding Path=Priority}" ToolTip="Priority" MinWidth="80"/>
+                <Label Content="Post Delay" Margin="4,0,0,0" ></Label>
+                <controls:NumericUpDown Minimum="0" Maximum="1000" Interval="100" Value="{Binding PostDelay}" ToolTip="Amount of delay in ms after execution of each actor. This is scaled based on execution speed."/>
             </StackPanel>
 
             <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">

--- a/src/Pixel.Automation.TestExplorer.Views/EditTestFixtureView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/EditTestFixtureView.xaml
@@ -52,13 +52,15 @@
                 <CheckBox x:Name="IsMuted" IsChecked="{Binding IsMuted}" ToolTip="Tests belonging to a muted fixture are not executed"/>
                 <Label Content="Order" Margin="5,0,0,0" ></Label>
                 <controls:NumericUpDown Minimum="0" Value="{Binding Order}" ToolTip="Order of execution of fixture"/>
+                <Label Content="Post Delay" Margin="4,0,0,0" ></Label>
+                <controls:NumericUpDown Minimum="0" Maximum="1000" Interval="100" Value="{Binding PostDelay}" ToolTip="Amount of delay in ms after execution of each actor. This is scaled based on execution speed."/>
             </StackPanel>
             
             <StackPanel Orientation="Vertical" Margin="{StaticResource ControlMargin}">
                 <Label Content="Execution Speed"/>
                 <Slider x:Name="DelayFactor" Value="{Binding DelayFactor}" SmallChange="1" TickPlacement="None" LargeChange="10"
                         Margin="5,5,5,0" AutoToolTipPlacement="TopLeft"
-                        Minimum="0"  Maximum="100" ToolTip="Controls the pre-delay and post-delay for actors"/>
+                        Minimum="0"  Maximum="100" ToolTip="Scaling factor for Post Delay amount"/>
             </StackPanel>
                         
             <StackPanel x:Name="TagPanel" Orientation="Vertical" Margin="{StaticResource ControlMargin}" Style="{StaticResource StackPanelWithoutErrorTemplateStyle}"

--- a/src/Unit.Tests/Pixel.Automation.Test.Helpers/Components/MockEntityProcessor.cs
+++ b/src/Unit.Tests/Pixel.Automation.Test.Helpers/Components/MockEntityProcessor.cs
@@ -22,7 +22,7 @@ namespace Pixel.Automation.Test.Helpers
             return Task.CompletedTask;
         }
 
-        public void ConfigureDelay(int preDelayAmount, int postDelayAmount)
+        public void ConfigureDelay(int preDelayAmount)
         {
             
         }


### PR DESCRIPTION
1. PreDelay is removed now as it doesn't seem to add any value. For any exceptional scenarios, Wait actor can be used where required.
2. Pre and Post Delay calculations were based on application setting. This can change across different users or designer and test runner. To keep execution behavior consistent across different setups , delay is not dependent on application setting now. PostDelay and DelayFactor application setting only provide the default value for these properties while creating a new fixture or test case now.
3.Mutex was used to handle scenario where two parallel blocks need focus on application window ( could be different window) . It would require other block to wait until timeout until the first block is done executing. However, usage of mutex is causing threading issues due to async execution path. Mutex requires that it is released by same thread which acquired it . Removing this for now. We need some other signaling mechanism across parallel blocks to wait .
4. Changed default accent color to Crimson