### PR TITLE
Initializer functions for Initialize environment script

### DIFF
--- a/src/Pixel.Automation.Core/Constants.cs
+++ b/src/Pixel.Automation.Core/Constants.cs
@@ -89,10 +89,14 @@
         public static readonly string ReferencesFileName = "References.ref";       
 
         /// <summary>
-        /// Default name for the Initialization script for configuring ProcessDaaModel used at design time.
-        /// A custom initialization script can be provided as a command line argument to test runner process.
+        /// Initialization script for configuring ProcessDatModel and other variables used at design time.       
         /// </summary>
         public static readonly string InitializeEnvironmentScript = "InitializeEnvironment.csx";
+
+        /// <summary>
+        /// Default function that will be executed in the Initialize Environment script to initialize data
+        /// </summary>
+        public static readonly string DefaultInitFunction = "InitializeDefault()";
 
         /// <summary>
         /// Meta data file name for applications

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -117,16 +117,23 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 if (!File.Exists(scriptFile))
                 {
                     using (var sw = File.CreateText(scriptFile))
-                    {
-                        sw.WriteLine("//Default Initialization script for automation process");
+                    {                       
+                        sw.WriteLine("string dataSourceSuffix = string.Empty;");
                         sw.WriteLine();
-                        sw.Write("string dataSourceSuffix = string.Empty;");
+                        sw.WriteLine("//Default Initialization function");                     
+                        sw.Write("void ");
+                        sw.Write(Constants.DefaultInitFunction);
+                        sw.WriteLine("{");
+                        sw.WriteLine();
+                        sw.WriteLine("}");
                     };
                     logger.Information("Created initialization script file : {scriptFile}", scriptFile);
                 }
                 var scriptEngine = this.entityManager.GetScriptEngine();
                 await scriptEngine.ExecuteFileAsync(scriptFile);
-                logger.Information("Executed initialization script : {scriptFile}", scriptFile);
+                logger.Information("Executed initialize environment script : {scriptFile}", scriptFile);
+                await scriptEngine.ExecuteScriptAsync(Constants.DefaultInitFunction);
+                logger.Information("Executed default initializer function : {DefaultInitFunction}", Constants.DefaultInitFunction);
             }
             catch (Exception ex)
             {
@@ -170,7 +177,6 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
         /// <returns></returns>
         public override async Task Reload()
         {
-
             logger.Information($"{this.GetProjectName()} will be re-loaded");
             var reference = this.fileSystem.LoadFile<ProjectReferences>(this.fileSystem.ReferencesFile);
             this.referenceManager.SetProjectReferences(reference);

--- a/src/Pixel.Automation.Test.Runner/Commands/ExecuteAdhocTestCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/ExecuteAdhocTestCommand.cs
@@ -30,9 +30,9 @@ internal sealed class ExecuteAdhocTestCommand : AsyncCommand<AdhocTestSettings>
         [CommandArgument(2, "<Selector>")]
         public string Selector { get; init; }
 
-        [Description("Name of the initialization script file")]
-        [CommandArgument(3, "<InitScriptFile>")]
-        public string InitializationScript { get; init; }
+        [Description("Name of the initializer function in initialize environment script file")]
+        [CommandArgument(3, "<InitFunction>")]
+        public string InitFunction { get; init; }
 
         [Description("Only list the test cases without executing them")]
         [CommandOption("-l|--list")]
@@ -63,7 +63,7 @@ internal sealed class ExecuteAdhocTestCommand : AsyncCommand<AdhocTestSettings>
             Name = Guid.NewGuid().ToString(),
             ProjectName = settings.Project,            
             Selector = settings.Selector,
-            InitializeScript =  settings.InitializationScript
+            InitFunction =  settings.InitFunction
         };
 
         var projects = this.projectDataManager.GetAllProjects();

--- a/src/Pixel.Automation.Test.Runner/TemplateManager.cs
+++ b/src/Pixel.Automation.Test.Runner/TemplateManager.cs
@@ -30,11 +30,11 @@ namespace Pixel.Automation.Test.Runner
             var table = new Table();
             table.AddColumn(new TableColumn("[blue]Template Name[/]"));
             table.AddColumn(new TableColumn("[blue]Project Name[/]"));
-            table.AddColumn(new TableColumn("[blue]Initialization Script[/]"));
+            table.AddColumn(new TableColumn("[blue]Initialize Function[/]"));
             table.AddColumn(new TableColumn("[blue]Test Selector[/]"));
             foreach (var template in templates)
             {
-                table.AddRow(template.Name, template.ProjectName, template.InitializeScript, template.Selector);               
+                table.AddRow(template.Name, template.ProjectName, template.InitFunction, template.Selector);               
             }
             ansiConsole.Write(table);
         }
@@ -81,13 +81,13 @@ namespace Pixel.Automation.Test.Runner
                     }
                     return ValidationResult.Success();
                 }));           
-            string initializeScript = ansiConsole.Prompt(new TextPrompt<string>("[grey][[Optional]][/] [green]Initialization Script[/] :").AllowEmpty());
+            string initializeScript = ansiConsole.Prompt(new TextPrompt<string>("[grey][[Optional]][/] [green]Initialize Function[/] :").AllowEmpty());
             SessionTemplate template = new SessionTemplate()
             {
                 Name = name,
                 ProjectName = projectName,                
                 Selector = selector,
-                InitializeScript = initializeScript
+                InitFunction = initializeScript
             };
             var availableProjects = this.projectDataManager.GetAllProjects();
             var targetProject = availableProjects.FirstOrDefault(a => a.Name.Equals(projectName)) ?? throw new ArgumentException($"Project with name :" +
@@ -110,8 +110,8 @@ namespace Pixel.Automation.Test.Runner
             table.AddColumn(new TableColumn("Template Name"));           
             table.AddColumn(new TableColumn("Project Name"));
             table.AddColumn(new TableColumn("Test Selector"));
-            table.AddColumn(new TableColumn("Initialization Script"));
-            table.AddRow(template.Name, template.ProjectName, template.Selector, template.InitializeScript);
+            table.AddColumn(new TableColumn("Initialize Function"));
+            table.AddRow(template.Name, template.ProjectName, template.Selector, template.InitFunction);
            
             ansiConsole.WriteLine("[blue]Enter below details to update template :[/]");
 
@@ -125,10 +125,10 @@ namespace Pixel.Automation.Test.Runner
             {
                 template.Selector = selector;
             }
-            string initializeScript = ansiConsole.Prompt(new TextPrompt<string>("[grey][[Optional]][/] [green]Initialization Script[/]").AllowEmpty());
+            string initializeScript = ansiConsole.Prompt(new TextPrompt<string>("[grey][[Optional]][/] [green]Initialize Function[/]").AllowEmpty());
             if (!string.IsNullOrEmpty(initializeScript) || !string.IsNullOrWhiteSpace(initializeScript))
             {
-                template.InitializeScript = initializeScript;
+                template.InitFunction = initializeScript;
             }
             
             if (ansiConsole.Confirm($"Do you want to proceed and update  template : {template.Name} ?"))

--- a/src/Pixel.Automation.Web.Portal/Pages/Template/AddTemplate.razor
+++ b/src/Pixel.Automation.Web.Portal/Pages/Template/AddTemplate.razor
@@ -30,8 +30,8 @@
                         </MudSelect>
                         <MudTextField UserAttributes="@(new (){{"id","txtSelector"}})" Label="Selector" Variant="Variant.Text" 
                             Class="mt-3"  @bind-Value="sessionTemplate.Selector" Lines="2" For="@(() => sessionTemplate.Selector)" />
-                        <MudTextField UserAttributes="@(new (){{"id","txtInitializeScript"}})" Label="Initialization Script" Class="mt-3"
-                            @bind-Value="sessionTemplate.InitializeScript" For="@(() => sessionTemplate.InitializeScript)" />                      
+                        <MudTextField UserAttributes="@(new (){{"id","txtInitFunction"}})" Label="Initializer Function" Class="mt-3"
+                            @bind-Value="sessionTemplate.InitFunction" For="@(() => sessionTemplate.InitFunction)" />                      
                 </MudCardContent>
                 <MudCardActions>
                     <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled"

--- a/src/Pixel.Automation.Web.Portal/Pages/Template/EditTemplate.razor
+++ b/src/Pixel.Automation.Web.Portal/Pages/Template/EditTemplate.razor
@@ -16,7 +16,7 @@
                 <MudCardContent>
                     <MudTextField UserAttributes="@(new (){{"id","txtTemplateName"}})" Label="Template Name" Class="mt-3"
                               @bind-Value="sessionTemplate.Name" For="@(() => sessionTemplate.Name)" />
-                    <MudTextField UserAttributes="@(new (){{"id","txtProjectName"}})" Label="Template Name" Class="mt-3"
+                    <MudTextField UserAttributes="@(new (){{"id","txtProjectName"}})" Label="Project Name" Class="mt-3"
                               @bind-Value="sessionTemplate.ProjectName" For="@(() => sessionTemplate.ProjectName)" ReadOnly="true" />
                     <MudSelect T="ProjectVersion" Label="Version" Variant="Variant.Text" @bind-Value="selectedVersion"
                            AnchorOrigin="Origin.BottomCenter" ToStringFunc="@(e => e?.Version.ToString())">
@@ -27,8 +27,8 @@
                     </MudSelect>
                     <MudTextField UserAttributes="@(new (){{"id","txtSelector"}})" Label="Selector" Variant="Variant.Text"
                               Class="mt-3" @bind-Value="sessionTemplate.Selector" Lines="2" For="@(() => sessionTemplate.Selector)" />
-                    <MudTextField UserAttributes="@(new (){{"id","txtInitializeScript"}})" Label="Initialization Script" Class="mt-3"
-                              @bind-Value="sessionTemplate.InitializeScript" For="@(() => sessionTemplate.InitializeScript)" />
+                    <MudTextField UserAttributes="@(new (){{"id","txtInitFunction"}})" Label="Initializer Function" Class="mt-3"
+                              @bind-Value="sessionTemplate.InitFunction" For="@(() => sessionTemplate.InitFunction)" />
                 </MudCardContent>
                 <MudCardActions>
                     <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled" Color="Color.Primary" Class="ml-auto">Update</MudButton>

--- a/src/Pixel.Persistence.Core/Models/SessionTemplate.cs
+++ b/src/Pixel.Persistence.Core/Models/SessionTemplate.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.VisualBasic;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 
@@ -41,13 +42,13 @@ namespace Pixel.Persistence.Core.Models
         [Required]
         [DataMember]
         public string Selector { get; set; }
-      
+
         /// <summary>
-        /// Script file (*.csx) override that can be used to initialize the process data model e.g. 
-        /// By default InitializeEnvironment.csx generated at design time is used
+        /// InitializeEnvironment.csx can have multiple initializer functions. By default InitializeDefault() will be executed.
+        /// However, templates can provide a custom function name instead.
         /// </summary>
         [DataMember(IsRequired = false)]
-        public string InitializeScript { get; set; }
+        public string InitFunction { get; set; } = "InitializeDefault()";
 
         /// <summary>
         /// Trigger associated with the template 

--- a/src/Pixel.Persistence.Respository/TemplateRepository.cs
+++ b/src/Pixel.Persistence.Respository/TemplateRepository.cs
@@ -87,7 +87,7 @@ namespace Pixel.Persistence.Respository
             .Set(t => t.Name, template.Name)
             .Set(t => t.Selector, template.Selector)
             .Set(t => t.TargetVersion, template.TargetVersion)
-            .Set(t => t.InitializeScript, template.InitializeScript);            
+            .Set(t => t.InitFunction, template.InitFunction);            
 
             await templates.FindOneAndUpdateAsync<SessionTemplate>(filter, updateDefinition);
         }


### PR DESCRIPTION
**Description**
It was possible to specify different initialization script earlier on a template so that different templates can use custom initialization. However, there was no way to upload custom scripts. To simplify this, we will have a single initialization script now , however, we can specify which initializer function to execute per template. At design time, we can add as many initializer functions as needed.