### PR TITLE
Cleanup configuration and removed agent project

### DIFF
--- a/Pixel.Automation.sln
+++ b/Pixel.Automation.sln
@@ -179,8 +179,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Automation.UIAComWrap
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Automation.Native.Linux", "src\Pixel.Automation.Native.Linux\Pixel.Automation.Native.Linux.csproj", "{1436F4EE-4E05-4188-9A3A-42CC8807BB71}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pixel.Automation.Server.Agent", "src\Pixel.Automation.Server.Agent\Pixel.Automation.Server.Agent.csproj", "{F8FDD21D-3CDD-4DCF-B1E1-C8D50C151282}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -463,10 +461,6 @@ Global
 		{1436F4EE-4E05-4188-9A3A-42CC8807BB71}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1436F4EE-4E05-4188-9A3A-42CC8807BB71}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1436F4EE-4E05-4188-9A3A-42CC8807BB71}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F8FDD21D-3CDD-4DCF-B1E1-C8D50C151282}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F8FDD21D-3CDD-4DCF-B1E1-C8D50C151282}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F8FDD21D-3CDD-4DCF-B1E1-C8D50C151282}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F8FDD21D-3CDD-4DCF-B1E1-C8D50C151282}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -546,7 +540,6 @@ Global
 		{89A122E5-5662-4400-BCC7-42C75A8BC4B6} = {2B0C7388-18D7-4E3C-8BDF-B7A414520615}
 		{59970211-C97D-4B93-8D13-ED34FD40C780} = {242744A0-4C9B-4B89-9AC0-4188D186D4D2}
 		{1436F4EE-4E05-4188-9A3A-42CC8807BB71} = {2B0C7388-18D7-4E3C-8BDF-B7A414520615}
-		{F8FDD21D-3CDD-4DCF-B1E1-C8D50C151282} = {29D9A408-E435-410E-86C8-D7A7D3936908}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DEAA90E2-A175-4FAA-99F1-30B64D8D3125}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -15,14 +15,6 @@ services:
       MONGO_INITDB_ROOT_USERNAME: mongoadmin
       MONGO_INITDB_ROOT_PASSWORD: mongopass     
 
-  redis-pub-sub:
-     image: redis:latest
-     container_name: pixel-redis-pub-sub
-     networks:
-       - pixel-network
-     ports:
-       - 6379:6379
-
   pixel-persistence:
     container_name: pixel-persistence-service
     env_file:
@@ -34,7 +26,6 @@ services:
       - ASPNETCORE_URLS=http://+;https://+;
       - Kestrel:Certificates:Default:Path=/etc/certs/localhost-cert.pem
       - Kestrel:Certificates:Default:KeyPath=/etc/certs/localhost-key.pem 
-      - RedisConnectionString=pixel-redis-pub-sub:6379
     volumes:
       # volume mount for providing required certificates for Kestrel (when using https)
       - ./.certificates:/etc/certs:ro

--- a/src/Pixel.Automation.Test.Runner/Dockerfile
+++ b/src/Pixel.Automation.Test.Runner/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/runtime:7.0-jammy AS base
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
@@ -21,7 +21,5 @@ WORKDIR "/pixel-automation/src/Pixel.Automation.Test.Runner"
 RUN dotnet build "Pixel.Automation.Test.Runner.csproj" -c release --runtime linux-x64 --self-contained false -p:TargetFramework=net7.0
 
 FROM base AS final
-RUN apk add --no-cache bash
 WORKDIR /pixel-run
 COPY --from=build /pixel-automation/.builds/release/Runner/net7.0/linux-x64 .
-ENTRYPOINT ["dotnet", "pixel-run.dll"]

--- a/src/Pixel.Automation.Web.Playwright.Components/Pixel.Automation.Web.Playwright.Components.csproj
+++ b/src/Pixel.Automation.Web.Playwright.Components/Pixel.Automation.Web.Playwright.Components.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="Serilog" Version="2.12.0">
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Playwright" Version="1.32.0" />
+		<PackageReference Include="Microsoft.Playwright" Version="1.33.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Pixel.Automation.Web.Selenium.Components/Pixel.Automation.Web.Selenium.Components.csproj
+++ b/src/Pixel.Automation.Web.Selenium.Components/Pixel.Automation.Web.Selenium.Components.csproj
@@ -33,8 +33,8 @@
 		<PackageReference Include="System.Dynamic.Runtime" Version="4.3.0">
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Selenium.Support" Version="4.8.2" />
-		<PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
+		<PackageReference Include="Selenium.Support" Version="4.9.1" />
+		<PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
 		<PackageReference Include="WebDriverManager" Version="2.16.2" />
 	</ItemGroup>
 

--- a/src/Pixel.Persistence.Services.Api/appsettings.Development.json
+++ b/src/Pixel.Persistence.Services.Api/appsettings.Development.json
@@ -5,7 +5,6 @@
   },
   "Quartz": {
   },
-  "RedisConnectionString": "localhost:6379",
   "MongoDbSettings": {
     "ConnectionString": "mongodb://localhost:27017",
     "DatabaseName": "pixel-automation-db",


### PR DESCRIPTION
**Description**
- Clean up redis configuration
- Updated webdriver and playwright  versions
- Use jammy as base image for pixel-run instead of alpine to run playwright automations
- Remove server agent project as we have a new repository pixel-automation-agents for them