### PR TITLE
Agent groups for controlling which agents can process a session trigger

### DIFF
--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor
@@ -9,6 +9,8 @@
                       Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>
         <MudTextField id="txtHandler" @bind-Value="@model.Handler" Label="Handler" @onfocus="(() => error = string.Empty)"
                       Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>
+        <MudTextField id="txtGroup" @bind-Value="@model.Group" Label="Group" @onfocus="(() => error = string.Empty)"
+                      Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>
         <MudTextField id="txtCronExpression" @bind-Value="@model.CronExpression" Label="Cron Expression" @onfocus="(() => error = string.Empty)"
                       Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>
         <br />     
@@ -19,7 +21,8 @@
     </DialogContent>
     <DialogActions>
         <MudButton id="btnAddNewClaim" OnClick="AddNewTriggerAsync"
-                   Disabled="string.IsNullOrEmpty(model.Name) || string.IsNullOrEmpty(model.Handler) || string.IsNullOrEmpty(model.CronExpression)"
+                   Disabled="string.IsNullOrEmpty(model.Name) || string.IsNullOrEmpty(model.Handler) 
+                   || string.IsNullOrEmpty(model.Group) || string.IsNullOrEmpty(model.CronExpression)"
                    Color="Color.Primary" Variant="Variant.Filled">
             Add
         </MudButton>

--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor
@@ -12,17 +12,19 @@
         <MudTextField UserAttributes="@(new (){{"id","txtSearchBox"}})" @bind-Value="searchString" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
     </ToolBarContent>
     <ColGroup>
-        <col style="width:12%;" />
-        <col style="width:24%;" />
-        <col style="width:24%;" />     
-        <col style="width:24%;" />
         <col style="width:8%;" />
-        <col style="width:8%;" />
+        <col style="width:20%;" />
+        <col style="width:20%;" />     
+        <col style="width:20%;" />
+        <col style="width:20%;" />
+        <col style="width:6%;" />
+        <col style="width:6%;" />
     </ColGroup>
     <HeaderContent>
         <MudTh>Is Enabled</MudTh>
         <MudTh><MudTableSortLabel SortBy="new Func<SessionTrigger, object>(x=>x.Name)">Name</MudTableSortLabel></MudTh>
         <MudTh><MudTableSortLabel SortBy="new Func<SessionTrigger, object>(x=>x.Handler)">Handler</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortBy="new Func<SessionTrigger, object>(x=>x.Group)">Group</MudTableSortLabel></MudTh>
         <MudTh>Cron Expression</MudTh>  
         <MudTh></MudTh>
         <MudTh></MudTh>
@@ -31,6 +33,7 @@
         <MudTd UserAttributes="@(new (){{"id","tdEnabled"}})" DataLabel="">@context.IsEnabled</MudTd>
         <MudTd UserAttributes="@(new (){{"id","tdName"}})" DataLabel="Name">@context.Name</MudTd>
         <MudTd UserAttributes="@(new (){{"id","tdHandler"}})" DataLabel="Handler">@context.Handler</MudTd>
+        <MudTd UserAttributes="@(new (){{"id","tdGroup"}})" DataLabel="Group">@context.Group</MudTd>
         @if(context is CronSessionTrigger cronSessionTrigger)
         {
             <MudTd UserAttributes="@(new (){{"id","tdCronExpression"}})" DataLabel="Cron Expression">@cronSessionTrigger.CronExpression</MudTd>
@@ -53,6 +56,9 @@
         </MudTd>
         <MudTd DataLabel="Handler">
             <MudTextField UserAttributes="@(new (){{"id","txtHandler"}})" @bind-Value="@context.Handler" Required />
+        </MudTd>
+        <MudTd DataLabel="Handler">
+            <MudTextField UserAttributes="@(new (){{"id","txtGroup"}})" @bind-Value="@context.Group" Required />
         </MudTd>
         @if (context is CronSessionTrigger cronSessionTrigger)
         {

--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor.cs
@@ -63,6 +63,7 @@ namespace Pixel.Automation.Web.Portal.Components.Triggers
             {
                 sessionTrigger.Name = ebe.Name;
                 sessionTrigger.Handler = ebe.Handler;
+                sessionTrigger.Group = ebe.Group;
                 sessionTrigger.IsEnabled = ebe.IsEnabled;
                 sessionTrigger.CronExpression = ebe.CronExpression;
             }           

--- a/src/Pixel.Persistence.Core/Models/SessionTrigger.cs
+++ b/src/Pixel.Persistence.Core/Models/SessionTrigger.cs
@@ -29,6 +29,13 @@ namespace Pixel.Persistence.Core.Models
         public string Handler { get; set; }
 
         /// <summary>
+        /// Group from which an agent must be selected to process the request
+        /// </summary>
+        [Required]
+        [DataMember]
+        public string Group { get; set; }
+
+        /// <summary>
         /// Indicates if trigger is enabled
         /// </summary>
         [Required]
@@ -60,6 +67,7 @@ namespace Pixel.Persistence.Core.Models
             {
                 Name = this.Name,
                 Handler = this.Handler,
+                Group = this.Group,
                 IsEnabled = this.IsEnabled,
                 CronExpression = this.CronExpression
             };

--- a/src/Pixel.Persistence.Services.Api/Jobs/JobManager.cs
+++ b/src/Pixel.Persistence.Services.Api/Jobs/JobManager.cs
@@ -48,6 +48,7 @@ namespace Pixel.Persistence.Services.Api.Jobs
             }
             var trigger = TriggerBuilder.Create().WithIdentity(cronSessionTrigger.Name, template.Name)
                 .UsingJobData("handler-key", cronSessionTrigger.Handler)
+                .UsingJobData("agent-group", cronSessionTrigger.Group)
                 .ForJob(job).WithCronSchedule(cronSessionTrigger.CronExpression).StartNow().Build();
             logger.LogInformation("Created a new trigger job for job : {0}, trigger : {1}", template.Name, cronSessionTrigger.Name);
             return await scheduler.ScheduleJob(trigger, CancellationToken.None);

--- a/src/Pixel.Persistence.Services.Api/Jobs/ProcessTriggerJob.cs
+++ b/src/Pixel.Persistence.Services.Api/Jobs/ProcessTriggerJob.cs
@@ -36,8 +36,9 @@ namespace Pixel.Persistence.Services.Api.Jobs
                 var dataMap = context.MergedJobDataMap;
                 string template = dataMap.Get("template-name").ToString();
                 string handler = dataMap.Get("handler-key").ToString();
+                string agentGroup = dataMap.Get("agent-group").ToString();
                 logger.LogInformation("Trigger activated for template : {0}, handler : {1}", template, handler);
-                await agentManager.ExecuteTemplateAsync(template, handler, "default");
+                await agentManager.ExecuteTemplateAsync(template, handler, agentGroup);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
When defining a session trigger, we can specify a group on trigger now. Only agents that belong to this group will be picked to process this session trigger requiest.