### PR TITLE
Fix issue with publish of projects and prefabs and update of control and prefab reference

### DIFF
--- a/src/Pixel.Persistence.Respository/PrefabsRepository.cs
+++ b/src/Pixel.Persistence.Respository/PrefabsRepository.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Respository.Extensions;
 using Pixel.Persistence.Respository.Interfaces;
@@ -127,7 +128,7 @@ namespace Pixel.Persistence.Respository
                 {
                     prefabVersion.PublishedOn = DateTime.UtcNow;
                 }
-                var update = Builders<PrefabProject>.Update.Set(x => x.AvailableVersions[-1], prefabVersion)
+                var update = Builders<PrefabProject>.Update.Set(x => x.AvailableVersions.FirstMatchingElement(), prefabVersion)
                      .Set(t => t.LastUpdated, DateTime.UtcNow)
                      .Inc(t => t.Revision, 1); ;
                 await this.prefabsCollection.UpdateOneAsync(filter, update);

--- a/src/Pixel.Persistence.Respository/ProjectsRepository.cs
+++ b/src/Pixel.Persistence.Respository/ProjectsRepository.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Respository.Extensions;
 using Pixel.Persistence.Respository.Interfaces;
@@ -161,7 +162,7 @@ namespace Pixel.Persistence.Respository
                 {
                     projectVersion.PublishedOn = DateTime.UtcNow;
                 }
-                var update = Builders<AutomationProject>.Update.Set(x => x.AvailableVersions[-1], projectVersion);
+                var update = Builders<AutomationProject>.Update.Set(x => x.AvailableVersions.FirstMatchingElement(), projectVersion);
                 await this.projectsCollection.UpdateOneAsync(filter, update);
                 logger.LogInformation("Project version {0} was updated for project : {1}", projectVersion, projectId);
                 return;

--- a/src/Pixel.Persistence.Respository/ReferencesRepository.cs
+++ b/src/Pixel.Persistence.Respository/ReferencesRepository.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Respository.Extensions;
 using Pixel.Persistence.Respository.Interfaces;
@@ -85,7 +86,7 @@ public class ReferencesRepository : IReferencesRepository
     {
         var filter = Builders<ProjectReferences>.Filter.Eq(x => x.ProjectId, projectId) & Builders<ProjectReferences>.Filter.Eq(x => x.ProjectVersion, projectVersion)
                       & Builders<ProjectReferences>.Filter.ElemMatch(x => x.ControlReferences, Builders<ControlReference>.Filter.Eq(x => x.ControlId, controlReference.ControlId));
-        var update = Builders<ProjectReferences>.Update.Set(x => x.ControlReferences[-1].Version, controlReference.Version);
+        var update = Builders<ProjectReferences>.Update.Set(x => x.ControlReferences.FirstMatchingElement().Version, controlReference.Version);
         await this.referencesCollection.UpdateOneAsync(filter, update);
         logger.LogInformation("Control reference {@0} was updated for version : '{1}' of  project : {2}", controlReference, projectVersion, projectId);
 
@@ -126,7 +127,7 @@ public class ReferencesRepository : IReferencesRepository
     {
         var filter = Builders<ProjectReferences>.Filter.Eq(x => x.ProjectId, projectId) & Builders<ProjectReferences>.Filter.Eq(x => x.ProjectVersion, projectVersion)
                        & Builders<ProjectReferences>.Filter.ElemMatch(x => x.PrefabReferences, Builders<PrefabReference>.Filter.Eq(x => x.PrefabId, prefabReference.PrefabId));
-        var update = Builders<ProjectReferences>.Update.Set(x => x.PrefabReferences[-1].Version, prefabReference.Version);
+        var update = Builders<ProjectReferences>.Update.Set(x => x.PrefabReferences.FirstMatchingElement().Version, prefabReference.Version);
         await this.referencesCollection.UpdateOneAsync(filter, update);
         logger.LogInformation("Prefab reference {@0} was updated for version : '{1}' of  project : {2}", prefabReference, projectVersion, projectId);
     }


### PR DESCRIPTION
**Description**
[-1] syntax is replaced by FirstMatchingElement() in newer version of mongodb. There is an exception at runtime when using [-1] older syntax.