### PR TITLE
Incorrect data format passed for TestResult executedAfter datetime parameter

### DIFF
--- a/src/Pixel.Automation.Web.Portal/Services/TestResultService.cs
+++ b/src/Pixel.Automation.Web.Portal/Services/TestResultService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.WebUtilities;
 using MudBlazor;
+using MudBlazor.Extensions;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Core.Request;
 using Pixel.Persistence.Core.Response;
@@ -71,7 +72,7 @@ namespace Pixel.Automation.Web.Portal.Services
                 {
                     ["currentPage"] = request.CurrentPage.ToString(),
                     ["pageSize"] = request.PageSize.ToString(),
-                    ["executedAfter"] = request.ExecutedAfter.ToUniversalTime().ToString(),
+                    ["executedAfter"] = request.ExecutedAfter.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss"),
                     //["executionTimeGte"] = request.ExecutionTimeGte.ToString(),
                     //["executionTimeLte"] = request.ExecutionTimeLte.ToString(),
                     ["result"] = request.Result.ToString(),


### PR DESCRIPTION
**Description**
ProjectStatistics and TestStatistics page fails to retrieve the test results as the passed datatime value can't be processed by the api endpoint.

Error Message : {"ExecutedAfter":["The value '31/07/2023 16:07:37' is not valid for ExecutedAfter."]}