### PR TITLE
Document as base class

### DIFF
--- a/src/Pixel.Automation.Test.Runner/ProjectManager.cs
+++ b/src/Pixel.Automation.Test.Runner/ProjectManager.cs
@@ -282,7 +282,7 @@ namespace Pixel.Automation.Test.Runner
         {
             TestSession testSession = new TestSession(this.sessionTemplate, this.targetVersion.Version.ToString());
             List<Persistence.Core.Models.TestResult> testResults = new List<Persistence.Core.Models.TestResult>();
-            testSession.SessionId = await sessionClient.AddSessionAsync(testSession);
+            testSession.Id = await sessionClient.AddSessionAsync(testSession);
 
             try
             {
@@ -315,7 +315,7 @@ namespace Pixel.Automation.Test.Runner
                        
                         await foreach(var testResult in  this.RunTestCaseAsync(testFixture, testCase))
                         {
-                            testResult.SessionId = testSession.SessionId;                          
+                            testResult.SessionId = testSession.Id;                          
                             testResult.ExecutionOrder = ++counter;
                             await sessionClient.AddResultAsync(testResult);
                             testResults.Add(testResult);
@@ -344,7 +344,7 @@ namespace Pixel.Automation.Test.Runner
             try
             {
                 testSession.OnFinished(testResults);
-                await sessionClient.UpdateSessionAsync(testSession.SessionId, testSession);
+                await sessionClient.UpdateSessionAsync(testSession.Id, testSession);
             }
             catch (Exception ex)
             {

--- a/src/Pixel.Automation.Web.Portal/Pages/SessionsPage.razor
+++ b/src/Pixel.Automation.Web.Portal/Pages/SessionsPage.razor
@@ -20,7 +20,7 @@
     </HeaderContent>
     <RowTemplate>
         <MudTd DataLabel="Details">
-            <MudButton Link="@($"./session-details/{context.SessionId}")"
+            <MudButton Href="@($"./session-details/{context.Id}")"
                        Variant="Variant.Filled"
                        Color="@((context.SessionResult == TestStatus.Success) ? Color.Success : Color.Error)"
                        Disabled=@(context.SessionStatus == SessionStatus.InProgress)>

--- a/src/Pixel.Automation.Web.Portal/Shared/NavMenu.razor
+++ b/src/Pixel.Automation.Web.Portal/Shared/NavMenu.razor
@@ -1,4 +1,4 @@
-﻿<MudNavLink Href="./" Match="NavLinkMatch.All" Icon="@Icons.Material.Outlined.Home">Home</MudNavLink>
+﻿@*<MudNavLink Href="./" Match="NavLinkMatch.All" Icon="@Icons.Material.Outlined.Home">Home</MudNavLink>*@
 <MudNavLink Href="./sessions" Icon="@Icons.Material.Outlined.ViewList">Sessions</MudNavLink>
 <MudNavLink Href="./templates/list" Icon="@Icons.Material.Outlined.ViewList">Templates</MudNavLink>
 <MudNavGroup Title="Statistics" Icon="@Icons.Material.Outlined.Dashboard" Expanded="true">

--- a/src/Pixel.Automation.Web.Portal/ViewModels/TestSessionViewModel.cs
+++ b/src/Pixel.Automation.Web.Portal/ViewModels/TestSessionViewModel.cs
@@ -10,7 +10,7 @@ namespace Pixel.Automation.Web.Portal.ViewModels
     {
         private TestSession testSession;
 
-        public string SessionId => testSession.SessionId;
+        public string SessionId => testSession.Id;
 
         public string ProjectId => testSession.ProjectId;
 

--- a/src/Pixel.Persistence.Core/Models/Document.cs
+++ b/src/Pixel.Persistence.Core/Models/Document.cs
@@ -6,12 +6,12 @@ using System.Runtime.Serialization;
 
 namespace Pixel.Persistence.Core.Models;
 
-public abstract class Document : IDocument<ObjectId>
+public abstract class Document : IDocument<string>
 {
     [BsonId]
     [BsonRepresentation(BsonType.ObjectId)]
     [DataMember(IsRequired = true, Order = 1000)]
-    public ObjectId Id { get; set; }
+    public string Id { get; set; }
 
     [DataMember(IsRequired = true, Order = 1010)]
     public int Revision { get; set; } = 1;

--- a/src/Pixel.Persistence.Core/Models/ProjectStatistics.cs
+++ b/src/Pixel.Persistence.Core/Models/ProjectStatistics.cs
@@ -1,17 +1,11 @@
-﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Pixel.Persistence.Core.Models
 {
     [DataContract]
-    public class ProjectStatistics
-    {
-        [BsonId]
-        [BsonRepresentation(BsonType.ObjectId)]
-        public string Id { get; set; }
-
+    public class ProjectStatistics : Document
+    {  
         [DataMember]
         public string ProjectId { get; set; }
 

--- a/src/Pixel.Persistence.Core/Models/SessionTemplate.cs
+++ b/src/Pixel.Persistence.Core/Models/SessionTemplate.cs
@@ -1,18 +1,12 @@
-﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 
 namespace Pixel.Persistence.Core.Models
 {
     [DataContract]
-    public class SessionTemplate
-    {
-        [BsonId]
-        [BsonRepresentation(BsonType.ObjectId)]
-        public string Id { get; set; }
-
+    public class SessionTemplate : Document
+    {       
         /// <summary>
         /// Name of the template
         /// </summary>

--- a/src/Pixel.Persistence.Core/Models/TestResult.cs
+++ b/src/Pixel.Persistence.Core/Models/TestResult.cs
@@ -1,17 +1,12 @@
-﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
+﻿using MongoDB.Bson.Serialization.Attributes;
 using Pixel.Persistence.Core.Enums;
 using System;
 
 namespace Pixel.Persistence.Core.Models
 {
     [BsonIgnoreExtraElements]
-    public class TestResult
-    {
-        [BsonId]
-        [BsonRepresentation(BsonType.ObjectId)]
-        public string Id { get; set; }
-
+    public class TestResult : Document
+    {        
         public string SessionId { get; set; }
        
         public string ProjectId { get; set; }

--- a/src/Pixel.Persistence.Core/Models/TestSession.cs
+++ b/src/Pixel.Persistence.Core/Models/TestSession.cs
@@ -1,5 +1,4 @@
-﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
+﻿using MongoDB.Bson.Serialization.Attributes;
 using Pixel.Persistence.Core.Enums;
 using System;
 using System.Collections.Generic;
@@ -9,15 +8,8 @@ using System.Runtime.InteropServices;
 namespace Pixel.Persistence.Core.Models
 {
     [BsonIgnoreExtraElements]
-    public class TestSession
-    {
-        /// <summary>
-        /// Session Identifier
-        /// </summary>
-        [BsonId]
-        [BsonRepresentation(BsonType.ObjectId)]
-        public string SessionId { get; set; }
-
+    public class TestSession : Document
+    {       
         /// <summary>
         /// Id of the Session Template that was used to start this session
         /// </summary>

--- a/src/Pixel.Persistence.Core/Models/TestStatistics.cs
+++ b/src/Pixel.Persistence.Core/Models/TestStatistics.cs
@@ -8,12 +8,8 @@ namespace Pixel.Persistence.Core.Models
 {
     [DataContract]
     [Serializable]
-    public class TestStatistics
-    {
-        [BsonId]
-        [BsonRepresentation(BsonType.ObjectId)]
-        public string Id { get; set; }
-
+    public class TestStatistics : Document
+    {     
         [DataMember]
         public string ProjectId { get; set; }
 

--- a/src/Pixel.Persistence.Respository/PrefabsRepository.cs
+++ b/src/Pixel.Persistence.Respository/PrefabsRepository.cs
@@ -91,7 +91,7 @@ namespace Pixel.Persistence.Respository
             }
 
             var prefabReferences = await this.referencesRepository.GetProjectReferences(prefabId, cloneFrom.Version.ToString());
-            prefabReferences.Id = ObjectId.Empty;
+            prefabReferences.Id = string.Empty;
             await this.referencesRepository.AddProjectReferences(prefabId, newVersion.ToString(), prefabReferences);
 
             

--- a/src/Pixel.Persistence.Respository/ProjectsRepository.cs
+++ b/src/Pixel.Persistence.Respository/ProjectsRepository.cs
@@ -104,7 +104,7 @@ namespace Pixel.Persistence.Respository
             }
 
             var projectReference = await this.referencesRepository.GetProjectReferences(projectId, cloneFrom.Version.ToString());
-            projectReference.Id = ObjectId.Empty;
+            projectReference.Id = string.Empty;
             await this.referencesRepository.AddProjectReferences(projectId, newVersion.ToString(), projectReference);
 
 
@@ -112,21 +112,21 @@ namespace Pixel.Persistence.Respository
             var fixtures = await this.fixturesRepository.GetFixturesAsync(projectId, cloneFrom.ToString(), laterThan, cancellationToken);
             foreach(var fixture in fixtures)
             {
-                fixture.Id = ObjectId.Empty;
+                fixture.Id = string.Empty;
             }
             await this.fixturesRepository.AddFixturesAsync(projectId, newVersion.ToString(), fixtures, cancellationToken);
 
             var tests = await this.testCaseRepository.GetTestCasesAsync(projectId, cloneFrom.ToString(), laterThan, cancellationToken);
             foreach(var test in tests)
             {
-                test.Id = ObjectId.Empty;
+                test.Id = string.Empty;
             }
             await this.testCaseRepository.AddTestCasesAsync(projectId, newVersion.ToString(), tests, cancellationToken);
 
             var dataSources = await this.testDataRepository.GetDataSourcesAsync(projectId, cloneFrom.ToString(), laterThan, cancellationToken);
             foreach(var dataSource in dataSources)
             {
-                dataSource.Id = ObjectId.Empty;
+                dataSource.Id = string.Empty;
             }
             await this.testDataRepository.AddDataSourcesAsync(projectId, newVersion.ToString(), dataSources, cancellationToken);
 

--- a/src/Pixel.Persistence.Respository/ReferencesRepository.cs
+++ b/src/Pixel.Persistence.Respository/ReferencesRepository.cs
@@ -136,6 +136,6 @@ public class ReferencesRepository : IReferencesRepository
     public async Task SetEditorReferences(string projectId, string projectVersion, EditorReferences editorReferences)
     {
         var projectReferences = await this.GetProjectReferences(projectId, projectVersion);
-        await this.referencesCollection.UpdateField<ProjectReferences, ObjectId, EditorReferences>(projectReferences, x => x.EditorReferences, editorReferences);
+        await this.referencesCollection.UpdateField<ProjectReferences, string, EditorReferences>(projectReferences, x => x.EditorReferences, editorReferences);
     }   
 }

--- a/src/Pixel.Persistence.Respository/TestSessionRespository.cs
+++ b/src/Pixel.Persistence.Respository/TestSessionRespository.cs
@@ -24,7 +24,7 @@ namespace Pixel.Persistence.Respository
         public async Task<TestSession> GetTestSessionAsync(string sessionId)
         {
             Guard.Argument(sessionId).NotNull().NotEmpty();
-            var result = await sessionsCollection.FindAsync<TestSession>(s => s.SessionId.Equals(sessionId));
+            var result = await sessionsCollection.FindAsync<TestSession>(s => s.Id.Equals(sessionId));
             return result.FirstOrDefault();
         }
 
@@ -83,14 +83,14 @@ namespace Pixel.Persistence.Respository
         {
             var filterBuilder = Builders<TestSession>.Filter;
             var condition = filterBuilder.And(filterBuilder.Ne<SessionStatus>(s => s.SessionStatus , Core.Enums.SessionStatus.InProgress), filterBuilder.Eq(s => s.IsProcessed , false) );
-            var fields = Builders<TestSession>.Projection.Include(p => p.SessionId);
+            var fields = Builders<TestSession>.Projection.Include(p => p.Id);
             var all = await sessionsCollection.Find(condition).Project<TestSession>(fields).ToListAsync();        
-            return all.Select(s => s.SessionId);
+            return all.Select(s => s.Id);
         }
 
         public async Task MarkSessionProcessedAsync(string sessionId)
         {
-            var filter = Builders<TestSession>.Filter.Eq(s => s.SessionId, sessionId);
+            var filter = Builders<TestSession>.Filter.Eq(s => s.Id, sessionId);
             var updateBuilder = Builders<TestSession>.Update;
             var update = updateBuilder.Set(t => t.IsProcessed, true);
             await sessionsCollection.FindOneAndUpdateAsync(filter, update);
@@ -106,14 +106,14 @@ namespace Pixel.Persistence.Respository
         {
             Guard.Argument(sessionId).NotNull().NotEmpty();
             Guard.Argument(testSession).NotNull();
-            var filter = Builders<TestSession>.Filter.Eq(t => t.SessionId, sessionId);
+            var filter = Builders<TestSession>.Filter.Eq(t => t.Id, sessionId);
             await sessionsCollection.ReplaceOneAsync(filter, testSession);
         }
 
         public async Task<bool> TryDeleteTestSessionAsync(string sessionId)
         {
             Guard.Argument(sessionId).NotNull().NotEmpty();
-            var result = await sessionsCollection.DeleteOneAsync(s => s.SessionId.Equals(sessionId));
+            var result = await sessionsCollection.DeleteOneAsync(s => s.Id.Equals(sessionId));
             return result.DeletedCount == 1;
         }
 

--- a/src/Pixel.Persistence.Services.Api/Controllers/TestSessionController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/TestSessionController.cs
@@ -45,7 +45,7 @@ namespace Pixel.Persistence.Services.Api.Controllers
         public async Task<IActionResult> Post([FromBody] TestSession testSession)
         {
             await testSessionRepository.AddTestSessionAsync(testSession);
-            return CreatedAtAction(nameof(Get), new { sessionId = testSession.SessionId }, testSession);
+            return CreatedAtAction(nameof(Get), new { sessionId = testSession.Id }, testSession);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Pixel.Persistence.Services.Api.Controllers
         public async Task<IActionResult> Post([FromRoute] string sessionId, [FromBody] TestSession testSession)
         {
             await testSessionRepository.UpdateTestSessionAsync(sessionId, testSession);
-            return CreatedAtAction(nameof(Get), new { sessionId = testSession.SessionId }, testSession);
+            return CreatedAtAction(nameof(Get), new { sessionId = testSession.Id }, testSession);
         }
 
         // DELETE: api/TestSession/sessionId

--- a/src/Pixel.Persistence.Services.Client/TestSessionClient.cs
+++ b/src/Pixel.Persistence.Services.Client/TestSessionClient.cs
@@ -31,7 +31,7 @@ namespace Pixel.Persistence.Services.Client
             restRequest.AddJsonBody(testSession);
             var client = this.clientFactory.GetOrCreateClient();
             var result = await client.PostAsync<TestSession>(restRequest);
-            return result.SessionId;
+            return result.Id;
         }
 
         ///<inheritdoc/>


### PR DESCRIPTION
**Description**
- Changed Id to string from ObjectId for Document as ObjectId can't be deserialized in blazor pages due to use of process id
- Removed Id property from some of the mongodb document models and changed their base class to Document