### PR TITLE
Incorrect entity manager set on fixtures and test cases after save

### DIFF
--- a/src/Pixel.Automation.Core/Component/Entity.cs
+++ b/src/Pixel.Automation.Core/Component/Entity.cs
@@ -112,7 +112,7 @@ namespace Pixel.Automation.Core
                     }
                     else
                     {
-                        //When adding TestCaseEntity, EntityManager is already set.
+                        //TestCase and TestFixture Entity have their own non-primary EntityManager
                         if (component is Entity entity)
                         {
                             this.EntityManager.RestoreParentChildRelation(entity);
@@ -150,8 +150,7 @@ namespace Pixel.Automation.Core
             if (component != null && this.components.Contains(component))
             {                
                 this.components.Remove(component);               
-                component.Parent = null;
-                component.EntityManager = null;
+                component.Parent = null;               
                
                 int i = 1;
                 foreach(var c in this.components)
@@ -161,6 +160,7 @@ namespace Pixel.Automation.Core
 
                 if (dispose && component is IDisposable disposable)
                 {
+                    component.EntityManager = null;
                     disposable.Dispose();
                 }               
             }

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -265,9 +265,10 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 //Remove all the test fixtures as we don't want them to save as a part of  automamtion process file
                 var testFixtureEntities = this.entityManager.RootEntity.GetComponentsOfType<TestFixtureEntity>(SearchScope.Descendants);
                 Entity parentEntity = testFixtureEntities.FirstOrDefault()?.Parent;
-                foreach (var testEntity in testFixtureEntities)
+                foreach (var testFixtureEntity in testFixtureEntities)
                 {
-                    testEntity.Parent.RemoveComponent(testEntity);
+                    //we don't want to dispose test fixture entity and/or clear out it's entity manager as we need to restore it back soon.
+                    testFixtureEntity.Parent.RemoveComponent(testFixtureEntity, false);
                 }
 
                 serializer.Serialize(this.projectFileSystem.ProjectFile, this.activeProject);

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -258,7 +258,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 serializer.Serialize(this.prefabFileSystem.PrefabFile, this.prefabEntity, typeProvider.GetKnownTypes());
 
                 var prefabParent = this.prefabEntity.Parent;
-                prefabParent.RemoveComponent(this.prefabEntity);
+                prefabParent.RemoveComponent(this.prefabEntity, false);
                 this.prefabFileSystem.CreateOrReplaceTemplate(this.RootEntity);
                 prefabParent.AddComponent(this.prefabEntity);
                                        

--- a/src/Pixel.Automation.RunTime/TestRunner.cs
+++ b/src/Pixel.Automation.RunTime/TestRunner.cs
@@ -406,11 +406,8 @@ namespace Pixel.Automation.RunTime
                     return $"{nameof(TestCaseEntity)} is not set for test case : {testCase}";
                 });
 
-                fixture.TestFixtureEntity.RemoveComponent(testCase.TestCaseEntity);
-
-                var entityManager = testCase.TestCaseEntity.EntityManager;
-                entityManager?.Dispose();
-                testCase.TestCaseEntity.EntityManager = null;
+                testCase.TestCaseEntity.EntityManager.Dispose();               
+                fixture.TestFixtureEntity.RemoveComponent(testCase.TestCaseEntity);              
 
                 logger.Information("Removed test case : {0} from Fixture.", testCase);
                 

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
@@ -576,7 +576,8 @@ namespace Pixel.Automation.TestExplorer.ViewModels
             var testCaseEntities = fixtureVM.TestFixtureEntity.GetComponentsOfType<TestCaseEntity>(SearchScope.Descendants);
             foreach (var testEntity in testCaseEntities)
             {
-                testEntity.Parent.RemoveComponent(testEntity);
+                //we don't want to dispose test fixture entity and/or clear out it's entity manager as we need to restore it back soon.
+                testEntity.Parent.RemoveComponent(testEntity, false);
             }
 
             if(fixtureVM.IsDirty)


### PR DESCRIPTION
**Description**
When we save the project, incorrect entity manager is applied on the fixtures and test cases as we remove and add them back during save. As a result , script variables are not available on the test cases and fixtures defined for them.