### PR TITLE
Upgrade playwright and selenium binaries

### DIFF
--- a/src/Pixel.Automation.Web.Playwright.Components/Pixel.Automation.Web.Playwright.Components.csproj
+++ b/src/Pixel.Automation.Web.Playwright.Components/Pixel.Automation.Web.Playwright.Components.csproj
@@ -4,7 +4,8 @@
 		<TargetFrameworks>net7.0;net7.0-windows</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<EnableDynamicLoading>true</EnableDynamicLoading>	
-		<RuntimeIdentifiers>win10-x64;linux-x64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win10-x64;linux-x64;</RuntimeIdentifiers>
+		<PlaywrightPlatform>win;linux;</PlaywrightPlatform>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -18,7 +19,7 @@
 		<PackageReference Include="Serilog" Version="2.12.0">
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Playwright" Version="1.33.0" />
+		<PackageReference Include="Microsoft.Playwright" Version="1.36.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Pixel.Automation.Web.Scrapper/Pixel.Automation.Web.Scrapper.csproj
+++ b/src/Pixel.Automation.Web.Scrapper/Pixel.Automation.Web.Scrapper.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="Serilog" Version="2.12.0">
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Playwright" Version="1.32.0" />
+		<PackageReference Include="Microsoft.Playwright" Version="1.36.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Pixel.Automation.Web.Selenium.Components/Pixel.Automation.Web.Selenium.Components.csproj
+++ b/src/Pixel.Automation.Web.Selenium.Components/Pixel.Automation.Web.Selenium.Components.csproj
@@ -33,8 +33,8 @@
 		<PackageReference Include="System.Dynamic.Runtime" Version="4.3.0">
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Selenium.Support" Version="4.9.1" />
-		<PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
+		<PackageReference Include="Selenium.Support" Version="4.10.0" />
+		<PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
 		<PackageReference Include="WebDriverManager" Version="2.16.2" />
 	</ItemGroup>
 


### PR DESCRIPTION
1. Update playwright and selenium binaries to latest version
2. Set PlaywrightPlatform to win;linux to avoid copying node for debian. linux-arm64 is strangely not included when specifying linux instead of all.