### PR TITLE
Quartz schedulers and redis pub sub

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,7 +4,7 @@ services:
 
   mongo:
      image: mongo:latest
-     container_name: pixel_mongo
+     container_name: pixel-mongo
      command: --auth
      restart: always
      volumes:
@@ -15,16 +15,26 @@ services:
       MONGO_INITDB_ROOT_USERNAME: mongoadmin
       MONGO_INITDB_ROOT_PASSWORD: mongopass     
 
+  redis-pub-sub:
+     image: redis:latest
+     container_name: pixel-redis-pub-sub
+     networks:
+       - pixel-network
+     ports:
+       - 6379:6379
+
   pixel-persistence:
-    container_name: pixel_persistence_service
+    container_name: pixel-persistence-service
     env_file:
       - ./.config/persistence.env
     ports:
+      - 5000:80 
       - 5001:443    
     environment:     
-      - ASPNETCORE_URLS=https://+;
+      - ASPNETCORE_URLS=http://+;https://+;
       - Kestrel:Certificates:Default:Path=/etc/certs/localhost-cert.pem
       - Kestrel:Certificates:Default:KeyPath=/etc/certs/localhost-key.pem 
+      - RedisConnectionString=pixel-redis-pub-sub:6379
     volumes:
       # volume mount for providing required certificates for Kestrel (when using https)
       - ./.certificates:/etc/certs:ro

--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor
@@ -1,0 +1,25 @@
+﻿<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            Add Cron Trigger
+        </MudText>
+    </TitleContent>
+    <DialogContent>        
+        <MudTextField id="txtHandler" @bind-Value="@model.Handler" Label="Handler" @onfocus="(() => error = string.Empty)"
+                      Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>
+        <MudTextField id="txtCronExpression" @bind-Value="@model.CronExpression" Label="Cron Expression" @onfocus="(() => error = string.Empty)"
+                      Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>
+        <br />     
+        @if (!string.IsNullOrEmpty(error))
+        {
+            <MudAlert id="errorMessage" Severity="Severity.Error">@error</MudAlert>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton id="btnAddNewClaim" OnClick="AddNewTriggerAsync"
+                   Disabled="string.IsNullOrEmpty(model.Handler) || string.IsNullOrEmpty(model.CronExpression)"
+                   Color="Color.Primary" Variant="Variant.Filled">
+            Add
+        </MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor
@@ -4,7 +4,9 @@
             Add Cron Trigger
         </MudText>
     </TitleContent>
-    <DialogContent>        
+    <DialogContent>  
+        <MudTextField id="txtName" @bind-Value="@model.Name" Label="Name" @onfocus="(() => error = string.Empty)"
+                      Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>
         <MudTextField id="txtHandler" @bind-Value="@model.Handler" Label="Handler" @onfocus="(() => error = string.Empty)"
                       Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>
         <MudTextField id="txtCronExpression" @bind-Value="@model.CronExpression" Label="Cron Expression" @onfocus="(() => error = string.Empty)"
@@ -17,7 +19,7 @@
     </DialogContent>
     <DialogActions>
         <MudButton id="btnAddNewClaim" OnClick="AddNewTriggerAsync"
-                   Disabled="string.IsNullOrEmpty(model.Handler) || string.IsNullOrEmpty(model.CronExpression)"
+                   Disabled="string.IsNullOrEmpty(model.Name) || string.IsNullOrEmpty(model.Handler) || string.IsNullOrEmpty(model.CronExpression)"
                    Color="Color.Primary" Variant="Variant.Filled">
             Add
         </MudButton>

--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pixel.Automation.Web.Portal.Services;
+using Pixel.Persistence.Core.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Components.Triggers
+{
+    public partial class CronTrigger : ComponentBase
+    {
+        string error = null;
+        CronSessionTrigger model = new();
+
+        [CascadingParameter]
+        MudDialogInstance MudDialog { get; set; }
+
+        [Parameter]
+        public ITriggerService Service { get; set; }
+
+        [Parameter]
+        public string TemplateId { get; set; }
+
+        [Parameter]
+        public IEnumerable<SessionTrigger> ExistingTriggers { get; set; }
+
+        /// <summary>
+        /// Add new trigger and close the dialog
+        /// </summary>
+        async Task AddNewTriggerAsync()
+        {
+            if (!ExistingTriggers.Any(t => t.Equals(model)))
+            {
+                //Don't try to add claim to role if role is not yet created.
+                if (!string.IsNullOrEmpty(TemplateId))
+                {
+                    var result = await Service.AddTriggerAsync(TemplateId, model);
+                    if (result.IsSuccess)
+                    {
+                        MudDialog.Close(DialogResult.Ok<SessionTrigger>(model));
+                        return;
+                    }
+                    error = result.ToString();
+                    return;
+                }
+
+            }
+            error = $"Trigger with same details already exists for Template.";
+        }
+
+        /// <summary>
+        /// Close the dialog without any result
+        /// </summary>
+        void Cancel() => MudDialog.Cancel();
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor
@@ -12,25 +12,28 @@
         <MudTextField UserAttributes="@(new (){{"id","txtSearchBox"}})" @bind-Value="searchString" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
     </ToolBarContent>
     <ColGroup>
-        <col style="width:16%;" />
-        <col style="width:32%;" />     
-        <col style="width:32%;" />
-        <col style="width:10%;" />
-        <col style="width:10%;" />
+        <col style="width:12%;" />
+        <col style="width:24%;" />
+        <col style="width:24%;" />     
+        <col style="width:24%;" />
+        <col style="width:8%;" />
+        <col style="width:8%;" />
     </ColGroup>
     <HeaderContent>
-        <MudTh>Is Enabled</MudTh>      
+        <MudTh>Is Enabled</MudTh>
+        <MudTh><MudTableSortLabel SortBy="new Func<SessionTrigger, object>(x=>x.Name)">Name</MudTableSortLabel></MudTh>
         <MudTh><MudTableSortLabel SortBy="new Func<SessionTrigger, object>(x=>x.Handler)">Handler</MudTableSortLabel></MudTh>
         <MudTh>Cron Expression</MudTh>  
         <MudTh></MudTh>
         <MudTh></MudTh>
     </HeaderContent>
     <RowTemplate>
-        <MudTd UserAttributes="@(new (){{"id","tdEnabled"}})" DataLabel="">@context.IsEnabled</MudTd>       
-        <MudTd UserAttributes="@(new (){{"id","tdHandler"}})" DataLabel="Include in access token">@context.Handler</MudTd>
+        <MudTd UserAttributes="@(new (){{"id","tdEnabled"}})" DataLabel="">@context.IsEnabled</MudTd>
+        <MudTd UserAttributes="@(new (){{"id","tdName"}})" DataLabel="Name">@context.Name</MudTd>
+        <MudTd UserAttributes="@(new (){{"id","tdHandler"}})" DataLabel="Handler">@context.Handler</MudTd>
         @if(context is CronSessionTrigger cronSessionTrigger)
         {
-            <MudTd UserAttributes="@(new (){{"id","tdCronExpression"}})" DataLabel="Include in identity token">@cronSessionTrigger.CronExpression</MudTd>
+            <MudTd UserAttributes="@(new (){{"id","tdCronExpression"}})" DataLabel="Cron Expression">@cronSessionTrigger.CronExpression</MudTd>
         }
         <MudTd DataLabel="">
             <MudIconButton UserAttributes="@(new (){{"id","btnEdit"}})" Icon="@Icons.Material.Filled.Edit" Color="Color.Primary"
@@ -44,7 +47,10 @@
     <RowEditingTemplate>
          <MudTd DataLabel="IsEnabled">
            <MudSwitch UserAttributes="@(new (){{"id","cbIsEnabled"}})" @bind-Checked="@context.IsEnabled" Color="Color.Primary" />
-        </MudTd>       
+        </MudTd>
+        <MudTd DataLabel="Name">
+            <MudTextField UserAttributes="@(new (){{"id","txtName"}})" @bind-Value="@context.Name" Required />
+        </MudTd>
         <MudTd DataLabel="Handler">
             <MudTextField UserAttributes="@(new (){{"id","txtHandler"}})" @bind-Value="@context.Handler" Required />
         </MudTd>

--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor
@@ -1,0 +1,65 @@
+﻿<MudTable UserAttributes="@(new (){{"id","tblTriggers"}})" Items="@(Triggers ?? Enumerable.Empty<SessionTrigger>())" Dense="false" Hover="true" ReadOnly="false"
+          CanCancelEdit="true" Filter="@(new Func<SessionTrigger,bool>(FilterFunc))" @ref="table"
+          @bind-SelectedItem="selectedTrigger" SortLabel="Sort By" CommitEditTooltip="Commit Edit"
+          OnCommitEditClick="UpdateItemAsync"
+          RowEditPreview="BackupItem" RowEditCancel="ResetItemToOriginalValues"
+          IsEditRowSwitchingBlocked="true" Elevation="4">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Triggers</MudText>
+        <MudIconButton UserAttributes="@(new (){{"id","btnNewTrigger"}})" Icon="@Icons.Material.Outlined.AddCircleOutline" Size="Size.Medium"
+                       @onclick="@(() => OnAddItem.InvokeAsync())" Color="Color.Primary"></MudIconButton>
+        <MudSpacer />
+        <MudTextField UserAttributes="@(new (){{"id","txtSearchBox"}})" @bind-Value="searchString" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+    </ToolBarContent>
+    <ColGroup>
+        <col style="width:16%;" />
+        <col style="width:32%;" />     
+        <col style="width:32%;" />
+        <col style="width:10%;" />
+        <col style="width:10%;" />
+    </ColGroup>
+    <HeaderContent>
+        <MudTh>Is Enabled</MudTh>      
+        <MudTh><MudTableSortLabel SortBy="new Func<SessionTrigger, object>(x=>x.Handler)">Handler</MudTableSortLabel></MudTh>
+        <MudTh>Cron Expression</MudTh>  
+        <MudTh></MudTh>
+        <MudTh></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd UserAttributes="@(new (){{"id","tdEnabled"}})" DataLabel="">@context.IsEnabled</MudTd>       
+        <MudTd UserAttributes="@(new (){{"id","tdHandler"}})" DataLabel="Include in access token">@context.Handler</MudTd>
+        @if(context is CronSessionTrigger cronSessionTrigger)
+        {
+            <MudTd UserAttributes="@(new (){{"id","tdCronExpression"}})" DataLabel="Include in identity token">@cronSessionTrigger.CronExpression</MudTd>
+        }
+        <MudTd DataLabel="">
+            <MudIconButton UserAttributes="@(new (){{"id","btnEdit"}})" Icon="@Icons.Material.Filled.Edit" Color="Color.Primary"
+                           @onclick="() => EditItem(context)" Size="Size.Medium"></MudIconButton>
+        </MudTd>
+        <MudTd DataLabel="">
+            <MudIconButton UserAttributes="@(new (){{"id","btnDelete"}})" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
+                           @onclick="() => OnDeleteItem.InvokeAsync(context)" Size="Size.Medium"></MudIconButton>
+        </MudTd>
+    </RowTemplate>
+    <RowEditingTemplate>
+         <MudTd DataLabel="IsEnabled">
+           <MudSwitch UserAttributes="@(new (){{"id","cbIsEnabled"}})" @bind-Checked="@context.IsEnabled" Color="Color.Primary" />
+        </MudTd>       
+        <MudTd DataLabel="Handler">
+            <MudTextField UserAttributes="@(new (){{"id","txtHandler"}})" @bind-Value="@context.Handler" Required />
+        </MudTd>
+        @if (context is CronSessionTrigger cronSessionTrigger)
+        {
+            <MudTd DataLabel="Cron Expression">
+                <MudTextField UserAttributes="@(new (){{"id","txtCronExpression"}})" @bind-Value="@cronSessionTrigger.CronExpression" Required />
+            </MudTd>
+        }       
+        <MudTd DataLabel="">
+        </MudTd>
+        <MudTd DataLabel="">
+        </MudTd>
+    </RowEditingTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>

--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+using Pixel.Persistence.Core.Models;
+
+namespace Pixel.Automation.Web.Portal.Components.Triggers
+{
+    public partial class TriggerManager : ComponentBase
+    {
+        [Inject]
+        public ISnackbar SnackBar { get; set; }
+
+        [Parameter]
+        public IEnumerable<SessionTrigger> Triggers { get; set; }
+
+        [Parameter]
+        public EventCallback OnAddItem { get; set; }
+
+        [Parameter]
+        public EventCallback<SessionTrigger> OnDeleteItem { get; set; }
+
+
+        [Parameter]
+        public Func<SessionTrigger, SessionTrigger, Task<bool>> OnUpdateItem { get; set; }
+
+        private MudTable<SessionTrigger> table;
+
+
+        private SessionTrigger selectedTrigger = null;
+        private SessionTrigger elementBeforeEdit;
+        private string searchString = "";
+
+        void EditItem(SessionTrigger model)
+        {
+            selectedTrigger = model;
+            table.SetEditingItem(model);
+            BackupItem(model);
+        }
+
+        async Task UpdateItemAsync()
+        {
+            var success = await this.OnUpdateItem(elementBeforeEdit, selectedTrigger);
+            if (!success)
+            {
+                ResetItemToOriginalValues(selectedTrigger);
+            }
+        }
+
+        void BackupItem(object element)
+        {
+            if (element is ICloneable beforeEdit)
+            {
+                elementBeforeEdit = beforeEdit.Clone() as SessionTrigger;
+            }
+
+        }
+
+        void ResetItemToOriginalValues(object element)
+        {
+            if(element is CronSessionTrigger sessionTrigger && elementBeforeEdit is CronSessionTrigger ebe)
+            {
+                sessionTrigger.Handler = ebe.Handler;
+                sessionTrigger.IsEnabled = ebe.IsEnabled;
+                sessionTrigger.CronExpression = ebe.CronExpression;
+            }           
+        }
+
+        private bool FilterFunc(SessionTrigger element)
+        {
+            if (string.IsNullOrWhiteSpace(searchString))
+                return true;            
+            if (element.Handler.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+                return true;
+            return false;
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor.cs
@@ -61,6 +61,7 @@ namespace Pixel.Automation.Web.Portal.Components.Triggers
         {
             if(element is CronSessionTrigger sessionTrigger && elementBeforeEdit is CronSessionTrigger ebe)
             {
+                sessionTrigger.Name = ebe.Name;
                 sessionTrigger.Handler = ebe.Handler;
                 sessionTrigger.IsEnabled = ebe.IsEnabled;
                 sessionTrigger.CronExpression = ebe.CronExpression;
@@ -70,7 +71,9 @@ namespace Pixel.Automation.Web.Portal.Components.Triggers
         private bool FilterFunc(SessionTrigger element)
         {
             if (string.IsNullOrWhiteSpace(searchString))
-                return true;            
+                return true;    
+            if(element.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+                return true;
             if (element.Handler.Contains(searchString, StringComparison.OrdinalIgnoreCase))
                 return true;
             return false;

--- a/src/Pixel.Automation.Web.Portal/Helpers/OperationResult.cs
+++ b/src/Pixel.Automation.Web.Portal/Helpers/OperationResult.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Helpers
+{
+    public class OperationResult
+    {
+        public HttpStatusCode StatusCode { get; protected set; }
+
+        public List<string> ErrorMessages { get; protected set; } = new List<string>();
+
+        public bool IsSuccess { get; private set; } = true;
+
+        protected OperationResult(HttpStatusCode statusCode)
+        {
+            this.StatusCode = statusCode;
+        }
+
+        protected OperationResult(HttpStatusCode statusCode, IEnumerable<string> errorMessages) : this(statusCode)
+        {
+            this.ErrorMessages.AddRange(errorMessages);
+        }
+
+        public static OperationResult Success(HttpStatusCode statusCode) => new OperationResult(statusCode);
+
+        public static OperationResult Failed(HttpStatusCode statusCode, string errorMessage)
+         => new OperationResult(statusCode, new[] { errorMessage }) { IsSuccess = false };
+
+        public static OperationResult Failed(HttpStatusCode statusCode, IEnumerable<string> errorMessages)
+           => new OperationResult(statusCode, errorMessages) { IsSuccess = false };
+
+        public static async Task<OperationResult> FromResponseAsync(HttpResponseMessage result)
+        {
+            try
+            {             
+                result.EnsureSuccessStatusCode();               
+                return Success(result.StatusCode);
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.BadRequest)
+            {
+                var badRequestResponse = await result.Content.ReadFromJsonAsync<BadRequestResponse>();             
+                return Failed(result.StatusCode, badRequestResponse.Errors);
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                var notFoundResponse = await result.Content.ReadFromJsonAsync<NotFoundResponse>();
+                return Failed(result.StatusCode, notFoundResponse.Message);
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.InternalServerError)
+            {
+                var problemResponse = await result?.Content.ReadFromJsonAsync<ProblemResponse>();
+                return Failed(result.StatusCode, problemResponse.Title);
+            }           
+        }
+
+        public override string ToString()
+        {
+            if(IsSuccess)
+            {
+                return $"{StatusCode} success";
+            }
+            return $"{StatusCode} : {string.Join(';', this.ErrorMessages)}";
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Helpers/Response.cs
+++ b/src/Pixel.Automation.Web.Portal/Helpers/Response.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Pixel.Automation.Web.Portal.Helpers
+{
+    public class ResponseBase
+    {       
+        public int Status { get; set; }
+
+        public string Message { get; set; }
+      
+        public ResponseBase()
+        {
+        }
+
+        public ResponseBase(int status, string message)
+        {
+            Status = status;
+            Message = message ?? GetDefaultMessageForStatusCode(status);
+        }
+
+        private static string GetDefaultMessageForStatusCode(int status)
+        {
+            switch (status)
+            {
+                case 400:
+                    return "Bad Request";
+                case 404:
+                    return "Resource not found";
+                case 500:
+                    return "An unhandled error occurred";
+                default:
+                    return status.ToString();
+            }
+        }
+    }
+
+    public class OkResponse : ResponseBase
+    {
+        public object Result { get; set; }
+
+        public OkResponse() : base()
+        {
+        }
+
+        public OkResponse(object result) : base(200, string.Empty)
+        {
+            Result = result;
+        }      
+    }
+
+    public class BadRequestResponse : ResponseBase
+    {
+        public List<string> Errors { get; set; } = new List<string>();
+
+        public BadRequestResponse() : base()
+        {
+        }
+
+        public BadRequestResponse(IEnumerable<string> errors) : base(400, string.Empty)
+        {
+            this.Errors.AddRange(errors);
+        }
+    }
+
+    public class NotFoundResponse : ResponseBase
+    {
+        public NotFoundResponse() : base()
+        {
+        }
+
+        public NotFoundResponse(string message) : base(404, message)
+        {           
+        }
+    }
+
+    public class ProblemResponse : ResponseBase
+    {                
+        public string? Type { get; set; }      
+        
+        public string? Title { get; set; }        
+     
+        public string? Detail { get; set; }     
+     
+        public string? Instance { get; set; }
+     
+        [JsonExtensionData]
+        public IDictionary<string, object?> Extensions { get; } = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        public ProblemResponse() : base()
+        {
+        }
+
+        public ProblemResponse(string error) : base(500, error)
+        {            
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Pages/Template/AddTemplate.razor
+++ b/src/Pixel.Automation.Web.Portal/Pages/Template/AddTemplate.razor
@@ -1,0 +1,45 @@
+﻿@page "/templates/new"
+
+@if (sessionTemplate != null)
+{
+    <MudGrid Spacing="2" Justify="Justify.FlexStart" Class="p-2">
+         <MudItem xs="8">
+               <MudText Typo="Typo.h4">Create New</MudText>
+         </MudItem/>       
+    </MudGrid>  
+
+    <br />
+    <MudPaper Elevation="4">
+        <EditForm Model="@sessionTemplate" OnValidSubmit="AddTemplateAsync">
+            <FluentValidationValidator />           
+            <MudCard>
+                <MudCardContent>
+                    <MudTextField UserAttributes="@(new (){{"id","txtTemplateName"}})" Label="Template Name" Class="mt-3"
+                            @bind-Value="sessionTemplate.Name" For="@(() => sessionTemplate.Name)" />
+                     <MudAutocomplete T="AutomationProject" Label="Project Name" @bind-Value="selectedProject"
+                         SearchFunc="@SearchProjects" Class="mt-3"
+                         ResetValueOnEmptyText="true" ToStringFunc="@(e => e?.Name)"
+                         CoerceText="false" CoerceValue="false"
+                         AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Primary" />         
+                         <MudSelect T="ProjectVersion" Label="Version" Variant="Variant.Text" @bind-Value="selectedVersion"
+                            AnchorOrigin="Origin.BottomCenter" ToStringFunc="@(e => e?.Version.ToString())">
+                               @foreach (var version in selectedProject?.AvailableVersions ?? Enumerable.Empty<ProjectVersion>())
+                                {
+                                    <MudSelectItem T="ProjectVersion" Value="@version">@version</MudSelectItem>
+                                }
+                        </MudSelect>
+                        <MudTextField UserAttributes="@(new (){{"id","txtSelector"}})" Label="Selector" Variant="Variant.Text" 
+                            Class="mt-3"  @bind-Value="sessionTemplate.Selector" Lines="2" For="@(() => sessionTemplate.Selector)" />
+                        <MudTextField UserAttributes="@(new (){{"id","txtInitializeScript"}})" Label="Initialization Script" Class="mt-3"
+                            @bind-Value="sessionTemplate.InitializeScript" For="@(() => sessionTemplate.InitializeScript)" />                      
+                </MudCardContent>
+                <MudCardActions>
+                    <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled"
+                           Color="Color.Primary" Class="ml-auto">Create</MudButton>
+                </MudCardActions>
+            </MudCard>
+        </EditForm>
+    </MudPaper>
+    <br/>
+    <br/>
+}

--- a/src/Pixel.Automation.Web.Portal/Pages/Template/AddTemplate.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Pages/Template/AddTemplate.razor.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pixel.Automation.Web.Portal.Services;
+using Pixel.Persistence.Core.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Pages.Template
+{
+    public partial class AddTemplate : ComponentBase
+    {
+        [Inject]
+        public IDialogService DialogService { get; set; }
+
+        [Inject]
+        public ISnackbar SnackBar { get; set; }
+
+        [Inject]
+        public IProjectService ProjectService { get; set; }
+
+        [Inject]
+        public ITemplateService TemplateService { get; set; }
+
+        [Inject]
+        public NavigationManager Navigator { get; set; }
+
+        SessionTemplate sessionTemplate = new();
+        List<AutomationProject> automationProjects = new();
+        AutomationProject selectedProject;
+        ProjectVersion selectedVersion;
+
+        protected override async Task OnInitializedAsync()
+        {
+            var projects = await ProjectService.GetProjectsAsync();
+            automationProjects.AddRange(projects);
+            await base.OnInitializedAsync();
+        }
+
+        private async  Task<IEnumerable<AutomationProject>> SearchProjects(string value)
+        {
+            if(string.IsNullOrEmpty(value))
+            {
+                return await Task.FromResult(automationProjects);
+            }
+            return await  Task.FromResult(automationProjects.Where(s => s.Name.StartsWith(value) || s.Name.Contains(value)));
+        }
+
+        /// <summary>
+        /// Add new application details
+        /// </summary>
+        /// <returns></returns>
+        private async Task AddTemplateAsync()
+        {
+            sessionTemplate.ProjectId = selectedProject.ProjectId;
+            sessionTemplate.ProjectName = selectedProject.Name;
+            sessionTemplate.TargetVersion = selectedVersion.ToString();
+            var result = await TemplateService.AddTemplateAsync(sessionTemplate);
+            if (result.IsSuccess)
+            {
+                Navigator.NavigateTo($"templates/list");
+                SnackBar.Add("Added successfully.", Severity.Success);
+                return;
+            }
+            SnackBar.Add(result.ToString(), Severity.Error);
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Pages/Template/EditTemplate.razor
+++ b/src/Pixel.Automation.Web.Portal/Pages/Template/EditTemplate.razor
@@ -1,0 +1,43 @@
+﻿@page "/templates/edit/{templateId}"
+<MudText Typo="Typo.h4">Edit Template</MudText>
+<br />
+
+@if (hasErrors)
+{
+    <MudAlert Severity="Severity.Error">Template details could not be retrieved for template with ID : @(TemplateId ?? string.Empty).</MudAlert>
+}
+
+@if (sessionTemplate != null)
+{
+    <MudPaper Elevation="4">
+        <EditForm Model="@sessionTemplate" OnValidSubmit="UpdateTemplatesAsync">
+            <FluentValidationValidator />           
+            <MudCard>
+                <MudCardContent>
+                    <MudTextField UserAttributes="@(new (){{"id","txtTemplateName"}})" Label="Template Name" Class="mt-3"
+                              @bind-Value="sessionTemplate.Name" For="@(() => sessionTemplate.Name)" />
+                    <MudTextField UserAttributes="@(new (){{"id","txtProjectName"}})" Label="Template Name" Class="mt-3"
+                              @bind-Value="sessionTemplate.ProjectName" For="@(() => sessionTemplate.ProjectName)" ReadOnly="true" />
+                    <MudSelect T="ProjectVersion" Label="Version" Variant="Variant.Text" @bind-Value="selectedVersion"
+                           AnchorOrigin="Origin.BottomCenter" ToStringFunc="@(e => e?.Version.ToString())">
+                        @foreach (var version in selectedProject?.AvailableVersions ?? Enumerable.Empty<ProjectVersion>())
+                        {
+                            <MudSelectItem T="ProjectVersion" Value="@version">@version</MudSelectItem>
+                        }
+                    </MudSelect>
+                    <MudTextField UserAttributes="@(new (){{"id","txtSelector"}})" Label="Selector" Variant="Variant.Text"
+                              Class="mt-3" @bind-Value="sessionTemplate.Selector" Lines="2" For="@(() => sessionTemplate.Selector)" />
+                    <MudTextField UserAttributes="@(new (){{"id","txtInitializeScript"}})" Label="Initialization Script" Class="mt-3"
+                              @bind-Value="sessionTemplate.InitializeScript" For="@(() => sessionTemplate.InitializeScript)" />
+                </MudCardContent>
+                <MudCardActions>
+                    <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled" Color="Color.Primary" Class="ml-auto">Update</MudButton>
+                </MudCardActions>
+            </MudCard>
+        </EditForm>
+    </MudPaper>
+    <br />
+    <Pixel.Automation.Web.Portal.Components.Triggers.TriggerManager Triggers="sessionTemplate.Triggers" OnAddItem="AddTriggerAsync"
+               OnUpdateItem="UpdateTriggerAsync" OnDeleteItem="RemoveTriggerAsync" />
+}
+

--- a/src/Pixel.Automation.Web.Portal/Pages/Template/TemplateList.razor
+++ b/src/Pixel.Automation.Web.Portal/Pages/Template/TemplateList.razor
@@ -1,0 +1,50 @@
+﻿@page "/templates/list"
+
+<MudTable UserAttributes="@(new (){{"id","tblTemplates"}})" ServerData="@(new Func<TableState, Task<TableData<SessionTemplate>>>(GetTemplatesAsync))"
+          Dense="false" Hover="true" ReadOnly="true" SortLabel="Sort By" Elevation="4" @ref="templatesTable">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Templates</MudText>
+        <MudIconButton UserAttributes="@(new (){{"id","btnNew"}})" Icon="@Icons.Material.Outlined.AddCircleOutline" Size="Size.Medium"
+                       @onclick="AddNewTemplate" Color="Color.Primary"></MudIconButton>
+        <MudSpacer></MudSpacer>
+        <MudTextField UserAttributes="@(new (){{"id","txtSearchBox"}})" T="string" ValueChanged="@(s=>OnSearch(s))" Placeholder="Search by template name or project name" Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh>Template Name</MudTh>
+        <MudTh>Project Name</MudTh>
+        <MudTh>Project Version</MudTh>
+        <MudTh></MudTh>
+        <MudTh></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Template Name">
+            @context.Name
+        </MudTd>
+        <MudTd DataLabel="Project Name">
+            @context.ProjectName
+        </MudTd>
+        <MudTd DataLabel="Project Version">
+            @context.TargetVersion
+        </MudTd>
+        <MudTd DataLabel="">
+            <MudIconButton UserAttributes="@(new (){{"id","btnEdit"}})" Icon="@Icons.Material.Filled.Edit" Color="Color.Primary"
+                           @onclick="()=> EditTemplate(context)" Size="Size.Medium"></MudIconButton>
+        </MudTd>
+        <MudTd DataLabel="">
+            <MudIconButton UserAttributes="@(new (){{"id","btnDelete"}})" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
+                           @onclick="()=> DeleteTemplatesAsync(context)" Size="Size.Medium"></MudIconButton>
+        </MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager PageSizeOptions="pageSizeOptions" RowsPerPageString="Results Per Page" />
+    </PagerContent>
+    <ColGroup>
+        <col />
+        <col />
+        <col />
+        <col style="width:20px;" />
+        <col style="width:20px;" />
+    </ColGroup>
+</MudTable>
+

--- a/src/Pixel.Automation.Web.Portal/Pages/Template/TemplateList.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Pages/Template/TemplateList.razor.cs
@@ -1,0 +1,120 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pixel.Automation.Web.Portal.Services;
+using System.Linq;
+using System.Threading.Tasks;
+using System;
+using Pixel.Persistence.Core.Models;
+using Pixel.Persistence.Core.Request;
+
+namespace Pixel.Automation.Web.Portal.Pages.Template
+{
+    public partial class TemplateList : ComponentBase
+    {
+        [Inject]
+        public ITemplateService TemplateService { get; set; }
+
+        [Inject]
+        public IDialogService DialogService { get; set; }
+
+        [Inject]
+        public ISnackbar SnackBar { get; set; }
+
+        [Inject]
+        public NavigationManager Navigator { get; set; }
+
+        private readonly int[] pageSizeOptions = { 10, 20, 30, 40, 50 };
+        private MudTable<SessionTemplate> templatesTable;
+        private GetTemplatesRequest templatesRequest = new ();
+        private bool resetCurrentPage = false;
+
+        /// <summary>
+        /// Get templates from api endpoint for the current page of the data table
+        /// </summary>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        private async Task<TableData<SessionTemplate>> GetTemplatesAsync(TableState state)
+        {
+            try
+            {
+                templatesRequest.CurrentPage = resetCurrentPage ? 1 : (state.Page + 1);
+                resetCurrentPage = false;
+                templatesRequest.PageSize = state.PageSize;
+                var sessionPage = await TemplateService.GetTemplatesAsync(templatesRequest);
+
+                return new TableData<SessionTemplate>
+                {
+                    Items = sessionPage.Items,
+                    TotalItems = sessionPage.ItemsCount
+                };
+            }
+            catch (Exception ex)
+            {
+                SnackBar.Add($"Error while retrieving templates.{ex.Message}", Severity.Error);
+            }
+            return new TableData<SessionTemplate>
+            {
+                Items = Enumerable.Empty<SessionTemplate>(),
+                TotalItems = 0
+            };
+        }
+
+        /// <summary>
+        /// Refresh data for the search query
+        /// </summary>
+        /// <param name="text"></param>
+        private void OnSearch(string text)
+        {
+            templatesRequest.TemplateFilter = string.Empty;
+            if (!string.IsNullOrEmpty(text))
+            {
+                templatesRequest.TemplateFilter = text;
+            }
+            resetCurrentPage = true;
+            templatesTable.ReloadServerData();
+        }
+
+        /// <summary>
+        /// Navigate to add new session template page
+        /// </summary>
+        void AddNewTemplate()
+        {
+            Navigator.NavigateTo($"templates/new");
+        }
+
+        /// <summary>
+        /// Navigate to edit application page
+        /// </summary>
+        /// <param name="sessionTemplate"></param>
+        void EditTemplate(SessionTemplate sessionTemplate)
+        {
+            Navigator.NavigateTo($"templates/edit/{sessionTemplate.Id}");
+        }
+
+        /// <summary>
+        /// Delete the template
+        /// </summary>
+        /// <param name="sessionTemplate"></param>
+        /// <returns></returns>
+        async Task DeleteTemplatesAsync(SessionTemplate sessionTemplate)
+        {
+            bool? dialogResult = await DialogService.ShowMessageBox("Warning", "Delete can't be undone !!",
+                yesText: "Delete!", cancelText: "Cancel", options: new DialogOptions() { FullWidth = true });
+            if (dialogResult.GetValueOrDefault())
+            {
+                var result = await TemplateService.DeleteTemplateAsync(sessionTemplate);
+                if (result.IsSuccess)
+                {
+                    SnackBar.Add("Deleted successfully.", Severity.Success);
+                    await templatesTable.ReloadServerData();
+                    return;
+                }
+                SnackBar.Add(result.ToString(), Severity.Error, config =>
+                {
+                    config.ShowCloseIcon = true;
+                    config.RequireInteraction = true;
+                });
+            }
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Pixel.Automation.Web.Portal.csproj
+++ b/src/Pixel.Automation.Web.Portal/Pixel.Automation.Web.Portal.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="Blazored.FluentValidation" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.5" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />

--- a/src/Pixel.Automation.Web.Portal/Program.cs
+++ b/src/Pixel.Automation.Web.Portal/Program.cs
@@ -19,6 +19,9 @@ namespace Pixel.Automation.Web.Portal
             builder.Services.AddHttpClient("Pixel.Automation.Web.Portal", client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));          
             builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("Pixel.Automation.Web.Portal"));
 
+            builder.Services.AddHttpClient<IProjectService, ProjectService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
+            builder.Services.AddHttpClient<ITemplateService, TemplateService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
+            builder.Services.AddHttpClient<ITriggerService, TriggerService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
             builder.Services.AddHttpClient<ITestResultService, TestResultService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
             builder.Services.AddHttpClient<ITestSessionService, TestSessionService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
             builder.Services.AddHttpClient<ITestStatisticsService, TestStatisticsService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));

--- a/src/Pixel.Automation.Web.Portal/Services/ProjectService.cs
+++ b/src/Pixel.Automation.Web.Portal/Services/ProjectService.cs
@@ -1,0 +1,63 @@
+﻿using Pixel.Persistence.Core.Models;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Services
+{
+    public interface IProjectService
+    {
+        /// <summary>
+        /// Get all the available session templates based on request
+        /// </summary>
+        /// <returns></returns>
+        Task<IEnumerable<AutomationProject>> GetProjectsAsync();
+
+        /// <summary>
+        /// Get AutomationProject given it's id
+        /// </summary>
+        /// <param name="projectId"></param>
+        /// <returns></returns>
+        Task<AutomationProject> GetProjectByIdAsync(string projectId);
+
+        /// <summary>
+        /// Get AutomationProject given it's name
+        /// </summary>
+        /// <param name="projectName"></param>
+        /// <returns></returns>
+        Task<AutomationProject> GetProjectByNameAsync(string projectName);
+    }
+
+    public class ProjectService : IProjectService
+    {
+        private readonly HttpClient httpClient;
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="httpClient"></param>
+        public ProjectService(HttpClient httpClient)
+        {
+            this.httpClient = httpClient;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<AutomationProject>> GetProjectsAsync()
+        {          
+            return await this.httpClient.GetFromJsonAsync<IEnumerable<AutomationProject>>("api/projects");
+        }
+
+        /// <inheritdoc/>
+        public async Task<AutomationProject> GetProjectByIdAsync(string projectId)
+        {
+            return await this.httpClient.GetFromJsonAsync<AutomationProject>($"api/projects/id/{projectId}");
+        }
+
+        /// <inheritdoc/>
+        public async Task<AutomationProject> GetProjectByNameAsync(string projectName)
+        {
+            return await this.httpClient.GetFromJsonAsync<AutomationProject>($"api/projects/name/{projectName}");
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Services/TemplateService.cs
+++ b/src/Pixel.Automation.Web.Portal/Services/TemplateService.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.AspNetCore.WebUtilities;
+using Pixel.Automation.Web.Portal.Helpers;
+using Pixel.Persistence.Core.Models;
+using Pixel.Persistence.Core.Request;
+using Pixel.Persistence.Core.Response;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Services
+{
+    public interface ITemplateService
+    {
+        /// <summary>
+        /// Get all the available session templates based on request
+        /// </summary>
+        /// <returns></returns>
+        Task<PagedList<SessionTemplate>> GetTemplatesAsync(GetTemplatesRequest getTemplatesRequest);
+
+        /// <summary>
+        /// Get session template with a given template id
+        /// </summary>
+        /// <param name="templateId"></param>
+        /// <returns></returns>
+        Task<SessionTemplate> GetTemplateByIdAsync(string templateId);
+
+        /// <summary>
+        /// Get session template with a given template name
+        /// </summary>
+        /// <param name="templateName"></param>
+        /// <returns></returns>
+        Task<SessionTemplate> GetTemplateByNameAsync(string templateName);
+
+        /// <summary>
+        /// Add a new session template
+        /// </summary>
+        /// <param name="applicationDescriptor"></param>
+        /// <returns></returns>
+        Task<OperationResult> AddTemplateAsync(SessionTemplate sessionTemplate);
+
+        /// <summary>
+        /// Update details of an existing session template
+        /// </summary>
+        /// <param name="sessionTemplate"></param>
+        /// <returns></returns>
+        Task<OperationResult> UpdateTemplateAsync(SessionTemplate sessionTemplate);
+
+        /// <summary>
+        /// Delete an existing session template
+        /// </summary>
+        /// <param name="sessionTemplate"></param>
+        /// <returns></returns>
+        Task<OperationResult> DeleteTemplateAsync(SessionTemplate sessionTemplate);
+    }
+
+    public class TemplateService : ITemplateService
+    {
+        private readonly HttpClient httpClient;
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="httpClient"></param>
+        public TemplateService(HttpClient httpClient)
+        {
+            this.httpClient = httpClient;
+        }
+
+        /// <inheritdoc/>
+        public async Task<PagedList<SessionTemplate>> GetTemplatesAsync(GetTemplatesRequest request)
+        {
+            var queryStringParam = new Dictionary<string, string>
+            {
+                ["currentPage"] = request.CurrentPage.ToString(),
+                ["pageSize"] = request.PageSize.ToString()
+            };
+            if (!string.IsNullOrEmpty(request.TemplateFilter))
+            {
+                queryStringParam.Add("templateFilter", request.TemplateFilter);
+            }
+            return await this.httpClient.GetFromJsonAsync<PagedList<SessionTemplate>>(QueryHelpers.AddQueryString("api/templates/paged", queryStringParam));
+        }
+
+        /// <inheritdoc/>
+        public async Task<SessionTemplate> GetTemplateByIdAsync(string templateId)
+        {
+            return await httpClient.GetFromJsonAsync<SessionTemplate>($"api/templates/id/{templateId}");
+        }
+
+        /// <inheritdoc/>
+        public async Task<SessionTemplate> GetTemplateByNameAsync(string templateName)
+        {
+            return await httpClient.GetFromJsonAsync<SessionTemplate>($"api/templates/name/{templateName}");
+        }
+
+        /// <inheritdoc/>
+        public async Task<OperationResult> AddTemplateAsync(SessionTemplate sessionTemplate)
+        {
+            var result = await httpClient.PostAsJsonAsync<SessionTemplate>("api/templates", sessionTemplate);
+            return await OperationResult.FromResponseAsync(result);
+        }
+
+        /// <inheritdoc/>
+        public async Task<OperationResult> UpdateTemplateAsync(SessionTemplate sessionTemplate)
+        {
+            var result = await httpClient.PutAsJsonAsync<SessionTemplate>("api/templates", sessionTemplate);
+            return await OperationResult.FromResponseAsync(result);
+        }
+
+        /// <inheritdoc/>
+        public async Task<OperationResult> DeleteTemplateAsync(SessionTemplate sessionTemplate)
+        {
+            var result = await httpClient.DeleteAsync($"api/templates/{sessionTemplate.Id}");
+            return await OperationResult.FromResponseAsync(result);
+        }       
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Services/TriggerService.cs
+++ b/src/Pixel.Automation.Web.Portal/Services/TriggerService.cs
@@ -59,7 +59,7 @@ namespace Pixel.Automation.Web.Portal.Services
         /// <inheritdoc/>
         public async Task<OperationResult> DeleteTriggerAsync(string templateId, SessionTrigger trigger)
         {
-            var result = await httpClient.PostAsJsonAsync<DeleteTriggerRequest>($"api/templates/triggers/delete", new DeleteTriggerRequest(templateId, trigger));
+            var result = await httpClient.DeleteAsync($"api/templates/triggers/delete/{templateId}/{trigger.Name}");
             return await OperationResult.FromResponseAsync(result);
         }
 

--- a/src/Pixel.Automation.Web.Portal/Services/TriggerService.cs
+++ b/src/Pixel.Automation.Web.Portal/Services/TriggerService.cs
@@ -1,0 +1,73 @@
+﻿using Pixel.Automation.Web.Portal.Helpers;
+using Pixel.Persistence.Core.Models;
+using Pixel.Persistence.Core.Request;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Services
+{
+    public interface ITriggerService
+    {
+        /// <summary>
+        /// Add a new trigger to a template
+        /// </summary>
+        /// <param name="templateId"></param>
+        /// <param name="trigger"></param>
+        /// <returns></returns>
+        Task<OperationResult> AddTriggerAsync(string templateId, SessionTrigger trigger);
+
+        /// <summary>
+        /// Remove trigger from template
+        /// </summary>
+        /// <param name="templateId"></param>
+        /// <param name="trigger"></param>
+        /// <returns></returns>
+        Task<OperationResult> DeleteTriggerAsync(string templateId, SessionTrigger trigger);
+
+        /// <summary>
+        /// Update details of an existing trigger on template
+        /// </summary>
+        /// <param name="owner"></param>
+        /// <param name="original"></param>
+        /// <param name="modified"></param>
+        /// <returns></returns>
+        Task<OperationResult> UpdateTriggerAsync(string templateId, SessionTrigger original, SessionTrigger modified);
+    }
+
+    public class TriggerService : ITriggerService
+    {
+
+        private readonly HttpClient httpClient;
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="httpClient"></param>
+        public TriggerService(HttpClient httpClient)
+        {
+            this.httpClient = httpClient;
+        }
+
+        /// <inheritdoc/>
+        public async Task<OperationResult> AddTriggerAsync(string templateId, SessionTrigger trigger)
+        {
+            var result = await httpClient.PostAsJsonAsync<AddTriggerRequest>($"api/templates/triggers/add", new AddTriggerRequest(templateId, trigger));
+            return await OperationResult.FromResponseAsync(result);
+        }
+
+        /// <inheritdoc/>
+        public async Task<OperationResult> DeleteTriggerAsync(string templateId, SessionTrigger trigger)
+        {
+            var result = await httpClient.PostAsJsonAsync<DeleteTriggerRequest>($"api/templates/triggers/delete", new DeleteTriggerRequest(templateId, trigger));
+            return await OperationResult.FromResponseAsync(result);
+        }
+
+        /// <inheritdoc/>
+        public async Task<OperationResult> UpdateTriggerAsync(string templateId, SessionTrigger original, SessionTrigger modified)
+        {            
+            var result = await httpClient.PutAsJsonAsync<UpdateTriggerRequest>($"api/templates/triggers/update", new UpdateTriggerRequest(templateId, original, modified));
+            return await OperationResult.FromResponseAsync(result);
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Shared/NavMenu.razor
+++ b/src/Pixel.Automation.Web.Portal/Shared/NavMenu.razor
@@ -1,5 +1,6 @@
 ﻿<MudNavLink Href="./" Match="NavLinkMatch.All" Icon="@Icons.Material.Outlined.Home">Home</MudNavLink>
 <MudNavLink Href="./sessions" Icon="@Icons.Material.Outlined.ViewList">Sessions</MudNavLink>
+<MudNavLink Href="./templates/list" Icon="@Icons.Material.Outlined.ViewList">Templates</MudNavLink>
 <MudNavGroup Title="Statistics" Icon="@Icons.Material.Outlined.Dashboard" Expanded="true">
     <MudNavLink Href="./project-statistics">Project</MudNavLink>
     <MudNavLink Href="./test-statistics">Test</MudNavLink>

--- a/src/Pixel.Automation.Web.Portal/_Imports.razor
+++ b/src/Pixel.Automation.Web.Portal/_Imports.razor
@@ -19,3 +19,4 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using Pixel.Persistence.Core.Security
 @using Microsoft.AspNetCore.Authorization
+@using Blazored.FluentValidation

--- a/src/Pixel.Persistence.Core/Models/SessionTemplate.cs
+++ b/src/Pixel.Persistence.Core/Models/SessionTemplate.cs
@@ -1,5 +1,6 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 
@@ -32,7 +33,14 @@ namespace Pixel.Persistence.Core.Models
         [Required]
         [DataMember]
         public string ProjectName { get; set; }
-      
+
+        /// <summary>
+        /// Version of the Project to use
+        /// </summary>
+        [Required]
+        [DataMember]
+        public string TargetVersion { get; set; }
+        
         /// <summary>
         /// Query script for selecting the tests
         /// </summary>
@@ -46,6 +54,12 @@ namespace Pixel.Persistence.Core.Models
         /// </summary>
         [DataMember(IsRequired = false)]
         public string InitializeScript { get; set; }
+
+        /// <summary>
+        /// Trigger associated with the template 
+        /// </summary>
+        [DataMember(IsRequired = false)]
+        public List<SessionTrigger> Triggers { get; set; } = new();
      
     }
 }

--- a/src/Pixel.Persistence.Core/Models/SessionTrigger.cs
+++ b/src/Pixel.Persistence.Core/Models/SessionTrigger.cs
@@ -1,0 +1,70 @@
+﻿using MongoDB.Bson.Serialization.Attributes;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace Pixel.Persistence.Core.Models
+{
+    /// <summary>
+    /// Defines a trigger that can be used to initiate execution of the template 
+    /// </summary>
+    [DataContract] 
+    [JsonDerivedType(typeof(CronSessionTrigger), typeDiscriminator: nameof(CronSessionTrigger))]
+    [BsonKnownTypes(typeof(CronSessionTrigger))]
+    public abstract class SessionTrigger : ICloneable, IEquatable<SessionTrigger>
+    {      
+        /// <summary>
+        /// Identifies the handler that will be used to execute the template when trigger occurs
+        /// </summary>
+        [Required]
+        [DataMember]
+        public string Handler { get; set; }
+
+        /// <summary>
+        /// Indicates if trigger is enabled
+        /// </summary>
+        [Required]
+        [DataMember]
+        public bool IsEnabled { get; set; } = true;
+
+        public abstract object Clone();
+
+        public abstract bool Equals(SessionTrigger other);
+        
+    }
+
+    /// <summary>
+    /// Trigger based on a cron expression to execute template on a scheduled basis
+    /// </summary>
+    [DataContract]
+    public class CronSessionTrigger : SessionTrigger, IEquatable<CronSessionTrigger>
+    {  
+        /// <summary>
+        /// Cron expression
+        /// </summary>
+        [Required]
+        [DataMember]
+        public string CronExpression { get; set; }
+
+        public override object Clone()
+        {
+            return new CronSessionTrigger()
+            {
+                Handler = this.Handler,
+                IsEnabled = this.IsEnabled,
+                CronExpression = this.CronExpression
+            };
+        }
+
+        public override bool Equals(SessionTrigger other)
+        {
+            return other is CronSessionTrigger cst && cst.Handler.Equals(this.Handler) && cst.CronExpression.Equals(this.CronExpression);
+        }
+
+        public bool Equals(CronSessionTrigger other)
+        {
+            return this.Equals(other);
+        }
+    }
+}

--- a/src/Pixel.Persistence.Core/Models/SessionTrigger.cs
+++ b/src/Pixel.Persistence.Core/Models/SessionTrigger.cs
@@ -13,7 +13,14 @@ namespace Pixel.Persistence.Core.Models
     [JsonDerivedType(typeof(CronSessionTrigger), typeDiscriminator: nameof(CronSessionTrigger))]
     [BsonKnownTypes(typeof(CronSessionTrigger))]
     public abstract class SessionTrigger : ICloneable, IEquatable<SessionTrigger>
-    {      
+    {
+        /// <summary>
+        /// Display name for the trigger
+        /// </summary>
+        [Required]
+        [DataMember]
+        public string Name { get; set; }
+
         /// <summary>
         /// Identifies the handler that will be used to execute the template when trigger occurs
         /// </summary>
@@ -51,6 +58,7 @@ namespace Pixel.Persistence.Core.Models
         {
             return new CronSessionTrigger()
             {
+                Name = this.Name,
                 Handler = this.Handler,
                 IsEnabled = this.IsEnabled,
                 CronExpression = this.CronExpression
@@ -59,7 +67,8 @@ namespace Pixel.Persistence.Core.Models
 
         public override bool Equals(SessionTrigger other)
         {
-            return other is CronSessionTrigger cst && cst.Handler.Equals(this.Handler) && cst.CronExpression.Equals(this.CronExpression);
+            return other is CronSessionTrigger cst && cst.Name.Equals(this.Name) &&
+                cst.Handler.Equals(this.Handler) && cst.CronExpression.Equals(this.CronExpression);
         }
 
         public bool Equals(CronSessionTrigger other)

--- a/src/Pixel.Persistence.Core/Request/GetProjectRequest.cs
+++ b/src/Pixel.Persistence.Core/Request/GetProjectRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Pixel.Persistence.Core.Request
+{
+    public class GetProjectRequest : PagedDataRequest
+    {
+        public string ProjectFilter { get; set; }
+    }
+
+}

--- a/src/Pixel.Persistence.Core/Request/GetTemplatesRequest.cs
+++ b/src/Pixel.Persistence.Core/Request/GetTemplatesRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace Pixel.Persistence.Core.Request
+{
+    public class GetTemplatesRequest : PagedDataRequest
+    {
+        public string TemplateFilter { get; set; }
+    }
+}

--- a/src/Pixel.Persistence.Core/Request/PagedDataRequest.cs
+++ b/src/Pixel.Persistence.Core/Request/PagedDataRequest.cs
@@ -1,0 +1,59 @@
+﻿using System.Runtime.Serialization;
+
+namespace Pixel.Persistence.Core.Request
+{
+    /// <summary>
+    /// Base class for a paged data request
+    /// </summary>
+    [DataContract]
+    public class PagedDataRequest
+    {
+        protected readonly int maxPageSize = 50;
+
+        private int currentPage;
+        /// <summary>
+        /// Current page for the request
+        /// </summary>
+        [DataMember(IsRequired = true)]
+        public int CurrentPage
+        {
+            get => currentPage;
+            set
+            {
+                if (value >= 1)
+                {
+                    currentPage = value;
+                }
+            }
+        }
+
+        private int pagesSize = 10;
+        /// <summary>
+        /// Page size for the request
+        /// </summary>
+        [DataMember(IsRequired = true)]
+        public int PageSize
+        {
+            get
+            {
+                return pagesSize;
+            }
+            set
+            {
+                pagesSize = (value > maxPageSize) ? maxPageSize : value;
+            }
+        }
+
+        /// <summary>
+        /// Number of items to skip
+        /// </summary>
+        [IgnoreDataMember]
+        public int Skip => (CurrentPage - 1) * PageSize;
+
+        /// <summary>
+        /// Number of items to take
+        /// </summary>
+        [IgnoreDataMember]
+        public int Take => PageSize;
+    }
+}

--- a/src/Pixel.Persistence.Core/Request/TriggerRequests.cs
+++ b/src/Pixel.Persistence.Core/Request/TriggerRequests.cs
@@ -1,0 +1,10 @@
+﻿using Pixel.Persistence.Core.Models;
+
+namespace Pixel.Persistence.Core.Request
+{
+    public record AddTriggerRequest(string TemplateId, SessionTrigger Trigger);
+   
+    public record UpdateTriggerRequest(string TemplateId, SessionTrigger Original, SessionTrigger Updated);
+
+    public record DeleteTriggerRequest(string TemplateId, SessionTrigger Trigger);
+}

--- a/src/Pixel.Persistence.Core/Request/TriggerRequests.cs
+++ b/src/Pixel.Persistence.Core/Request/TriggerRequests.cs
@@ -5,6 +5,4 @@ namespace Pixel.Persistence.Core.Request
     public record AddTriggerRequest(string TemplateId, SessionTrigger Trigger);
    
     public record UpdateTriggerRequest(string TemplateId, SessionTrigger Original, SessionTrigger Updated);
-
-    public record DeleteTriggerRequest(string TemplateId, SessionTrigger Trigger);
 }

--- a/src/Pixel.Persistence.Respository/Interfaces/ITemplateRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/ITemplateRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Pixel.Persistence.Core.Models;
+using Pixel.Persistence.Core.Request;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -22,6 +23,13 @@ namespace Pixel.Persistence.Respository
         /// <param name="name">Name of the SessionTemplate</param>
         /// <returns>SessionTemplate with matching Name</returns>
         Task<SessionTemplate> GetByNameAsync(string name);
+
+        /// <summary>
+        /// Get all templates matching request parameters
+        /// </summary>
+        /// <param name="queryParameter"></param>
+        /// <returns></returns>
+        Task<IEnumerable<SessionTemplate>> GetTemplatesAsync(GetTemplatesRequest queryParameter);
 
         /// <summary>
         /// Get all the <see cref="SessionTemplate"/> stored in database
@@ -48,6 +56,22 @@ namespace Pixel.Persistence.Respository
         /// </summary>
         /// <param name="id">Id of the SessionTemplate to be deleted</param>
         /// <returns></returns>
-        Task<bool> TryDeleteAsync(string id);       
+        Task<bool> TryDeleteAsync(string id);
+
+        /// <summary>
+        /// Add a new trigger to the template
+        /// </summary>
+        /// <param name="template"></param>
+        /// <param name="trigger"></param>
+        /// <returns></returns>
+        Task AddTriggerAsync(SessionTemplate template, SessionTrigger trigger);
+
+        /// <summary>
+        /// Delete an existing trigger from template
+        /// </summary>
+        /// <param name="template"></param>
+        /// <param name="trigger"></param>
+        /// <returns></returns>
+        Task DeleteTriggerAsync(SessionTemplate template, SessionTrigger trigger);
     }
 }

--- a/src/Pixel.Persistence.Services.Api/Controllers/TemplatesController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/TemplatesController.cs
@@ -1,12 +1,17 @@
 ﻿using Dawn;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Pixel.Automation.Web.Portal.Helpers;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Core.Request;
 using Pixel.Persistence.Core.Response;
 using Pixel.Persistence.Respository;
+using Pixel.Persistence.Services.Api.Jobs;
+using Quartz;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Pixel.Persistence.Services.Api.Controllers
@@ -15,11 +20,16 @@ namespace Pixel.Persistence.Services.Api.Controllers
     [ApiController]
     public class TemplatesController : ControllerBase
     {
-        private readonly ITemplateRepository templateRepository;
+        private readonly ILogger logger;
+        private readonly ITemplateRepository templateRepository;       
+        private readonly IJobManager jobManager;
 
-        public TemplatesController(ITemplateRepository templateRepository)
+        public TemplatesController(ILogger<TemplatesController> logger, ITemplateRepository templateRepository, 
+           IJobManager jobManager)
         {
-            this.templateRepository = templateRepository;
+            this.logger = Guard.Argument(logger, nameof(logger)).NotNull().Value;
+            this.templateRepository = Guard.Argument(templateRepository, nameof(templateRepository)).NotNull().Value;     
+            this.jobManager =  Guard.Argument(jobManager, nameof(jobManager)).NotNull().Value;
         }
 
         // GET: api/TestSession/5
@@ -117,6 +127,19 @@ namespace Pixel.Persistence.Services.Api.Controllers
                     return BadRequest(new BadRequestResponse(new[] { "Trigger with same details already exists for template" }));
                 }
                 await templateRepository.AddTriggerAsync(template, addTriggerRequest.Trigger);
+                logger.LogInformation("A new trigger @{0} was added to template {1}", addTriggerRequest.Trigger, template.Name);
+                if(addTriggerRequest.Trigger is CronSessionTrigger cronSessionTrigger && cronSessionTrigger.IsEnabled)
+                {
+                    try
+                    {
+                       await jobManager.AddCronJobAsync(template, cronSessionTrigger);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "An error occured while trying to schedule a new job for trigger : {0} beloning to template {1}", cronSessionTrigger.Name, template.Name);
+                        return Problem($"An error occured while trying to schedule job for trigger. {ex.Message}");
+                    }
+                }               
                 return Ok();
             }
             return NotFound(new NotFoundResponse($"Template with Id: {addTriggerRequest.TemplateId} not found."));
@@ -133,7 +156,12 @@ namespace Pixel.Persistence.Services.Api.Controllers
                 if (template.Triggers.Any(a => a.Equals(updateTriggerRequest.Original)))
                 {
                     await templateRepository.DeleteTriggerAsync(template, updateTriggerRequest.Original);
+                    await jobManager.DeleteTriggerAsync(template, updateTriggerRequest.Original);
                     await templateRepository.AddTriggerAsync(template, updateTriggerRequest.Updated);
+                    if(updateTriggerRequest.Updated is CronSessionTrigger cronSessionTrigger)
+                    {
+                        await jobManager.AddCronJobAsync(template, cronSessionTrigger);
+                    }
                     return Ok();
                 }
                 return NotFound(new NotFoundResponse($"No matching trigger was found to  update"));
@@ -141,21 +169,29 @@ namespace Pixel.Persistence.Services.Api.Controllers
             return NotFound(new NotFoundResponse($"Template with Id: {updateTriggerRequest.TemplateId} not found."));
         }
 
-        [HttpDelete("triggers/delete")]
-        public async Task<IActionResult> DeleteTriggerFromTemplate( [FromBody] DeleteTriggerRequest deleteTriggerRequest)
+        [HttpDelete("triggers/delete/{templateId}/{triggerName}")]
+        public async Task<IActionResult> DeleteTriggerFromTemplate(string templateId, string triggerName)
         {          
-            Guard.Argument(deleteTriggerRequest, nameof(deleteTriggerRequest)).NotNull();
-            var template = await templateRepository.GetByIdAsync(deleteTriggerRequest.TemplateId);
+            Guard.Argument(templateId, nameof(templateId)).NotNull().NotEmpty();
+            Guard.Argument(triggerName, nameof(triggerName)).NotNull().NotEmpty();
+            var template = await templateRepository.GetByIdAsync(templateId);
             if (template != null)
             {
-                if (template.Triggers.Any(a => a.Equals(deleteTriggerRequest.Trigger)))
+                if (template.Triggers.Any(a => a.Name.Equals(triggerName)))
                 {
-                    await templateRepository.DeleteTriggerAsync(template, deleteTriggerRequest.Trigger);
+                    var triggerToDelete = template.Triggers.First(t => t.Name.Equals(triggerName));
+                    await templateRepository.DeleteTriggerAsync(template, triggerToDelete);
+                    logger.LogInformation("Deleted trigger {0} from template {1}", triggerToDelete.Name, template.Name);
+                    bool wasJobDeleted = await jobManager.DeleteTriggerAsync(template, triggerToDelete);
+                    if(!wasJobDeleted)
+                    {                     
+                        return NotFound(new NotFoundResponse($"Trigger was deleted. However, job associated with trigger could not be deleted."));
+                    }                                          
                     return Ok();
                 }
                 return NotFound(new NotFoundResponse($"No matching trigger was found to  delete"));
             }
-            return NotFound(new NotFoundResponse($"Template with Id: {deleteTriggerRequest.TemplateId} not found."));
+            return NotFound(new NotFoundResponse($"Template with Id: {templateId} not found."));
         }
     }
 }

--- a/src/Pixel.Persistence.Services.Api/Jobs/JobManager.cs
+++ b/src/Pixel.Persistence.Services.Api/Jobs/JobManager.cs
@@ -1,0 +1,95 @@
+﻿using Dawn;
+using Microsoft.Extensions.Logging;
+using Pixel.Persistence.Core.Models;
+using Quartz;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pixel.Persistence.Services.Api.Jobs
+{
+    public interface IJobManager
+    {
+        Task<DateTimeOffset> AddCronJobAsync(SessionTemplate template, CronSessionTrigger cronSessionTrigger);
+        Task<bool> DeleteTriggerAsync(SessionTemplate template, SessionTrigger sessionTrigger);
+        Task PauseTriggerAsync(SessionTemplate template, SessionTrigger sessionTrigger);
+        Task ResumeTriggerAsync(SessionTemplate template, SessionTrigger sessionTrigger);
+        Task UpdateCronJobAsync(SessionTemplate template, CronSessionTrigger cronSessionTrigger);
+    }
+
+    public class JobManager : IJobManager
+    {
+        private readonly ISchedulerFactory schedulerFactory;
+        private readonly ILogger logger;
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="scheduler"></param>
+        public JobManager(ILogger<JobManager> logger, ISchedulerFactory schedulerFactory)
+        {
+            this.logger = Guard.Argument(logger, nameof(logger)).NotNull().Value;
+            this.schedulerFactory = Guard.Argument(schedulerFactory, nameof(schedulerFactory)).NotNull().Value;
+        }
+
+        public async Task<DateTimeOffset> AddCronJobAsync(SessionTemplate template, CronSessionTrigger cronSessionTrigger)
+        {
+            var scheduler = await this.schedulerFactory.GetScheduler();
+            JobKey jobKey = new JobKey(template.Name, template.Name);
+            var job = await scheduler.GetJobDetail(jobKey);
+            if (job == null)
+            {
+                job = JobBuilder.Create<SendTriggerNotificationJob>()
+                   .WithIdentity(jobKey).StoreDurably(true)
+                   .UsingJobData("template-name", template.Name)
+                   .Build();
+                await scheduler.AddJob(job, true);
+                logger.LogInformation("Created a new quartz job for template : {0}", template.Name);
+            }
+            var trigger = TriggerBuilder.Create().WithIdentity(cronSessionTrigger.Name, template.Name)
+                .UsingJobData("handler-key", cronSessionTrigger.Handler)
+                .ForJob(job).WithCronSchedule(cronSessionTrigger.CronExpression).StartNow().Build();
+            logger.LogInformation("Created a new trigger job for job : {0}, trigger : {1}", template.Name, cronSessionTrigger.Name);
+            return await scheduler.ScheduleJob(trigger, CancellationToken.None);
+        }
+
+        public async Task UpdateCronJobAsync(SessionTemplate template, CronSessionTrigger cronSessionTrigger)
+        {
+            await DeleteTriggerAsync(template, cronSessionTrigger);
+            await AddCronJobAsync(template, cronSessionTrigger);
+        }
+
+        public async Task<bool> DeleteTriggerAsync(SessionTemplate template, SessionTrigger sessionTrigger)
+        {
+            var scheduler = await this.schedulerFactory.GetScheduler();
+            var triggerKey = new TriggerKey(sessionTrigger.Name, template.Name);
+            bool wasRemoved = await scheduler.UnscheduleJob(triggerKey);
+            if(wasRemoved)
+            {
+                logger.LogInformation("Trigger {0} was deleted from job {1}", sessionTrigger.Name, template.Name);
+            }
+            else
+            {
+                logger.LogWarning("Trigger {0} could not be deleted from job {1}", sessionTrigger.Name, template.Name);
+            }
+            return wasRemoved;
+        }
+
+        public async Task PauseTriggerAsync(SessionTemplate template, SessionTrigger sessionTrigger)
+        {
+            var scheduler = await this.schedulerFactory.GetScheduler();
+            var triggerKey = new TriggerKey(sessionTrigger.Name, template.Name);
+            await scheduler.PauseTrigger(triggerKey);
+            logger.LogInformation("Trigger {0} was paused for job {1}", sessionTrigger.Name, template.Name);
+        }
+
+        public async Task ResumeTriggerAsync(SessionTemplate template, SessionTrigger sessionTrigger)
+        {
+            var scheduler = await this.schedulerFactory.GetScheduler();
+            var triggerKey = new TriggerKey(sessionTrigger.Name, template.Name);
+            await scheduler.ResumeTrigger(triggerKey);
+            logger.LogInformation("Trigger {0} was resumed for job {1}", sessionTrigger.Name, template.Name);
+        }
+
+    }
+}

--- a/src/Pixel.Persistence.Services.Api/Jobs/RedisConnectionFactory.cs
+++ b/src/Pixel.Persistence.Services.Api/Jobs/RedisConnectionFactory.cs
@@ -1,0 +1,71 @@
+﻿using Dawn;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using StackExchange.Redis;
+using System;
+
+namespace Pixel.Persistence.Services.Api.Jobs
+{
+    public interface IRedisConnectionFactory
+    {
+        ConnectionMultiplexer GetOrCreateConnectionMultiplexer();
+    }
+
+    public class RedisConnectionFactory : IRedisConnectionFactory
+    {
+        private readonly string connectionStringKey = "RedisConnectionString";
+        private readonly ILogger logger;
+        private readonly IConfiguration configuration;
+        private readonly IChangeToken changeToken;
+        private ConnectionMultiplexer multiplexer;
+
+        public RedisConnectionFactory(ILogger<RedisConnectionFactory> logger, IConfiguration configuration)
+        {
+            this.logger = Guard.Argument(logger, nameof(logger)).NotNull().Value;
+            this.configuration = Guard.Argument(configuration, nameof(configuration)).NotNull().Value;
+            this.changeToken = this.configuration.GetReloadToken();
+        }
+
+        public ConnectionMultiplexer GetOrCreateConnectionMultiplexer()
+        {
+            if (multiplexer != null && !this.changeToken.HasChanged)
+            {
+                return multiplexer;
+            }
+            string redisConnectionString = this.configuration[connectionStringKey];
+            try
+            {
+                if (this.multiplexer != null)
+                {
+                    this.multiplexer.ConnectionFailed -= OnConnectionFailed;
+                    this.multiplexer.ConnectionRestored -= OnConnectionRestored;
+                    this.multiplexer.Dispose();
+                    logger.LogInformation("Existing redis connection was disposed");
+                }
+                if (!string.IsNullOrEmpty(redisConnectionString))
+                {
+                    this.multiplexer = ConnectionMultiplexer.Connect(redisConnectionString);
+                    this.multiplexer.ConnectionFailed += OnConnectionFailed;
+                    this.multiplexer.ConnectionRestored += OnConnectionRestored;
+                    logger.LogInformation("A new redis connection was established to : {0}", redisConnectionString);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "An error occured while trying to connect to redis instance : {0}", redisConnectionString);
+            }
+            return this.multiplexer;
+        }
+
+        private void OnConnectionRestored(object sender, ConnectionFailedEventArgs e)
+        {
+            logger.LogInformation("Redis connection is restored now");
+        }
+
+        private void OnConnectionFailed(object sender, ConnectionFailedEventArgs e)
+        {
+            logger.LogInformation("Redis connection is disconnected now");
+        }
+    }
+}

--- a/src/Pixel.Persistence.Services.Api/Jobs/SendTriggerNotificationJob.cs
+++ b/src/Pixel.Persistence.Services.Api/Jobs/SendTriggerNotificationJob.cs
@@ -1,0 +1,50 @@
+﻿using Dawn;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Quartz;
+using StackExchange.Redis;
+using System;
+using System.Threading.Tasks;
+
+namespace Pixel.Persistence.Services.Api.Jobs
+{
+    public class SendTriggerNotificationJob : IJob
+    {
+        private readonly ILogger logger;
+        private readonly string redisConnectionString;
+        private readonly ConnectionMultiplexer connection;
+       
+        public SendTriggerNotificationJob(ILogger<SendTriggerNotificationJob> logger, IConfiguration configuration)
+        {
+            this.logger = Guard.Argument(logger, nameof(logger)).NotNull().Value;
+            Guard.Argument(configuration, nameof(configuration)).NotNull();
+            this.redisConnectionString = configuration["RedisConnectionString"] ?? string.Empty;
+            if(!string.IsNullOrEmpty(redisConnectionString) )
+            {
+                try
+                {
+                    this.connection = ConnectionMultiplexer.Connect(this.redisConnectionString);
+                    logger.LogInformation("Redis connection established to : {0}", this.redisConnectionString);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "An error occured while connecting to redis instance : {0}", this.redisConnectionString);
+                }
+                return;
+            }
+            logger.LogWarning("Redis connection could not be established to : {0}. No template executions message will be sent on trigger activations.", this.redisConnectionString);
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            var dataMap = context.MergedJobDataMap;
+            if(this.connection != null)
+            {
+                var pubsub = connection.GetSubscriber();
+                var redisChannel = new RedisChannel(dataMap.Get("handler-key").ToString(), RedisChannel.PatternMode.Literal);
+                await pubsub.PublishAsync(redisChannel, dataMap.Get("template-name").ToString(), CommandFlags.FireAndForget);
+                logger.LogInformation($"Send notification for executing {dataMap.Get("template-name")} to channel {dataMap.Get("handler-key")}");
+            }           
+        }
+    }
+}

--- a/src/Pixel.Persistence.Services.Api/Jobs/SendTriggerNotificationJob.cs
+++ b/src/Pixel.Persistence.Services.Api/Jobs/SendTriggerNotificationJob.cs
@@ -1,49 +1,35 @@
 ﻿using Dawn;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Quartz;
 using StackExchange.Redis;
-using System;
 using System.Threading.Tasks;
 
 namespace Pixel.Persistence.Services.Api.Jobs
 {
     public class SendTriggerNotificationJob : IJob
     {
-        private readonly ILogger logger;
-        private readonly string redisConnectionString;
-        private readonly ConnectionMultiplexer connection;
+        private readonly ILogger logger;       
+        private readonly IRedisConnectionFactory connectionFactory;
        
-        public SendTriggerNotificationJob(ILogger<SendTriggerNotificationJob> logger, IConfiguration configuration)
+        public SendTriggerNotificationJob(ILogger<SendTriggerNotificationJob> logger, IRedisConnectionFactory connectionFactory)
         {
             this.logger = Guard.Argument(logger, nameof(logger)).NotNull().Value;
-            Guard.Argument(configuration, nameof(configuration)).NotNull();
-            this.redisConnectionString = configuration["RedisConnectionString"] ?? string.Empty;
-            if(!string.IsNullOrEmpty(redisConnectionString) )
-            {
-                try
-                {
-                    this.connection = ConnectionMultiplexer.Connect(this.redisConnectionString);
-                    logger.LogInformation("Redis connection established to : {0}", this.redisConnectionString);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "An error occured while connecting to redis instance : {0}", this.redisConnectionString);
-                }
-                return;
-            }
-            logger.LogWarning("Redis connection could not be established to : {0}. No template executions message will be sent on trigger activations.", this.redisConnectionString);
+            this.connectionFactory = Guard.Argument(connectionFactory, nameof(connectionFactory)).NotNull().Value;           
         }
 
         public async Task Execute(IJobExecutionContext context)
         {
             var dataMap = context.MergedJobDataMap;
-            if(this.connection != null)
+            string template = dataMap.Get("template-name").ToString();
+            string handler = dataMap.Get("handler-key").ToString();
+            logger.LogInformation("Trigger activated for template : {0}, handler : {1}", template, handler);
+            var connection = this.connectionFactory.GetOrCreateConnectionMultiplexer();
+            if(connection  != null)
             {
                 var pubsub = connection.GetSubscriber();
-                var redisChannel = new RedisChannel(dataMap.Get("handler-key").ToString(), RedisChannel.PatternMode.Literal);
-                await pubsub.PublishAsync(redisChannel, dataMap.Get("template-name").ToString(), CommandFlags.FireAndForget);
-                logger.LogInformation($"Send notification for executing {dataMap.Get("template-name")} to channel {dataMap.Get("handler-key")}");
+                var redisChannel = new RedisChannel(handler, RedisChannel.PatternMode.Literal);
+                await pubsub.PublishAsync(redisChannel, template, CommandFlags.FireAndForget);
+                logger.LogInformation($"Send notification for executing {template} to channel {handler}");
             }           
         }
     }

--- a/src/Pixel.Persistence.Services.Api/Pixel.Persistence.Services.Api.csproj
+++ b/src/Pixel.Persistence.Services.Api/Pixel.Persistence.Services.Api.csproj
@@ -27,7 +27,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.6" />
+	<PackageReference Include="Quartz" Version="3.6.2" />
+	<PackageReference Include="Quartz.AspNetCore" Version="3.6.2" />
+	<PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.6.2" />
+	<PackageReference Include="Quartz.Extensions.Hosting" Version="3.6.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.104" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />

--- a/src/Pixel.Persistence.Services.Api/Services/QuartzJobBuilderService.cs
+++ b/src/Pixel.Persistence.Services.Api/Services/QuartzJobBuilderService.cs
@@ -1,0 +1,62 @@
+﻿using Dawn;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Pixel.Persistence.Core.Models;
+using Pixel.Persistence.Respository;
+using Pixel.Persistence.Services.Api.Jobs;
+using Quartz;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pixel.Persistence.Services.Api.Services
+{
+    public class QuartzJobBuilderService : IHostedService
+    {
+        private readonly ILogger logger;
+        private readonly ITemplateRepository templateRepository;
+        private readonly ISchedulerFactory schedulerFactory;
+
+        public QuartzJobBuilderService(ILogger<QuartzJobBuilderService> logger, ITemplateRepository templateRepository, ISchedulerFactory schedulerFactory)
+        {
+            this.logger = Guard.Argument(logger, nameof(logger)).NotNull().Value;
+            this.templateRepository = Guard.Argument(templateRepository, nameof(templateRepository)).NotNull().Value;
+            this.schedulerFactory = Guard.Argument(schedulerFactory, nameof(schedulerFactory)).NotNull().Value;           
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            var scheduler = await schedulerFactory.GetScheduler();
+            var templates = await this.templateRepository.GetAllAsync();
+            foreach (var template in templates)
+            {
+                foreach (var sessionTriger in template.Triggers.OfType<CronSessionTrigger>())
+                {
+                    try
+                    {
+                        logger.LogInformation("Creating a quartz job and trigger for {0} -> {1} with cron expression : {2}", template.Name, sessionTriger.Name, sessionTriger.CronExpression);
+                        JobKey sendNotificationJob = new JobKey(sessionTriger.Name, template.Name);
+                        var job = JobBuilder.Create<SendTriggerNotificationJob>()
+                               .WithIdentity(sendNotificationJob)
+                               .UsingJobData("template-name", template.Name)
+                               .UsingJobData("handler-key", sessionTriger.Handler)
+                               .Build();
+                        var trigger = TriggerBuilder.Create().ForJob(job).WithCronSchedule(sessionTriger.CronExpression).Build();
+                        await scheduler.ScheduleJob(job, trigger, cancellationToken);
+                        logger.LogInformation("Job is now scheduled for {0} -> {1}", template.Name, sessionTriger.Name);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "An exception occured while trying to create a quart job and trigger for {0} -> {1}", template.Name, sessionTriger.Name);                     
+                    }
+                }
+            }
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/src/Pixel.Persistence.Services.Api/Services/QuartzJobBuilderService.cs
+++ b/src/Pixel.Persistence.Services.Api/Services/QuartzJobBuilderService.cs
@@ -15,19 +15,19 @@ namespace Pixel.Persistence.Services.Api.Services
     public class QuartzJobBuilderService : IHostedService
     {
         private readonly ILogger logger;
-        private readonly ITemplateRepository templateRepository;
-        private readonly ISchedulerFactory schedulerFactory;
+        private readonly ITemplateRepository templateRepository;       
+        private readonly IJobManager jobManager;
 
-        public QuartzJobBuilderService(ILogger<QuartzJobBuilderService> logger, ITemplateRepository templateRepository, ISchedulerFactory schedulerFactory)
+        public QuartzJobBuilderService(ILogger<QuartzJobBuilderService> logger, ITemplateRepository templateRepository,
+            IJobManager jobManager)
         {
             this.logger = Guard.Argument(logger, nameof(logger)).NotNull().Value;
-            this.templateRepository = Guard.Argument(templateRepository, nameof(templateRepository)).NotNull().Value;
-            this.schedulerFactory = Guard.Argument(schedulerFactory, nameof(schedulerFactory)).NotNull().Value;           
+            this.templateRepository = Guard.Argument(templateRepository, nameof(templateRepository)).NotNull().Value;           
+            this.jobManager = Guard.Argument(jobManager, nameof(jobManager)).NotNull().Value;   
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            var scheduler = await schedulerFactory.GetScheduler();
             var templates = await this.templateRepository.GetAllAsync();
             foreach (var template in templates)
             {
@@ -35,16 +35,7 @@ namespace Pixel.Persistence.Services.Api.Services
                 {
                     try
                     {
-                        logger.LogInformation("Creating a quartz job and trigger for {0} -> {1} with cron expression : {2}", template.Name, sessionTriger.Name, sessionTriger.CronExpression);
-                        JobKey sendNotificationJob = new JobKey(sessionTriger.Name, template.Name);
-                        var job = JobBuilder.Create<SendTriggerNotificationJob>()
-                               .WithIdentity(sendNotificationJob)
-                               .UsingJobData("template-name", template.Name)
-                               .UsingJobData("handler-key", sessionTriger.Handler)
-                               .Build();
-                        var trigger = TriggerBuilder.Create().ForJob(job).WithCronSchedule(sessionTriger.CronExpression).Build();
-                        await scheduler.ScheduleJob(job, trigger, cancellationToken);
-                        logger.LogInformation("Job is now scheduled for {0} -> {1}", template.Name, sessionTriger.Name);
+                        await jobManager.AddCronJobAsync(template, sessionTriger);                       
                     }
                     catch (Exception ex)
                     {

--- a/src/Pixel.Persistence.Services.Api/Startup.cs
+++ b/src/Pixel.Persistence.Services.Api/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Respository;
 using Pixel.Persistence.Respository.Interfaces;
+using Pixel.Persistence.Services.Api.Jobs;
 using Pixel.Persistence.Services.Api.Services;
 using Quartz;
 using Serilog;
@@ -36,7 +37,9 @@ namespace Pixel.Persistence.Services.Api
             services.Configure<MongoDbSettings>(Configuration.GetSection(nameof(MongoDbSettings)));
             services.Configure<RetentionPolicy>(Configuration.GetSection(nameof(RetentionPolicy)));
             services.AddSingleton<IMongoDbSettings>(sp => sp.GetRequiredService<IOptions<MongoDbSettings>>().Value);
-            services.AddSingleton<RetentionPolicy>(sp => sp.GetRequiredService<IOptions<RetentionPolicy>>().Value);  
+            services.AddSingleton<RetentionPolicy>(sp => sp.GetRequiredService<IOptions<RetentionPolicy>>().Value);
+            services.AddSingleton<IJobManager, JobManager>();
+            services.AddSingleton<IRedisConnectionFactory, RedisConnectionFactory>();
             services.AddTransient<ITestSessionRepository, TestSessionRespository>();
             services.AddTransient<ITestResultsRepository, TestResultsRepository>();
             services.AddTransient<ITestStatisticsRepository, TestStatisticsRepository>();
@@ -52,7 +55,7 @@ namespace Pixel.Persistence.Services.Api
             services.AddTransient<ITestDataRepository, TestDataRepository>();           
             services.AddTransient<IPrefabsRepository, PrefabsRepository>();
             services.AddTransient<ITemplateRepository, TemplateRepository>();                      
-          
+           
             services.AddControllers();
             services.AddRazorPages();
 

--- a/src/Pixel.Persistence.Services.Api/Startup.cs
+++ b/src/Pixel.Persistence.Services.Api/Startup.cs
@@ -57,8 +57,12 @@ namespace Pixel.Persistence.Services.Api
             services.AddControllers();
             services.AddRazorPages();
 
-            services.AddSwaggerGen();
-            services.AddHostedService<StatisticsProcessorService>();           
+            services.AddSwaggerGen(c =>
+            {
+                c.UseOneOfForPolymorphism();
+            });
+ 
+             services.AddHostedService<StatisticsProcessorService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Pixel.Persistence.Services.Api/appsettings.Development.json
+++ b/src/Pixel.Persistence.Services.Api/appsettings.Development.json
@@ -3,6 +3,9 @@
     "MaxNumberOfRevisions": 50,
     "MaxAgeOfRevisions": 10
   },
+  "Quartz": {
+  },
+  "RedisConnectionString": "localhost:6379",
   "MongoDbSettings": {
     "ConnectionString": "mongodb://localhost:27017",
     "DatabaseName": "pixel-automation-db",


### PR DESCRIPTION
**Description**
- Templates and triggers can be created from dashboard now
- Quartz jobs and triggers are created now for triggers configured on templates
- A notification is sent out over redis pub sub through a Quartz job whenever trigger is activated

**Why**
 - External clients can now subscribe and listen for these triggers to act on them e.g. prepare execution environment and start test execution
 - Every one will have their own environment e.g. on premise ,  clouds , docker , etc. Hence, this decoupling will make it easier for users to manage test environment and execution on their own.
 - Some clients will be provided out of the box to handle some standard environments