### PR TITLE
Add support for Template triggers

### DIFF
--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor
@@ -7,8 +7,14 @@
     <DialogContent>  
         <MudTextField id="txtName" @bind-Value="@model.Name" Label="Name" @onfocus="(() => error = string.Empty)"
                       Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>
-        <MudTextField id="txtHandler" @bind-Value="@model.Handler" Label="Handler" @onfocus="(() => error = string.Empty)"
-                      Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>
+        <MudSelect @bind-Value="@model.Handler" Label="Handler" AdornmentColor="Color.Secondary" Class="mt-3">
+            @foreach (string handler in templateHandlers.Select(s => s.Name))
+            {
+                <MudSelectItem Value="@handler">@handler</MudSelectItem>
+            }
+        </MudSelect>
+    @*    <MudTextField id="txtHandler" @bind-Value="@model.Handler" Label="Handler" @onfocus="(() => error = string.Empty)"
+                      Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>*@
         <MudTextField id="txtGroup" @bind-Value="@model.Group" Label="Group" @onfocus="(() => error = string.Empty)"
                       Variant="Variant.Text" Immediate="true" Style="width:360px"></MudTextField>
         <MudTextField id="txtCronExpression" @bind-Value="@model.CronExpression" Label="Cron Expression" @onfocus="(() => error = string.Empty)"

--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/CronTrigger.razor.cs
@@ -16,6 +16,9 @@ namespace Pixel.Automation.Web.Portal.Components.Triggers
         [CascadingParameter]
         MudDialogInstance MudDialog { get; set; }
 
+        [Inject]
+        public IHandlerService HandlersService { get; set; }
+
         [Parameter]
         public ITriggerService Service { get; set; }
 
@@ -24,6 +27,18 @@ namespace Pixel.Automation.Web.Portal.Components.Triggers
 
         [Parameter]
         public IEnumerable<SessionTrigger> ExistingTriggers { get; set; }
+
+
+        List<TemplateHandler> templateHandlers = new();
+
+
+        protected override async Task OnInitializedAsync()
+        {
+            templateHandlers.Clear();
+            var availableHandlers = await HandlersService.GetAllAsync();
+            templateHandlers.AddRange(availableHandlers);
+            await base.OnInitializedAsync();
+        }
 
         /// <summary>
         /// Add new trigger and close the dialog

--- a/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/Triggers/TriggerManager.razor
@@ -88,7 +88,7 @@
             <MudTextField UserAttributes="@(new (){{"id","txtName"}})" @bind-Value="@context.Name" Required />
         </MudTd>
         <MudTd DataLabel="Handler">
-            <MudTextField UserAttributes="@(new (){{"id","txtHandler"}})" @bind-Value="@context.Handler" Required />
+            <MudTextField UserAttributes="@(new (){{"id","txtHandler"}})" @bind-Value="@context.Handler" ReadOnly Disabled Required />
         </MudTd>
         <MudTd DataLabel="Group">
             <MudTextField UserAttributes="@(new (){{"id","txtGroup"}})" @bind-Value="@context.Group" Required />

--- a/src/Pixel.Automation.Web.Portal/Helpers/OperationResult.cs
+++ b/src/Pixel.Automation.Web.Portal/Helpers/OperationResult.cs
@@ -52,7 +52,7 @@ namespace Pixel.Automation.Web.Portal.Helpers
             catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.InternalServerError)
             {
                 var problemResponse = await result?.Content.ReadFromJsonAsync<ProblemResponse>();
-                return Failed(result.StatusCode, problemResponse.Title);
+                return Failed(result.StatusCode, problemResponse.Detail);
             }           
         }
 

--- a/src/Pixel.Automation.Web.Portal/Pages/Handlers/AddHandler.razor
+++ b/src/Pixel.Automation.Web.Portal/Pages/Handlers/AddHandler.razor
@@ -1,0 +1,83 @@
+﻿@page "/handlers/new"
+
+
+<MudGrid Spacing="2" Justify="Justify.FlexStart" Class="p-2">
+    <MudItem xs="8">
+        <MudText Typo="Typo.h4">Add New Template Handler</MudText>
+    </MudItem>
+</MudGrid>
+
+<br />
+<MudPaper Elevation="4">
+
+    <MudSelect @bind-Value="Environment" Label="Execution Environment" AdornmentColor="Color.Secondary" Class="ma-3">
+        @foreach (string environment in environments)
+        {
+            <MudSelectItem Value="@environment">@environment</MudSelectItem>
+        }
+    </MudSelect>
+
+    @if (templateHandler != null)
+    {
+        <EditForm Model="@templateHandler" OnValidSubmit="AddHandlerAsync">
+            <FluentValidationValidator />
+            <MudCard>
+                <MudCardContent>
+                    <MudTextField UserAttributes="@(new (){{"id", "txtHandlerName"}})" Label="Handler Name" Class="mt-3"
+                              @bind-Value="templateHandler.Name" For="@(() => templateHandler.Name)" />
+                    <MudTextField UserAttributes="@(new (){{"id", "txtParameters"}})" Label="Parameters" Class="mt-3"
+                              @bind-Value="parameters" For="@(() => parameters)" />
+                    <MudTextField UserAttributes="@(new (){{"id", "txtDescription"}})" Label="Description" Class="mt-3"
+                              @bind-Value="templateHandler.Description" For="@(() => templateHandler.Description)" />
+                    @if (templateHandler is DockerTemplateHandler dockerTemplateHandler)
+                    {
+                        <MudSelect @bind-Value="dockerTemplateHandler.DockerComposeFileName" Label="Docker Compose File" AdornmentColor="Color.Secondary" Class="mt-3">
+                            @foreach (string dockerFile in dockerComposeFiles)
+                            {
+                                <MudSelectItem Value="@dockerFile">@dockerFile</MudSelectItem>
+                            }
+                        </MudSelect>
+                    }
+                </MudCardContent>
+                <MudCardActions>
+                    <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled"
+                           Color="Color.Primary" Class="ml-auto">Create</MudButton>
+                </MudCardActions>
+            </MudCard>
+        </EditForm>
+
+    }
+
+</MudPaper>
+<br />
+<br />
+
+@if (templateHandler is DockerTemplateHandler dockerTemplateHandler)
+{
+    <MudGrid Spacing="2" Justify="Justify.FlexStart" Class="p-2">
+        <MudItem xs="8">
+            <MudText Typo="Typo.h4">Add Docker Compose Files</MudText>
+        </MudItem>
+    </MudGrid>
+
+    <MudPaper Elevation="4">
+        <MudStack Class="ma-3">
+            <MudFileUpload T="IReadOnlyList<IBrowserFile>" OnFilesChanged="OnInputFileChanged" AppendMultipleFiles Hidden="false" Class="flex-1" InputClass="absolute mud-width-full mud-height-full overflow-hidden z-20" InputStyle="opacity:0"
+                       @ondragenter="@SetDragClass" @ondragleave="@ClearDragClass" @ondragend="@ClearDragClass">
+                <ButtonTemplate>
+                    <MudPaper Height="100px" Outlined="true" Class="@DragClass">
+                        <MudText Typo="Typo.h6">Drag and drop files here or click</MudText>
+                        @foreach (var file in filesToUpload.Select(f => f.Name))
+                        {
+                            <MudChip Color="Color.Dark" Text="@file" />
+                        }
+                    </MudPaper>
+                </ButtonTemplate>
+            </MudFileUpload>
+            <MudToolBar DisableGutters="true" Class="gap-4">
+                <MudButton OnClick="Upload" Disabled="@(!filesToUpload.Any())" Color="Color.Primary" Variant="Variant.Filled">Upload</MudButton>
+                <MudButton OnClick="Clear" Disabled="@(!filesToUpload.Any())" Color="Color.Error" Variant="Variant.Filled">Clear</MudButton>
+            </MudToolBar>
+        </MudStack>
+    </MudPaper>
+}

--- a/src/Pixel.Automation.Web.Portal/Pages/Handlers/AddHandler.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Pages/Handlers/AddHandler.razor.cs
@@ -1,0 +1,161 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using MudBlazor;
+using Pixel.Automation.Web.Portal.Services;
+using Pixel.Persistence.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Pages.Handlers;
+
+public partial class AddHandler : ComponentBase
+{
+    [Inject]
+    public IDialogService DialogService { get; set; }
+
+    [Inject]
+    public ISnackbar SnackBar { get; set; }     
+
+    [Inject]
+    public IHandlerService HandlersService { get; set; }
+
+    [Inject]
+    public IComposeFileService ComposeFileService { get; set; }
+
+    [Inject]
+    public NavigationManager Navigator { get; set; }
+
+    string[] environments = new[] { "Docker", "Linux", "Windows" };
+    
+    string environment = "Docker";
+    string Environment
+    {
+        get => environment; 
+        set
+        {
+            if(environment != value)
+            {
+                environment = value;
+                switch(value)
+                {
+                    case "Docker":
+                        templateHandler = new DockerTemplateHandler();
+                        break;
+                    case "Windows":
+                        templateHandler = new WindowsTemplateHandler();
+                        break;
+                    case "Linux":
+                        templateHandler = new LinuxTemplateHandler();
+                        break;
+                }
+            }
+        }
+    }
+
+    List<string> dockerComposeFiles = new();
+
+    TemplateHandler templateHandler = new DockerTemplateHandler();
+
+    string parameters = string.Empty;
+
+
+    protected override async Task OnInitializedAsync()
+    {
+        dockerComposeFiles.Clear();
+        var availableComposeFiles = await ComposeFileService.GetComposeFileNamesAsync();
+        dockerComposeFiles.AddRange(availableComposeFiles);
+        await base.OnInitializedAsync();
+    }
+
+    /// <summary>
+    /// Add new template handler
+    /// </summary>
+    /// <returns></returns>
+    private async Task AddHandlerAsync()
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(parameters))
+            {
+                foreach (var arg in parameters.Split(','))
+                {
+                    var keyValuePair = arg.Split('=');
+                    if (keyValuePair.Length != 2)
+                    {
+                        throw new ArgumentException($"Argument {arg} could not be parsed.");
+                    }
+                    this.templateHandler.Parameters.Add(keyValuePair[0], keyValuePair[1]);
+                }
+            }
+            var result = await HandlersService.AddHandlerAsync(this.templateHandler);
+            if (result.IsSuccess)
+            {
+                Navigator.NavigateTo($"handlers/list");
+                SnackBar.Add("Added successfully.", Severity.Success);
+                return;
+            }
+            SnackBar.Add(result.ToString(), Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            SnackBar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+
+    static string DefaultDragClass = "relative rounded-lg border-2 border-dashed pa-4 mt-4 mud-width-full mud-height-full z-10";
+    string DragClass = DefaultDragClass;
+    List<IBrowserFile> filesToUpload = new();
+
+    void OnInputFileChanged(InputFileChangeEventArgs e)
+    {
+        ClearDragClass();
+        filesToUpload.Clear();
+        filesToUpload.AddRange(e.GetMultipleFiles());      
+    }
+
+    private async Task Clear()
+    {
+        filesToUpload.Clear();
+        ClearDragClass();
+        await Task.Delay(100);
+    }
+    private async Task Upload()
+    {
+        var existingFiles = filesToUpload.Select(s => s.Name).Intersect(dockerComposeFiles);
+        if (existingFiles.Count() > 0)
+        {
+            bool? dialogResult = await DialogService.ShowMessageBox("Warning", $"Files {string.Join(',', existingFiles)} already exist.",
+               yesText: "Replace", cancelText: "Cancel", options: new DialogOptions() { FullWidth = true });
+            if (!dialogResult.GetValueOrDefault())
+            {
+                return;
+            }
+        }
+        foreach (var file in filesToUpload)
+        {          
+            var result = await ComposeFileService.AddComposeFileAsync(file);
+            if (result.IsSuccess)
+            {
+                SnackBar.Add($" {file.Name} was uploaded successfully.", Severity.Success);
+                continue;
+            }
+            SnackBar.Add(result.ToString(), Severity.Error);
+        }
+        dockerComposeFiles.Clear();
+        var availableComposeFiles = await ComposeFileService.GetComposeFileNamesAsync();
+        dockerComposeFiles.AddRange(availableComposeFiles);
+    }
+
+    private void SetDragClass()
+    {
+        DragClass = $"{DefaultDragClass} mud-border-primary";
+    }
+
+    private void ClearDragClass()
+    {
+        DragClass = DefaultDragClass;
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Pages/Handlers/EditHandler.razor
+++ b/src/Pixel.Automation.Web.Portal/Pages/Handlers/EditHandler.razor
@@ -1,0 +1,47 @@
+﻿@page "/handlers/edit/{handlerId}"
+
+
+<MudGrid Spacing="2" Justify="Justify.FlexStart" Class="p-2">
+    <MudItem xs="8">
+        <MudText Typo="Typo.h4">Edit Template Handler</MudText>
+    </MudItem>
+</MudGrid>
+
+<br />
+<MudPaper Elevation="4">
+      
+
+    @if (templateHandler != null)
+    {
+        <EditForm Model="@templateHandler" OnValidSubmit="UpdateHandlerAsync">
+            <FluentValidationValidator />
+            <MudCard>
+                <MudCardContent>
+                    <MudTextField UserAttributes="@(new (){{"id", "txtHandlerName"}})" Label="Handler Name" Class="mt-3"
+                              @bind-Value="templateHandler.Name" For="@(() => templateHandler.Name)" ReadOnly Disabled />
+                    <MudTextField UserAttributes="@(new (){{"id", "txtParameters"}})" Label="Parameters" Class="mt-3"
+                              @bind-Value="parameters" For="@(() => parameters)" HelperText=", seperated key=value pairs"/>
+                    <MudTextField UserAttributes="@(new (){{"id", "txtDescription"}})" Label="Description" Class="mt-3"
+                              @bind-Value="templateHandler.Description" For="@(() => templateHandler.Description)" />
+                    @if (templateHandler is DockerTemplateHandler dockerTemplateHandler)
+                    {
+                        <MudSelect @bind-Value="dockerTemplateHandler.DockerComposeFileName" Label="Docker Compose File" AdornmentColor="Color.Secondary" Class="mt-3">
+                            @foreach (string dockerFile in dockerComposeFiles)
+                            {
+                                <MudSelectItem Value="@dockerFile">@dockerFile</MudSelectItem>
+                            }
+                        </MudSelect>
+                    }
+                </MudCardContent>
+                <MudCardActions>
+                    <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled"
+                           Color="Color.Primary" Class="ml-auto">Update</MudButton>
+                </MudCardActions>
+            </MudCard>
+        </EditForm>
+
+    }
+
+</MudPaper>
+<br />
+<br />

--- a/src/Pixel.Automation.Web.Portal/Pages/Handlers/EditHandler.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Pages/Handlers/EditHandler.razor.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pixel.Automation.Web.Portal.Services;
+using Pixel.Persistence.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Pages.Handlers;
+
+public partial class EditHandler : ComponentBase
+{
+    [Parameter]
+    public string HandlerId { get; set; }
+
+    [Inject]
+    public IDialogService DialogService { get; set; }
+
+    [Inject]
+    public IComposeFileService ComposeFileService { get; set; }
+
+    [Inject]
+    public ISnackbar SnackBar { get; set; }
+
+    [Inject]
+    public IHandlerService HandlersService { get; set; }
+
+    [Inject]
+    public NavigationManager Navigator { get; set; }
+
+    List<string> dockerComposeFiles = new();
+
+    TemplateHandler templateHandler;
+    string parameters = string.Empty;
+
+
+    protected override async Task OnInitializedAsync()
+    {
+        templateHandler = await HandlersService.GetHandlerByIdAsync(HandlerId);
+        if(templateHandler is DockerTemplateHandler)
+        {
+            dockerComposeFiles.Clear();
+            var availableComposeFiles = await ComposeFileService.GetComposeFileNamesAsync();
+            dockerComposeFiles.AddRange(availableComposeFiles);
+        }
+        StringBuilder sb = new StringBuilder();
+        int i = 0;
+        foreach(var argument in templateHandler.Parameters)
+        {
+            sb.Append(argument.Key);
+            sb.Append("=");
+            sb.Append(argument.Value);
+            i++;
+            if(i < templateHandler.Parameters.Count)
+            {
+                sb.Append(',');
+            }
+        }
+        parameters = sb.ToString();
+        await base.OnInitializedAsync();
+    }
+
+    /// <summary>
+    /// Add new template handler
+    /// </summary>
+    /// <returns></returns>
+    private async Task UpdateHandlerAsync()
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(parameters))
+            {
+                this.templateHandler.Parameters.Clear();
+                foreach (var arg in parameters.Split(','))
+                {
+                    var keyValuePair = arg.Split('=');
+                    if (keyValuePair.Length != 2)
+                    {
+                        throw new ArgumentException($"Argument {arg} could not be parsed.");
+                    }
+                    this.templateHandler.Parameters.Add(keyValuePair[0], keyValuePair[1]);
+                }
+            }
+            var result = await HandlersService.UpdateHandlerAsync(this.templateHandler);
+            if (result.IsSuccess)
+            {
+                SnackBar.Add("Updated successfully.", Severity.Success);
+                return;
+            }
+            SnackBar.Add(result.ToString(), Severity.Error);
+
+        }       
+        catch(Exception ex)
+        {
+            SnackBar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+}

--- a/src/Pixel.Automation.Web.Portal/Pages/Handlers/HandlersList.razor
+++ b/src/Pixel.Automation.Web.Portal/Pages/Handlers/HandlersList.razor
@@ -1,0 +1,52 @@
+﻿@page "/handlers/list"
+
+<MudTable UserAttributes="@(new (){{"id","tblHandlers"}})" ServerData="@(new Func<TableState, Task<TableData<TemplateHandler>>>(GetHandlersAsync))"
+          Dense="false" Hover="true" ReadOnly="true" SortLabel="Sort By" Elevation="4" @ref="handlersTable">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Templates</MudText>
+        <MudIconButton UserAttributes="@(new (){{"id","btnNew"}})" Icon="@Icons.Material.Outlined.AddCircleOutline" Size="Size.Medium"
+                       @onclick="AddNewHandler" Color="Color.Primary"></MudIconButton>
+        <MudSpacer></MudSpacer>
+        <MudTextField UserAttributes="@(new (){{"id","txtSearchBox"}})" T="string" ValueChanged="@(s=>OnSearch(s))" Placeholder="Search by handler name" Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh>Environment</MudTh>
+        <MudTh>Name</MudTh>      
+        <MudTh>Arguments</MudTh>      
+        <MudTh></MudTh>
+        <MudTh></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Environment">
+           @context.GetType().Name.Replace("TemplateHandler", "")
+        </MudTd>
+        <MudTd DataLabel="Name">
+            <MudTooltip Text="@context.Description">
+                @context.Name
+            </MudTooltip>
+        </MudTd>       
+        <MudTd DataLabel="Parameters">  
+            @GetParameterString(context)           
+        </MudTd>       
+        <MudTd DataLabel="">
+            <MudIconButton UserAttributes="@(new (){{"id","btnEdit"}})" Icon="@Icons.Material.Filled.Edit" Color="Color.Primary"
+                           @onclick="()=> EditHandler(context)" Size="Size.Medium"></MudIconButton>
+        </MudTd>
+        <MudTd DataLabel="">
+            <MudIconButton UserAttributes="@(new (){{"id","btnDelete"}})" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
+                           @onclick="()=> DeleteHandlerAsync(context)" Size="Size.Medium"></MudIconButton>
+        </MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager PageSizeOptions="pageSizeOptions" RowsPerPageString="Results Per Page" />
+    </PagerContent>
+    <ColGroup>
+        <col style="width:120px;" />
+        <col style="width:360px;" />
+        <col />
+        <col style="width:20px;" />
+        <col style="width:20px;" />
+    </ColGroup>
+</MudTable>
+

--- a/src/Pixel.Automation.Web.Portal/Pages/Handlers/HandlersList.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Pages/Handlers/HandlersList.razor.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pixel.Automation.Web.Portal.Services;
+using Pixel.Persistence.Core.Models;
+using Pixel.Persistence.Core.Request;
+using System.Linq;
+using System.Threading.Tasks;
+using System;
+using System.Text;
+
+namespace Pixel.Automation.Web.Portal.Pages.Handlers;
+
+public partial class HandlersList : ComponentBase
+{
+    [Inject]
+    public IHandlerService HandlerService { get; set; }
+
+    [Inject]
+    public IDialogService DialogService { get; set; }
+
+    [Inject]
+    public ISnackbar SnackBar { get; set; }
+
+    [Inject]
+    public NavigationManager Navigator { get; set; }
+
+    private readonly int[] pageSizeOptions = { 10, 20, 30, 40, 50 };
+    private MudTable<TemplateHandler> handlersTable;
+    private GetHandlersRequest handlersRequest = new();
+    private bool resetCurrentPage = false;
+
+    /// <summary>
+    /// Get template handlers from api endpoint for the current page of the data table
+    /// </summary>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    private async Task<TableData<TemplateHandler>> GetHandlersAsync(TableState state)
+    {
+        try
+        {
+            handlersRequest.CurrentPage = resetCurrentPage ? 1 : (state.Page + 1);
+            resetCurrentPage = false;
+            handlersRequest.PageSize = state.PageSize;
+            var sessionPage = await HandlerService.GetHandlersAsync(handlersRequest);
+
+            return new TableData<TemplateHandler>
+            {
+                Items = sessionPage.Items,
+                TotalItems = sessionPage.ItemsCount
+            };
+        }
+        catch (Exception ex)
+        {
+            SnackBar.Add($"Error while retrieving template handlers.{ex.Message}", Severity.Error);
+        }
+        return new TableData<TemplateHandler>
+        {
+            Items = Enumerable.Empty<TemplateHandler>(),
+            TotalItems = 0
+        };
+    }
+
+    /// <summary>
+    /// Refresh data for the search query
+    /// </summary>
+    /// <param name="text"></param>
+    private void OnSearch(string text)
+    {
+        handlersRequest.HandlerFilter = string.Empty;
+        if (!string.IsNullOrEmpty(text))
+        {
+            handlersRequest.HandlerFilter = text;
+        }
+        resetCurrentPage = true;
+        handlersTable.ReloadServerData();
+    }
+
+    /// <summary>
+    /// Navigate to add new template handler page
+    /// </summary>
+    void AddNewHandler()
+    {
+        Navigator.NavigateTo($"handlers/new");
+    }
+
+    /// <summary>
+    /// Navigate to edit template handler page
+    /// </summary>
+    /// <param name="templateHandler"></param>
+    void EditHandler(TemplateHandler templateHandler)
+    {
+        Navigator.NavigateTo($"handlers/edit/{templateHandler.Id}");
+    }
+
+    /// <summary>
+    /// Delete the template handler
+    /// </summary>
+    /// <param name="templateHandler"></param>
+    /// <returns></returns>
+    async Task DeleteHandlerAsync(TemplateHandler templateHandler)
+    {
+        bool? dialogResult = await DialogService.ShowMessageBox("Warning", "Delete can't be undone !!",
+            yesText: "Delete!", cancelText: "Cancel", options: new DialogOptions() { FullWidth = true });
+        if (dialogResult.GetValueOrDefault())
+        {
+            var result = await HandlerService.DeleteHandlerAsync(templateHandler);
+            if (result.IsSuccess)
+            {
+                SnackBar.Add("Deleted successfully.", Severity.Success);
+                await handlersTable.ReloadServerData();
+                return;
+            }
+            SnackBar.Add(result.ToString(), Severity.Error, config =>
+            {
+                config.ShowCloseIcon = true;
+                config.RequireInteraction = true;
+            });
+        }
+    }
+
+    string GetParameterString(TemplateHandler handler)
+    {
+        StringBuilder sb = new StringBuilder();
+        int i = 0;
+        foreach (var argument in handler.Parameters)
+        {
+            sb.Append(argument.Key);
+            sb.Append("=");
+            sb.Append(argument.Value);
+            i++;
+            if (i < handler.Parameters.Count)
+            {
+                sb.Append(',');
+            }
+        }
+        return sb.ToString();
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Program.cs
+++ b/src/Pixel.Automation.Web.Portal/Program.cs
@@ -21,6 +21,8 @@ namespace Pixel.Automation.Web.Portal
 
             builder.Services.AddHttpClient<IProjectService, ProjectService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
             builder.Services.AddHttpClient<ITemplateService, TemplateService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
+            builder.Services.AddHttpClient<IHandlerService, HandlerService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
+            builder.Services.AddHttpClient<IComposeFileService, ComposeFileService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
             builder.Services.AddHttpClient<ITriggerService, TriggerService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
             builder.Services.AddHttpClient<ITestResultService, TestResultService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
             builder.Services.AddHttpClient<ITestSessionService, TestSessionService>(client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));

--- a/src/Pixel.Automation.Web.Portal/Services/ComposeFileService.cs
+++ b/src/Pixel.Automation.Web.Portal/Services/ComposeFileService.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Components.Forms;
+using Pixel.Automation.Web.Portal.Helpers;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Services;
+
+public interface IComposeFileService
+{
+    /// <summary>
+    /// Get all the available compose file names
+    /// </summary>
+    /// <returns></returns>
+    Task<string[]> GetComposeFileNamesAsync();
+
+    /// <summary>
+    /// Upload a compose file that can be used with a template handler later
+    /// </summary>
+    /// <param name="composeFile"></param>
+    /// <returns></returns>
+    Task<OperationResult> AddComposeFileAsync(IBrowserFile composeFile);   
+}
+
+public class ComposeFileService : IComposeFileService
+{
+    private readonly HttpClient httpClient;
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="httpClient"></param>
+    public ComposeFileService(HttpClient httpClient)
+    {
+        this.httpClient = httpClient;
+    }
+
+    /// <inheritdoc/>
+    public async Task<OperationResult> AddComposeFileAsync(IBrowserFile composeFile)
+    {
+        var fileContent = new StreamContent(composeFile.OpenReadStream());
+        using (var content = new MultipartFormDataContent())
+        {
+            content.Add(fileContent, "composeFile", composeFile.Name);
+            var result = await this.httpClient.PostAsync("api/composefiles", content);
+            return await OperationResult.FromResponseAsync(result);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<string[]> GetComposeFileNamesAsync()
+    {
+        return await this.httpClient.GetFromJsonAsync<string[]>("api/composefiles/names");
+    }
+}
+

--- a/src/Pixel.Automation.Web.Portal/Services/HandlerService.cs
+++ b/src/Pixel.Automation.Web.Portal/Services/HandlerService.cs
@@ -1,0 +1,145 @@
+﻿using Microsoft.AspNetCore.WebUtilities;
+using Pixel.Automation.Web.Portal.Helpers;
+using Pixel.Persistence.Core.Models;
+using Pixel.Persistence.Core.Request;
+using Pixel.Persistence.Core.Response;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Services
+{
+    public interface IHandlerService
+    {
+        /// <summary>
+        /// Get all the available handlers
+        /// </summary>
+        /// <returns></returns>
+        Task<IEnumerable<TemplateHandler>> GetAllAsync();
+
+        /// <summary>
+        /// Get all the available template handlers based on request
+        /// </summary>
+        /// <returns></returns>
+        Task<PagedList<TemplateHandler>> GetHandlersAsync(GetHandlersRequest getHandlersRequest);
+
+        /// <summary>
+        /// Get template handler with a given template name
+        /// </summary>
+        /// <param name="handlerName"></param>
+        /// <returns></returns>
+        Task<TemplateHandler> GetHandlerByNameAsync(string handlerName);
+
+        /// <summary>
+        /// Get template handler with a given Id
+        /// </summary>
+        /// <param name="handlerId"></param>
+        /// <returns></returns>
+        Task<TemplateHandler> GetHandlerByIdAsync(string handlerId);
+
+        /// <summary>
+        /// Add a new template handler
+        /// </summary>
+        /// <param name="templateHandler"></param>
+        /// <returns></returns>
+        Task<OperationResult> AddHandlerAsync(TemplateHandler templateHandler);
+
+        /// <summary>
+        /// Update details of an existing template handler
+        /// </summary>
+        /// <param name="templateHandler"></param>
+        /// <returns></returns>
+        Task<OperationResult> UpdateHandlerAsync(TemplateHandler templateHandler);      
+
+        /// <summary>
+        /// Add a new template handler
+        /// </summary>
+        /// <param name="templateHandler"></param>
+        /// <returns></returns>
+        //Task<OperationResult> AddHandlerAsync(TemplateHandlerViewModel templateHandler, IBrowserFile browserFile);
+
+        /// <summary>
+        /// Update details of an existing template handler
+        /// </summary>
+        /// <param name="templateHandler"></param>
+        /// <returns></returns>
+        //Task<OperationResult> UpdateHandlerAsync(TemplateHandlerViewModel templateHandler, IBrowserFile browserFile);
+
+        /// <summary>
+        /// Delete an existing template handler
+        /// </summary>
+        /// <param name="templateHandler"></param>
+        /// <returns></returns>
+        Task<OperationResult> DeleteHandlerAsync(TemplateHandler templateHandler);
+        
+    }
+
+    public class HandlerService : IHandlerService
+    {
+        private readonly HttpClient httpClient;
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="httpClient"></param>
+        public HandlerService(HttpClient httpClient)
+        {
+            this.httpClient = httpClient;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<TemplateHandler>> GetAllAsync()
+        {
+            return await this.httpClient.GetFromJsonAsync<IEnumerable<TemplateHandler>>("api/handlers");
+        }
+
+        /// <inheritdoc/>
+        public async Task<PagedList<TemplateHandler>> GetHandlersAsync(GetHandlersRequest request)
+        {
+            var queryStringParam = new Dictionary<string, string>
+            {
+                ["currentPage"] = request.CurrentPage.ToString(),
+                ["pageSize"] = request.PageSize.ToString()
+            };
+            if (!string.IsNullOrEmpty(request.HandlerFilter))
+            {
+                queryStringParam.Add("handlerFilter", request.HandlerFilter);
+            }
+            return await this.httpClient.GetFromJsonAsync<PagedList<TemplateHandler>>(QueryHelpers.AddQueryString("api/handlers/paged", queryStringParam));
+        }
+
+        /// <inheritdoc/>
+        public async Task<TemplateHandler> GetHandlerByNameAsync(string handlerName)
+        {
+            return await httpClient.GetFromJsonAsync<TemplateHandler>($"api/handlers/name/{handlerName}");
+        }
+
+        /// <inheritdoc/>
+        public async Task<TemplateHandler> GetHandlerByIdAsync(string handlerId)
+        {
+            return await httpClient.GetFromJsonAsync<TemplateHandler>($"api/handlers/id/{handlerId}");
+        }
+        
+        /// <inheritdoc/>
+        public async Task<OperationResult> DeleteHandlerAsync(TemplateHandler templateHandler)
+        {
+            var result = await httpClient.DeleteAsync($"api/handlers/{templateHandler.Id}");
+            return await OperationResult.FromResponseAsync(result);
+        }
+
+        /// <inheritdoc/>
+        public async Task<OperationResult> AddHandlerAsync(TemplateHandler templateHandler)
+        {
+            var result = await httpClient.PostAsJsonAsync<TemplateHandler>($"api/handlers", templateHandler);
+            return await OperationResult.FromResponseAsync(result);
+        }
+
+        /// <inheritdoc/>
+        public async Task<OperationResult> UpdateHandlerAsync(TemplateHandler templateHandler)
+        {
+            var result = await httpClient.PutAsJsonAsync<TemplateHandler>($"api/handlers", templateHandler);
+            return await OperationResult.FromResponseAsync(result);
+        }       
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Shared/NavMenu.razor
+++ b/src/Pixel.Automation.Web.Portal/Shared/NavMenu.razor
@@ -1,6 +1,7 @@
 ﻿@*<MudNavLink Href="./" Match="NavLinkMatch.All" Icon="@Icons.Material.Outlined.Home">Home</MudNavLink>*@
 <MudNavLink Href="./sessions" Icon="@Icons.Material.Outlined.ViewList">Sessions</MudNavLink>
 <MudNavLink Href="./templates/list" Icon="@Icons.Material.Outlined.ViewList">Templates</MudNavLink>
+<MudNavLink Href="./handlers/list" Icon="@Icons.Material.Outlined.ViewList">Handlers</MudNavLink>
 <MudNavGroup Title="Statistics" Icon="@Icons.Material.Outlined.Dashboard" Expanded="true">
     <MudNavLink Href="./project-statistics">Project</MudNavLink>
     <MudNavLink Href="./test-statistics">Test</MudNavLink>

--- a/src/Pixel.Persistence.Core/Models/SessionTemplate.cs
+++ b/src/Pixel.Persistence.Core/Models/SessionTemplate.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualBasic;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 

--- a/src/Pixel.Persistence.Core/Models/TemplateHandler.cs
+++ b/src/Pixel.Persistence.Core/Models/TemplateHandler.cs
@@ -1,0 +1,52 @@
+﻿using MongoDB.Bson.Serialization.Attributes;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace Pixel.Persistence.Core.Models;
+
+[DataContract]
+[JsonDerivedType(typeof(DockerTemplateHandler), typeDiscriminator: nameof(DockerTemplateHandler))]
+[JsonDerivedType(typeof(WindowsTemplateHandler), typeDiscriminator: nameof(WindowsTemplateHandler))]
+[JsonDerivedType(typeof(LinuxTemplateHandler), typeDiscriminator: nameof(LinuxTemplateHandler))]
+[BsonKnownTypes(typeof(DockerTemplateHandler))]
+[BsonKnownTypes(typeof(WindowsTemplateHandler))]
+[BsonKnownTypes(typeof(LinuxTemplateHandler))]
+public abstract class TemplateHandler : Document
+{   
+    [DataMember(Order = 10)]
+    public string Name { get; set; }   
+
+    [DataMember(Order = 20, IsRequired = true)]
+    public Dictionary<string, string> Parameters { get; set; } = new ();
+
+    [DataMember(Order = 30, IsRequired = false)]
+    public string Description { get; set; }   
+   
+}
+
+//Note : We need to duplicate JsonDerivedType on derived types so that $type information is serialized correctly when
+//retrieving TemplateHandler from endpoints like get by name or get by id
+
+[DataContract]
+[JsonDerivedType(typeof(DockerTemplateHandler), typeDiscriminator: nameof(DockerTemplateHandler))]
+public class DockerTemplateHandler : TemplateHandler
+{
+    [DataMember(Order = 100, IsRequired = true)]
+    public string DockerComposeFileName { get; set; }
+}
+
+[DataContract]
+[JsonDerivedType(typeof(WindowsTemplateHandler), typeDiscriminator: nameof(WindowsTemplateHandler))]
+public class WindowsTemplateHandler : TemplateHandler
+{
+   
+}
+
+[DataContract]
+[JsonDerivedType(typeof(LinuxTemplateHandler), typeDiscriminator: nameof(LinuxTemplateHandler))]
+public class LinuxTemplateHandler : TemplateHandler
+{
+
+}
+

--- a/src/Pixel.Persistence.Core/Request/GetHandlersRequest.cs
+++ b/src/Pixel.Persistence.Core/Request/GetHandlersRequest.cs
@@ -1,0 +1,6 @@
+﻿namespace Pixel.Persistence.Core.Request;
+
+public class GetHandlersRequest : PagedDataRequest
+{
+    public string HandlerFilter { get; set; }
+}

--- a/src/Pixel.Persistence.Respository/ComposeFilesRepository.cs
+++ b/src/Pixel.Persistence.Respository/ComposeFilesRepository.cs
@@ -1,0 +1,133 @@
+﻿using Dawn;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using MongoDB.Driver.GridFS;
+using Pixel.Persistence.Core.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pixel.Persistence.Respository;
+
+/// <summary>
+/// Default implementation of <see cref="IComposeFilesRepository"/>
+/// </summary>
+public class ComposeFilesRepository : IComposeFilesRepository
+{
+    private readonly ILogger logger;
+    private readonly IGridFSBucket bucket;
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="logger"></param>
+    /// <param name="dbSettings"></param>
+    public ComposeFilesRepository(ILogger<ComposeFilesRepository> logger, IMongoDbSettings dbSettings)
+    {
+        this.logger = Guard.Argument(logger, nameof(logger)).NotNull().Value;
+        var client = new MongoClient(dbSettings.ConnectionString);
+        var database = client.GetDatabase(dbSettings.DatabaseName);
+        this.bucket = new GridFSBucket(database, new GridFSBucketOptions
+        {
+            BucketName = dbSettings.ComposeFilesBucketName
+        });
+    }
+
+    /// <inheritdoc/>   
+    public async Task<bool> CheckFileExistsAsync(string fileName)
+    {
+        Guard.Argument(fileName, nameof(fileName)).NotNull().NotEmpty();
+
+        var filter = Builders<GridFSFileInfo>.Filter.Eq(x => x.Filename, fileName);
+        var options = new GridFSFindOptions();
+
+        using (var cursor = await bucket.FindAsync(filter, options))
+        {
+            return cursor.Any();
+        }
+    }  
+
+    /// <inheritdoc/>   
+    public async Task<DataFile> GetFileAsync(string fileName)
+    {
+        Guard.Argument(fileName, nameof(fileName)).NotNull().NotEmpty();
+
+        var filter = Builders<GridFSFileInfo>.Filter.Eq(x => x.Filename, fileName);
+        var options = new GridFSFindOptions();
+
+        using (var cursor = await bucket.FindAsync(filter, options))
+        {
+            var file = await cursor.FirstOrDefaultAsync() ?? throw new GridFSFileNotFoundException($"File {fileName} doesn't exist");
+            return new DataFile()
+            {
+                FileName = fileName,
+                Bytes = await bucket.DownloadAsBytesAsync(file.Id)
+            };
+        }
+    }
+
+    /// <inheritdoc/>   
+    public async IAsyncEnumerable<string> GetAllFileNamesAsync()
+    {
+        var filter = Builders<GridFSFileInfo>.Filter.Empty;
+        var options = new GridFSFindOptions();
+        using (var cursor = await bucket.FindAsync(filter, options))
+        {
+            foreach (var file in (await cursor.ToListAsync()))
+            {
+                yield return file.Filename;
+            }
+        }
+    }
+
+    /// <inheritdoc/>   
+    public async IAsyncEnumerable<DataFile> GetAllFilesAsync()
+    {
+        var filter = Builders<GridFSFileInfo>.Filter.Empty;
+        var options = new GridFSFindOptions();
+        using (var cursor = await bucket.FindAsync(filter, options))
+        {
+            foreach (var file in (await cursor.ToListAsync()))
+            {
+                var fileData = await bucket.DownloadAsBytesAsync(file.Id);
+                yield return new DataFile()
+                {
+                    FileName = file.Filename,
+                    Bytes = fileData
+                };
+            }
+        }
+    }
+
+    /// <inheritdoc/>   
+    public async Task AddOrUpdateFileAsync(string fileName, byte[] fileContents)
+    {
+        var filter = Builders<GridFSFileInfo>.Filter.Eq(x => x.Filename, fileName);
+
+        var file = (await bucket.FindAsync(filter)).FirstOrDefault();
+        if (file != null)
+        {
+            await bucket.DeleteAsync(file.Id);
+            logger.LogInformation("Deleted existing copy of file : {0} ", fileName);
+        }
+;
+        await bucket.UploadFromBytesAsync(fileName, fileContents, new GridFSUploadOptions());
+        logger.LogInformation("File {0} was added.", fileName);
+    }
+
+    /// <inheritdoc/>   
+    public async Task DeleteFileAsync(string fileName)
+    {
+        var filter = Builders<GridFSFileInfo>.Filter.Eq(x => x.Filename, fileName);
+
+        using (var cursor = await bucket.FindAsync(filter, new GridFSFindOptions()))
+        {
+            var files = await cursor.ToListAsync();
+            foreach (var file in files)
+            {
+                await bucket.DeleteAsync(file.Id);
+                logger.LogInformation("File {0} was deleted.", fileName);
+            }
+        }
+    }
+}

--- a/src/Pixel.Persistence.Respository/Interfaces/IComposeFilesRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/IComposeFilesRepository.cs
@@ -1,0 +1,53 @@
+﻿using Pixel.Persistence.Core.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Pixel.Persistence.Respository;
+
+/// <summary>
+/// Contract for managing docker compose files repository
+/// </summary>
+public interface IComposeFilesRepository
+{
+    /// <summary>
+    /// Check if file with given name exists
+    /// </summary>
+    /// <param name="fileName"></param>
+    /// <returns></returns>
+    Task<bool> CheckFileExistsAsync(string fileName);
+
+    /// <summary>
+    /// Get the names of all the available files
+    /// </summary>
+    /// <returns></returns>
+    IAsyncEnumerable<string> GetAllFileNamesAsync();
+
+    /// <summary>
+    /// Get all the avaialble files
+    /// </summary>
+    /// <returns></returns>
+    IAsyncEnumerable<DataFile> GetAllFilesAsync();
+
+    /// <summary>
+    /// Get file with given name
+    /// </summary>
+    /// <param name="fileName"></param>
+    /// <returns></returns>
+    Task<DataFile> GetFileAsync(string fileName);
+
+    /// <summary>
+    /// Add a new file
+    /// </summary>
+    /// <param name="fileName"></param>
+    /// <param name="fileContents"></param>
+    /// <returns></returns>
+    Task AddOrUpdateFileAsync(string fileName, byte[] fileContents);
+
+    /// <summary>
+    /// Delete an existing file
+    /// </summary>
+    /// <param name="fileName"></param>
+    /// <returns></returns>
+    Task DeleteFileAsync(string fileName);
+  
+}

--- a/src/Pixel.Persistence.Respository/Interfaces/ITemplateHandlerRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/ITemplateHandlerRepository.cs
@@ -1,0 +1,68 @@
+﻿using Pixel.Persistence.Core.Models;
+using Pixel.Persistence.Core.Request;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pixel.Persistence.Respository.Interfaces;
+
+/// <summary>
+/// Contract to manage template handlers
+/// </summary>
+public interface ITemplateHandlerRepository
+{
+    /// <summary>
+    /// Find template handler by Id
+    /// </summary>
+    /// <param name="Id"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<TemplateHandler> FindByIdAsync(string Id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Find template handler by name
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<TemplateHandler> FindByNameAsync(string name, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get all template handlers
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<IEnumerable<TemplateHandler>> GetAllAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get template handlers matching specified criterias on request
+    /// </summary>
+    /// <param name="queryParameter"></param>
+    /// <returns></returns>
+    Task<IEnumerable<TemplateHandler>> GetHandlersAsync(GetHandlersRequest queryParameter);
+
+    /// <summary>
+    /// Add a new template handler
+    /// </summary>
+    /// <param name="handler"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task AddHandlerAsync(TemplateHandler handler, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Update details of an existing template handler
+    /// </summary>
+    /// <param name="handler"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task UpdateHandlerAsync(TemplateHandler handler, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete an existing template handler
+    /// </summary>
+    /// <param name="Id"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task DeleteHandlerAsync(string Id, CancellationToken cancellationToken);
+
+}

--- a/src/Pixel.Persistence.Respository/MongoDbSettings.cs
+++ b/src/Pixel.Persistence.Respository/MongoDbSettings.cs
@@ -32,6 +32,8 @@
 
         string TemplatesCollectionName { get; set; }
 
+        string TemplateHandlersName { get; set; }
+
         string SessionsCollectionName { get; set; }
 
         string TestResultsCollectionName { get; set; }
@@ -39,6 +41,8 @@
         string TestStatisticsCollectionName { get; set; }
 
         string ProjectStatisticsCollectionName { get; set; }
+
+        string ComposeFilesBucketName { get; set; }
 
     }
 
@@ -76,11 +80,15 @@
 
         public string TemplatesCollectionName { get; set; }
 
+        public string TemplateHandlersName { get; set; }
+
         public string SessionsCollectionName { get; set; }
 
         public string TestResultsCollectionName { get; set; }
 
         public string TestStatisticsCollectionName { get; set; }
+
+        public string ComposeFilesBucketName { get; set; }
 
     }
 

--- a/src/Pixel.Persistence.Respository/TemplateHandlerRepository.cs
+++ b/src/Pixel.Persistence.Respository/TemplateHandlerRepository.cs
@@ -1,0 +1,124 @@
+﻿using Dawn;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using Pixel.Persistence.Core.Models;
+using Pixel.Persistence.Core.Request;
+using Pixel.Persistence.Respository.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pixel.Persistence.Respository;
+
+/// <summary>
+/// Default implementation of <see cref="ITemplateHandlerRepository"/>
+/// </summary>
+public class TemplateHandlerRepository : ITemplateHandlerRepository
+{
+    private readonly ILogger logger;
+    private readonly IMongoCollection<TemplateHandler> handlersCollection;
+
+    private static readonly InsertOneOptions InsertOneOptions = new InsertOneOptions();
+    private static readonly FindOptions<TemplateHandler> FindOptions = new FindOptions<TemplateHandler>();
+    private static readonly FindOneAndUpdateOptions<TemplateHandler> FindOneAndUpdateOptions = new FindOneAndUpdateOptions<TemplateHandler>();
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="logger"></param>
+    /// <param name="dbSettings"></param>
+    public TemplateHandlerRepository(ILogger<TemplateHandlerRepository> logger, IMongoDbSettings dbSettings)
+    {
+        this.logger = Guard.Argument(logger, nameof(logger)).NotNull().Value;
+        var client = new MongoClient(dbSettings.ConnectionString);
+        var database = client.GetDatabase(dbSettings.DatabaseName);
+        handlersCollection = database.GetCollection<TemplateHandler>(dbSettings.TemplateHandlersName);
+    }
+
+    /// <inheritdoc/>  
+    public async Task<TemplateHandler> FindByIdAsync(string Id, CancellationToken cancellationToken)
+    {
+        Guard.Argument(Id, nameof(Id)).NotNull().NotEmpty();
+        var filter = Builders<TemplateHandler>.Filter.And(Builders<TemplateHandler>.Filter.Eq(x => x.Id, Id));
+        return (await handlersCollection.FindAsync(filter, FindOptions, cancellationToken)).FirstOrDefault();
+    }
+
+    /// <inheritdoc/>  
+    public async Task<TemplateHandler> FindByNameAsync(string name, CancellationToken cancellationToken)
+    {
+        Guard.Argument(name, nameof(name)).NotNull().NotEmpty();
+        var filter = Builders<TemplateHandler>.Filter.And(Builders<TemplateHandler>.Filter.Eq(x => x.Name, name));
+        return (await handlersCollection.FindAsync(filter, FindOptions, cancellationToken)).FirstOrDefault();
+    }
+
+    /// <inheritdoc/>  
+    public async Task<IEnumerable<TemplateHandler>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        var filter = Builders<TemplateHandler>.Filter.Empty;
+        var handlers = await handlersCollection.FindAsync(filter, FindOptions, cancellationToken);
+        return await handlers.ToListAsync();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<TemplateHandler>> GetHandlersAsync(GetHandlersRequest queryParameter)
+    {
+        Guard.Argument(queryParameter).NotNull();
+
+        var filterBuilder = Builders<TemplateHandler>.Filter;
+        var filter = filterBuilder.Empty;
+        if (!string.IsNullOrEmpty(queryParameter.HandlerFilter))
+        {
+            filter = filterBuilder.And(filter, filterBuilder.Regex(t => t.Name, new MongoDB.Bson.BsonRegularExpression(queryParameter.HandlerFilter)));            
+        }
+        var sort = Builders<TemplateHandler>.Sort.Descending(nameof(TemplateHandler.Name));
+        var all = handlersCollection.Find(filter).Sort(sort).Skip(queryParameter.Skip).Limit(queryParameter.Take);
+        var result = await all.ToListAsync();
+        return result ?? Enumerable.Empty<TemplateHandler>();
+    }
+
+    /// <inheritdoc/>  
+    public async Task AddHandlerAsync(TemplateHandler handler, CancellationToken cancellationToken)
+    {
+        Guard.Argument(handler).NotNull();
+        var exists = (await FindByNameAsync(handler.Name, cancellationToken)) != null;
+        if (exists)
+        {
+            throw new InvalidOperationException($"Handler with name {handler.Name} already exists.");
+        }
+        await handlersCollection.InsertOneAsync(handler, InsertOneOptions, cancellationToken).ConfigureAwait(false);
+        logger.LogInformation("Handler {0} was added.", handler.Name);
+    }
+
+    /// <inheritdoc/>  
+    public async Task UpdateHandlerAsync(TemplateHandler handler, CancellationToken cancellationToken)
+    {
+        Guard.Argument(handler).NotNull();
+        var filter = Builders<TemplateHandler>.Filter.Eq(f => f.Id, handler.Id);
+        var updateDefinition = Builders<TemplateHandler>.Update
+          .Set(t => t.Parameters, handler.Parameters)
+          .Set(t => t.Description, handler.Description)            
+          .Set(t => t.LastUpdated, DateTime.UtcNow)
+          .Inc(t => t.Revision, 1);
+        if(handler is DockerTemplateHandler dockerTemplateHandler)
+        {
+            updateDefinition = updateDefinition.Set(t => (t as DockerTemplateHandler).DockerComposeFileName, dockerTemplateHandler.DockerComposeFileName);
+        }
+
+        await handlersCollection.FindOneAndUpdateAsync(filter, updateDefinition, FindOneAndUpdateOptions, cancellationToken);       
+        logger.LogInformation("Handler {0} was updated.", handler.Name);
+    }
+
+    /// <inheritdoc/>  
+    public async Task DeleteHandlerAsync(string Id, CancellationToken cancellationToken)
+    {
+        var filter = Builders<TemplateHandler>.Filter.Eq(f => f.Id, Id);
+        var updateDefinition = Builders<TemplateHandler>.Update
+            .Set(t => t.IsDeleted, true)
+            .Set(t => t.LastUpdated, DateTime.UtcNow)
+            .Inc(t => t.Revision, 1);
+        await handlersCollection.FindOneAndUpdateAsync(filter, updateDefinition, FindOneAndUpdateOptions, cancellationToken);
+        logger.LogInformation("Handler with Id : {0} was deleted", Id);
+    }
+}

--- a/src/Pixel.Persistence.Services.Api/Controllers/ComposeFilesController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/ComposeFilesController.cs
@@ -1,0 +1,119 @@
+﻿using Dawn;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Pixel.Persistence.Respository;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+
+namespace Pixel.Persistence.Services.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ComposeFilesController : ControllerBase
+    {
+        private readonly ILogger<ComposeFilesController> logger;      
+        private readonly IComposeFilesRepository composeFilesRepository;
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="composeFilesRepository"></param>
+        public ComposeFilesController(ILogger<ComposeFilesController> logger, IComposeFilesRepository composeFilesRepository)
+        {
+            this.logger = Guard.Argument(logger).NotNull().Value;          
+            this.composeFilesRepository = Guard.Argument(composeFilesRepository).NotNull().Value;
+        }
+
+        [HttpGet("names")]
+        public async Task<IEnumerable<string>> GetAllFileNames()
+        {
+            var files = composeFilesRepository.GetAllFileNamesAsync();
+            var names = new List<string>();
+            await foreach(var fileName in files)
+            {
+                names.Add(fileName);
+            }
+            return names;
+        }
+             
+        [HttpGet]
+        public async Task<ActionResult> GetAllFilesAsync()
+        {
+            try
+            {
+                using (var stream = new MemoryStream())
+                {
+                    using (var zipArchive = new ZipArchive(stream, ZipArchiveMode.Create))
+                    {
+                        await foreach (var file in this.composeFilesRepository.GetAllFilesAsync())
+                        {
+                            var zipEntry = zipArchive.CreateEntry(Path.Combine(file.FilePath));
+                            using (var zipEntryStream = zipEntry.Open())
+                            {
+                                zipEntryStream.Write(file.Bytes);
+                            }
+                        }
+                    }
+                    return File(stream.ToArray(), "application/zip", "compose-files.zip");
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+             
+        [HttpGet("name/{fileName}")]
+        public async Task<ActionResult> GetFileByName(string fileName)
+        {
+            try
+            {
+                var file = await composeFilesRepository.GetFileAsync(fileName);
+                if (file != null)
+                {
+                    return Ok(file);
+                }
+                return NotFound();
+
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [HttpPost()]
+        public async Task<IActionResult> AddComposeFileAsync(IFormFile composeFile)
+        {
+            try
+            {
+                Guard.Argument(composeFile, nameof(composeFile)).NotNull();
+                if (await composeFilesRepository.CheckFileExistsAsync(composeFile.FileName))
+                {
+                    logger.LogInformation("File {0} already exists and will be replaced", composeFile.FileName);
+                }
+                Byte[] fileBytes;
+                using (var ms = new MemoryStream())
+                {
+                    composeFile.CopyTo(ms);
+                    fileBytes = ms.ToArray();
+                }
+                await composeFilesRepository.AddOrUpdateFileAsync(composeFile.FileName, fileBytes);
+                logger.LogInformation("File {0} was uploaded", composeFile.FileName);
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+    }
+}

--- a/src/Pixel.Persistence.Services.Api/Controllers/HandlersController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/HandlersController.cs
@@ -1,0 +1,137 @@
+﻿using Dawn;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Pixel.Persistence.Core.Models;
+using Pixel.Persistence.Core.Request;
+using Pixel.Persistence.Core.Response;
+using Pixel.Persistence.Respository.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pixel.Persistence.Services.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class HandlersController : ControllerBase
+    {
+        private readonly ILogger<HandlersController> logger;
+        private readonly ITemplateHandlerRepository handlersRepository;
+        
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="fixturesRepository"></param>
+        public HandlersController(ILogger<HandlersController> logger, ITemplateHandlerRepository handlersRepository)
+        {
+            this.logger = Guard.Argument(logger).NotNull().Value;
+            this.handlersRepository = Guard.Argument(handlersRepository).NotNull().Value;            
+        }
+
+        [HttpGet("name/{name}")]
+        public async Task<ActionResult<TemplateHandler>> FindByNameAsync(string name)
+        {
+            try
+            {               
+                Guard.Argument(name, nameof(name)).NotNull().NotEmpty();
+                var handler = await handlersRepository.FindByNameAsync(name, CancellationToken.None);               
+                if(handler != null)
+                {
+                    return Ok(handler);
+                }
+                return NotFound();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [HttpGet("id/{id}")]
+        public async Task<TemplateHandler> FindByIdAsync(string id)
+        {
+            try
+            {
+                Guard.Argument(id, nameof(id)).NotNull().NotEmpty();
+                var handler = await handlersRepository.FindByIdAsync(id, CancellationToken.None);
+                return handler;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return null;
+            }
+        }
+
+        [HttpGet]
+        public async Task<IEnumerable<TemplateHandler>> GetAll()
+        {
+            var handlers = await handlersRepository.GetAllAsync(CancellationToken.None);
+            return handlers;
+        }
+
+        [HttpGet("paged")]
+        public async Task<PagedList<TemplateHandler>> Get([FromQuery] GetHandlersRequest queryParameter)
+        {
+            var handlers = await handlersRepository.GetHandlersAsync(queryParameter);
+            return new PagedList<TemplateHandler>(handlers, handlers.Count(), queryParameter.CurrentPage, queryParameter.PageSize);
+        }              
+
+        [HttpPost]
+        public async Task<ActionResult<TemplateHandler>> AddHandlerAsync(TemplateHandler handler)
+        {
+            try
+            {
+                Guard.Argument(handler, nameof(handler)).NotNull();             
+                await handlersRepository.AddHandlerAsync(handler, CancellationToken.None);
+                logger.LogInformation("Template handler {0} was added", handler.Name);
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [HttpPut]
+        public async Task<ActionResult<TemplateHandler>> UpdateHandlerAsync(TemplateHandler handler)
+        {
+            try
+            {
+                Guard.Argument(handler, nameof(handler)).NotNull();
+                await handlersRepository.UpdateHandlerAsync(handler, CancellationToken.None);
+                logger.LogInformation("Template handler {0} was updated", handler.Name);
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [HttpDelete]
+        public async Task<IActionResult> DeleteHandlerAsync(string Id)
+        {
+            try
+            {
+                Guard.Argument(Id, nameof(Id)).NotNull().NotEmpty();
+                await handlersRepository.DeleteHandlerAsync(Id, CancellationToken.None);
+                logger.LogInformation("Template handler with Id : {0} was deleted", Id);
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }        
+
+    }
+}

--- a/src/Pixel.Persistence.Services.Api/Startup.cs
+++ b/src/Pixel.Persistence.Services.Api/Startup.cs
@@ -56,8 +56,10 @@ namespace Pixel.Persistence.Services.Api
             services.AddTransient<ITestCaseRepository, TestCaseRepository>();
             services.AddTransient<ITestDataRepository, TestDataRepository>();           
             services.AddTransient<IPrefabsRepository, PrefabsRepository>();
-            services.AddTransient<ITemplateRepository, TemplateRepository>();                      
-           
+            services.AddTransient<ITemplateRepository, TemplateRepository>();
+            services.AddTransient<ITemplateHandlerRepository, TemplateHandlerRepository>();
+            services.AddTransient<IComposeFilesRepository, ComposeFilesRepository>();
+
             services.AddControllers();
             services.AddRazorPages();
             services.AddSignalR();

--- a/src/Pixel.Persistence.Services.Api/appsettings.Development.json
+++ b/src/Pixel.Persistence.Services.Api/appsettings.Development.json
@@ -22,6 +22,8 @@
     "PrefabProjectsCollectionname": "prefabs-projects",
     "PrefabFilesBucketName": "bucket-prefab-files",
     "TemplatesCollectionName": "templates",
+    "TemplateHandlersName": "template-handlers",
+    "ComposeFilesBucketName": "docker-compose-files",
     "SessionsCollectionName": "sessions",
     "TestResultsCollectionName": "test-results",
     "TestStatisticsCollectionName": "test-statistics",


### PR DESCRIPTION
Template triggers can be created and saved now. This will allow agents to retrieve handler details from service including docker template files for docker based templates. This allows for templates to be managed from UI. Also, parameters will allow customization e.g. specify which version of a container image to use.