### PR TITLE
Trace data for test execution

### DIFF
--- a/Pixel.Automation.sln
+++ b/Pixel.Automation.sln
@@ -179,6 +179,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Automation.UIAComWrap
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Automation.Native.Linux", "src\Pixel.Automation.Native.Linux\Pixel.Automation.Native.Linux.csproj", "{1436F4EE-4E05-4188-9A3A-42CC8807BB71}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.Pixel.Trace", "src\Serilog.Sinks.Pixel.Trace\Serilog.Sinks.Pixel.Trace.csproj", "{65FC70E2-B2F6-45AF-B0CF-21BAC68D7255}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -461,6 +463,10 @@ Global
 		{1436F4EE-4E05-4188-9A3A-42CC8807BB71}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1436F4EE-4E05-4188-9A3A-42CC8807BB71}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1436F4EE-4E05-4188-9A3A-42CC8807BB71}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65FC70E2-B2F6-45AF-B0CF-21BAC68D7255}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65FC70E2-B2F6-45AF-B0CF-21BAC68D7255}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65FC70E2-B2F6-45AF-B0CF-21BAC68D7255}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65FC70E2-B2F6-45AF-B0CF-21BAC68D7255}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -540,6 +546,7 @@ Global
 		{89A122E5-5662-4400-BCC7-42C75A8BC4B6} = {2B0C7388-18D7-4E3C-8BDF-B7A414520615}
 		{59970211-C97D-4B93-8D13-ED34FD40C780} = {242744A0-4C9B-4B89-9AC0-4188D186D4D2}
 		{1436F4EE-4E05-4188-9A3A-42CC8807BB71} = {2B0C7388-18D7-4E3C-8BDF-B7A414520615}
+		{65FC70E2-B2F6-45AF-B0CF-21BAC68D7255} = {7E4532E6-7928-4E6F-8874-15482508447F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DEAA90E2-A175-4FAA-99F1-30B64D8D3125}

--- a/src/Pixel.Automation.Core/Enums/TraceLevel.cs
+++ b/src/Pixel.Automation.Core/Enums/TraceLevel.cs
@@ -1,0 +1,22 @@
+﻿namespace Pixel.Automation.Core.Enums;
+
+/// <summary>
+/// Represents different levels in to which trace messages captured during execution of test cases can be categorized
+/// </summary>
+public enum TraceLevel
+{
+    /// <summary>
+    /// Indicates that trace message is an informational message
+    /// </summary>
+    Information,
+
+    /// <summary>
+    /// Indicates that trace message is a warning message
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// /Indicates that trace message is an error message
+    /// </summary>
+    Error
+}

--- a/src/Pixel.Automation.Core/Enums/TraceType.cs
+++ b/src/Pixel.Automation.Core/Enums/TraceType.cs
@@ -1,0 +1,17 @@
+﻿namespace Pixel.Automation.Core.Enums;
+
+/// <summary>
+/// Represents different types of trace messages captured during execution of test cases
+/// </summary>
+public enum TraceType
+{
+    /// <summary>
+    /// Indicates that captured trace is a message
+    /// </summary>
+    Message,
+
+    /// <summary>
+    /// Indicates that captured trace is an image
+    /// </summary>
+    Image
+}

--- a/src/Pixel.Automation.Core/TestData/TestResult.cs
+++ b/src/Pixel.Automation.Core/TestData/TestResult.cs
@@ -31,6 +31,11 @@ namespace Pixel.Automation.Core.TestData
                 OnPropertyChanged();
             }
         }
+       
+        /// <summary>
+        /// DateTime when the test case execution started
+        /// </summary>
+        public DateTime StartTime { get; private set; } = DateTime.Now;
 
         TimeSpan executionTime = TimeSpan.Zero;
         /// <summary>

--- a/src/Pixel.Automation.Core/TraceManager.cs
+++ b/src/Pixel.Automation.Core/TraceManager.cs
@@ -1,0 +1,89 @@
+﻿using Pixel.Automation.Core.Enums;
+using System;
+using System.Collections.Generic;
+
+namespace Pixel.Automation.Core;
+
+/// <summary>
+/// TraceData represents a log message or an image captured while executing a test case
+/// </summary>
+/// <param name="RecordedAt"></param>
+/// <param name="TraceType"></param>
+/// <param name="TraceLevel"></param>
+/// <param name="Content"></param>
+public record TraceData(DateTime RecordedAt, TraceType TraceType, TraceLevel TraceLevel, string Content);
+
+/// <summary>
+/// TraceManager is responsible for collecting emitted messages and images and processing these in to <see cref="TraceData"/> during execution of test case.
+/// </summary>
+public static class TraceManager
+{
+    public static readonly string CaptureTrace = nameof(CaptureTrace);
+    
+    private static readonly ICollection<TraceData> traces = new List<TraceData>(32);
+       
+    private static bool isCapturing;
+       
+    private static bool isEnabled;
+    /// <summary>
+    /// Indicates if TraceManager is enabled
+    /// </summary>
+    public static bool IsEnabled 
+    {
+        get => isEnabled && isCapturing;
+        set => isEnabled = value;        
+    }
+
+    /// <summary>
+    /// Add a message to the TraceManager
+    /// </summary>
+    /// <param name="traceLevel"></param>
+    /// <param name="message"></param>
+    public static void AddMessage(TraceLevel traceLevel, string message)
+    {
+        if (IsEnabled)
+        {
+            traces.Add(new TraceData(DateTime.UtcNow, TraceType.Message, traceLevel, message));
+        }
+    }
+
+    /// <summary>
+    /// Add an image to the TraceManager
+    /// </summary>
+    /// <param name="imageFile"></param>
+    public static void AddImage(string imageFile)
+    {
+        if (IsEnabled)
+        {
+            traces.Add(new TraceData(DateTime.UtcNow, TraceType.Image, TraceLevel.Information, imageFile));
+        }
+    }
+
+    /// <summary>
+    /// Signal the TraceManager to start capturing of <see cref="TraceData"/>
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static void StartCapture() 
+    {
+        if(traces.Count > 0)
+        {
+            throw new InvalidOperationException("Capture still in progress. EndCapture should be invoked before starting a new capture.");
+        }
+        isCapturing = true;
+    }
+
+    /// <summary>
+    /// Retrieve all the <see cref="TraceData"/> captured so far and stop capturing
+    /// </summary>
+    /// <returns></returns>
+    public static IEnumerable<TraceData> EndCapture()
+    {
+        foreach(var trace in traces)
+        {
+            yield return trace;
+        }       
+        traces.Clear();
+        isCapturing = false;
+        yield break;
+    }
+}

--- a/src/Pixel.Automation.Test.Runner/Pixel.Automation.Test.Runner.csproj
+++ b/src/Pixel.Automation.Test.Runner/Pixel.Automation.Test.Runner.csproj
@@ -54,6 +54,7 @@
 		<ProjectReference Include="..\Pixel.Scripting.Common.CSharp\Pixel.Scripting.Common.CSharp.csproj" />
 		<ProjectReference Include="..\Pixel.Scripting.Editor.Core\Pixel.Scripting.Editor.Core.csproj" />
 		<ProjectReference Include="..\Pixel.Scripting.Engine.CSharp\Pixel.Scripting.Engine.CSharp.csproj" />
+		<ProjectReference Include="..\Serilog.Sinks.Pixel.Trace\Serilog.Sinks.Pixel.Trace.csproj" />
 	</ItemGroup>
 	
 	<Import Project="..\Pixel.Automation.Plugin.Automation.targets" />		

--- a/src/Pixel.Automation.Test.Runner/Program.cs
+++ b/src/Pixel.Automation.Test.Runner/Program.cs
@@ -61,6 +61,8 @@ namespace Pixel.Automation.Test.Runner
             #endif
             var traceProvider = traceProviderBuilder.Build();
 
+            TraceManager.IsEnabled = true;
+
             try
             {
                 logger.Information("Started with args : {0}", args);

--- a/src/Pixel.Automation.Test.Runner/appsettings.json
+++ b/src/Pixel.Automation.Test.Runner/appsettings.json
@@ -1,6 +1,6 @@
 {
   "Serilog": {
-    "Using": [ "Serilog.Sinks.SpectreConsole", "Serilog.Sinks.File", "Serilog.Sinks.OpenTelemetry", "Serilog.Sinks.Http" ],
+    "Using": [ "Serilog.Sinks.SpectreConsole", "Serilog.Sinks.File", "Serilog.Sinks.OpenTelemetry", "Serilog.Sinks.Http", "Serilog.Sinks.Pixel.Trace" ],
     "MinimumLevel": "Information",
     "WriteTo": [
       {
@@ -23,6 +23,9 @@
           "endpoint": "http://localhost:5341/ingest/otlp/v1/logs",
           "protocol": "HttpProtobuf"
         }
+      },
+      {
+        "Name": "Trace"
       }
     ],
     "Enrich": [ "FromLogContext", "WithMachineName", "WithEnvironmentUserName", "WithThreadId", "WithSpan" ],

--- a/src/Pixel.Automation.Web.Portal/Components/TestResultsTable.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/TestResultsTable.razor
@@ -8,7 +8,7 @@
                       AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
         <MudItem xs="1" Class="ml-4">
             <MudSelect Label="Last N Months" T="int" Value="lastNMonths" ValueChanged="OnMonthsChanged"
-                       OffsetY="true">
+                       AnchorOrigin="Origin.BottomRight">
                 @foreach (int item in Enumerable.Range(1, 6))
                 {
                     <MudSelectItem Value="@item">@item</MudSelectItem>
@@ -34,7 +34,7 @@
         {
             <MudTh>Statistics</MudTh>
         }
-
+        <MudTh>Traces</MudTh>
     </HeaderContent>
     <RowTemplate>
         <MudTd>
@@ -68,11 +68,16 @@
         @if (ShowStatisticsButton)
         {
             <MudTd DataLabel="Statistics">
-                <MudButton Link="@($"test-statistics/{context.TestId}")" Variant="Variant.Filled">
+                <MudButton Href="@($"test-statistics/{context.TestId}")" Variant="Variant.Filled">
                     View Stats
                 </MudButton>
             </MudTd>
-        }
+        } 
+        <MudTd DataLabel="Trace">
+            <MudButton Href="@($"test-traces/{context.Id}")" Variant="Variant.Filled">
+                View Trace
+            </MudButton>
+        </MudTd>
     </RowTemplate>
     <ChildRowContent>
         @if (context.IsErrorDetailsVisible)
@@ -100,5 +105,6 @@
         {
             <col />
         }
+        <col />
     </ColGroup>
 </MudTable>

--- a/src/Pixel.Automation.Web.Portal/Components/Tests/ImageDialog.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/Tests/ImageDialog.razor
@@ -1,0 +1,13 @@
+﻿@inject ISnackbar Snackbar
+
+<MudDialog DisableSidePadding="true">
+    <DialogContent>
+        @if(imageBytes != null)
+        {
+           <div class="d-flex justify-center">
+                <MudImage Src="@string.Format("data:image/png;base64,{0}", Convert.ToBase64String(imageBytes))"
+                          Fluid="true" Class="rounded-lg ma-4" Height="800" Width="600" />
+            </div>             
+        }     
+    </DialogContent>   
+</MudDialog>

--- a/src/Pixel.Automation.Web.Portal/Components/Tests/ImageDialog.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Components/Tests/ImageDialog.razor.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Components;
+
+namespace Pixel.Automation.Web.Portal.Components.Tests;
+
+public partial class ImageDialog : ComponentBase
+{  
+    [Parameter] public byte[] imageBytes { get; set; }
+}

--- a/src/Pixel.Automation.Web.Portal/Components/Tests/TestTraces.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/Tests/TestTraces.razor
@@ -1,0 +1,39 @@
+﻿ <MudStack>
+    @foreach (var trace in this.TestResult?.Traces ?? Enumerable.Empty<TraceData>())
+    {
+        if (trace is MessageTraceData messageTrace)
+        {         
+            <MudCard>
+                <MudCardHeader>
+                    <CardHeaderAvatar>
+                        <MudIcon Color="GetColor(trace)" Icon="@Icons.Material.Outlined.Info" Size="Size.Large" />
+                    </CardHeaderAvatar>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.body1">@messageTrace.Messsage</MudText>
+                    </CardHeaderContent>                   
+                </MudCardHeader>             
+            </MudCard>
+        }
+        else if (trace is ImageTraceData imageTrace)
+        {
+            <MudCard>
+                <MudCardHeader>
+                    <CardHeaderAvatar>
+                        <MudIcon Color="Color.Info" Icon="@Icons.Material.Outlined.Info" Size="Size.Large" />
+                    </CardHeaderAvatar>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.body1">Screenshot was captured</MudText>
+                    </CardHeaderContent>
+                    <CardHeaderActions>
+                        <MudIconButton Icon="@Icons.Material.Filled.Settings" Color="Color.Default" @onclick="()=> ShowImageAsync(imageTrace)" />
+                    </CardHeaderActions>
+                </MudCardHeader>
+            </MudCard>
+        }
+    }
+    @if (this.TestResult?.FailureDetails != null)
+    {
+        <ErrorDetails FailureDetails="new FailureDetailsViewModel(this.TestResult.SessionId, this.TestResult.TestId, this.TestResult.FailureDetails)" IsFailureReasonEditable="true" />
+    }
+
+ </MudStack>

--- a/src/Pixel.Automation.Web.Portal/Components/Tests/TestTraces.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Components/Tests/TestTraces.razor.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pixel.Automation.Web.Portal.Services;
+using Pixel.Persistence.Core.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Components.Tests;
+
+/// <summary>
+/// Component for showing the TraceData captured while execution of a test case
+/// </summary>
+public partial class TestTraces : ComponentBase
+{
+    [Inject]
+    IDialogService DialogService { get; set; }
+
+    [Inject]
+    public ISnackbar SnackBar { get; set; }
+
+    [Inject]
+    ITestResultService TestResultService { get; set; }
+
+    [Parameter]
+    public TestResult TestResult { get; set; }   
+
+    /// <summary>
+    /// Get the color based on the trace level of the TraceData
+    /// </summary>
+    /// <param name="trace"></param>
+    /// <returns></returns>
+    Color GetColor(TraceData trace)
+    {
+        switch(trace.TraceLevel)
+        {
+            case Persistence.Core.Enums.TraceLevel.Information:
+                return Color.Success;
+            case Persistence.Core.Enums.TraceLevel.Warning:
+                return Color.Warning;
+            case Persistence.Core.Enums.TraceLevel.Error:
+                return Color.Error;
+            default:
+                return Color.Default;
+        }
+    }
+
+    /// <summary>
+    /// Retreive image and show in a popup dialog on clicking the button
+    /// </summary>
+    /// <param name="traceData"></param>
+    /// <returns></returns>
+    async Task ShowImageAsync(ImageTraceData traceData)
+    {
+        try
+        {
+            var dataFile = await TestResultService.GetTraceImage(TestResult.Id, traceData.ImageFile);
+            DialogOptions dialogOptions = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+            var parameters = new DialogParameters<ImageDialog> { { x => x.imageBytes, dataFile.Bytes } };
+            var dialog = await DialogService.ShowAsync<ImageDialog>("Screenshot", parameters, dialogOptions);
+            await dialog.Result;
+        }
+        catch (Exception ex)
+        {
+            SnackBar.Add(ex.Message, Severity.Error);
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Pages/Tests/StatisticsPage.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Pages/Tests/StatisticsPage.razor.cs
@@ -1,17 +1,9 @@
 ﻿using Microsoft.AspNetCore.Components;
-using MudBlazor;
-using Pixel.Automation.Web.Portal.Services;
-using Pixel.Automation.Web.Portal.ViewModels;
-using Pixel.Persistence.Core.Models;
-using Pixel.Persistence.Core.Request;
-using Pixel.Persistence.Core.Response;
-using System.Threading.Tasks;
 
-namespace Pixel.Automation.Web.Portal.Pages.Tests
-{
-    public partial class StatisticsPage : ComponentBase
-    {      
-        [Parameter]
-        public string TestId { get; set; }     
-    }
+namespace Pixel.Automation.Web.Portal.Pages.Tests;
+
+public partial class StatisticsPage : ComponentBase
+{      
+    [Parameter]
+    public string TestId { get; set; }     
 }

--- a/src/Pixel.Automation.Web.Portal/Pages/Tests/TracesPage.razor
+++ b/src/Pixel.Automation.Web.Portal/Pages/Tests/TracesPage.razor
@@ -1,0 +1,17 @@
+﻿@page "/test-traces/{TestResultId?}"
+
+<MudGrid Elevation="4" Justify="Justify.Center">
+    <MudItem xs="12">
+        <MudPaper Elevation="3" Class="d-flex flex-row pt-4 pl-3" Style="height:60px;">
+            <MudText Typo="Typo.h5" Color="Color.Primary">Viewing traces for test case : @testResult?.TestName</MudText>
+        </MudPaper>
+    </MudItem>
+</MudGrid>
+<br />
+<MudPaper Elevation="3" Class="pa-4">
+    @if (testResult != null)
+    {
+        <Pixel.Automation.Web.Portal.Components.Tests.TestTraces TestResult="@testResult" />
+    }
+</MudPaper>
+

--- a/src/Pixel.Automation.Web.Portal/Pages/Tests/TracesPage.razor.cs
+++ b/src/Pixel.Automation.Web.Portal/Pages/Tests/TracesPage.razor.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Components;
+using Pixel.Automation.Web.Portal.Services;
+using Pixel.Persistence.Core.Models;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Web.Portal.Pages.Tests;
+
+/// <summary>
+/// Page for viewing trace data captured while execution of a test case
+/// </summary>
+public partial class TracesPage : ComponentBase
+{
+    TestResult testResult;
+    
+    [Parameter]
+    public string TestResultId { get; set; }
+      
+    [Inject]
+    ITestResultService TestResultService { get; set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!string.IsNullOrEmpty(TestResultId))
+        {
+            testResult = await TestResultService.GetResultById(TestResultId);           
+        }
+    }
+}

--- a/src/Pixel.Automation.Web.Portal/Services/TestResultService.cs
+++ b/src/Pixel.Automation.Web.Portal/Services/TestResultService.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.WebUtilities;
 using MudBlazor;
-using MudBlazor.Extensions;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Core.Request;
 using Pixel.Persistence.Core.Response;
@@ -12,9 +11,32 @@ using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 namespace Pixel.Automation.Web.Portal.Services
-{    
+{
     public interface ITestResultService
     {
+        /// <summary>
+        /// Get the test result with a given identifier
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        Task<TestResult> GetResultById(string id);
+
+
+        /// <summary>
+        /// Get trace image file with specified name for a given test result
+        /// </summary>
+        /// <param name="id">Identifier of the TestResult</param>
+        /// <param name="imageFile">Name of the image file</param>
+        /// <returns></returns>
+        Task<DataFile> GetTraceImage(string id, string imageFile);
+
+        /// <summary>
+        /// Get trace image files for a given test result
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        Task<IEnumerable<DataFile>> GetTraceImages(string id);
+
         /// <summary>
         /// Get all the test results for a TestSession given it's sessionId
         /// </summary>
@@ -43,17 +65,41 @@ namespace Pixel.Automation.Web.Portal.Services
         private readonly HttpClient http;
         private readonly ISnackbar snackBar;
 
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="http"></param>
+        /// <param name="snackBar"></param>
         public TestResultService(HttpClient http, ISnackbar snackBar)
         {
             this.http = http;
             this.snackBar = snackBar;
         }
 
+        ///<inheritdoc/>
+        public async Task<TestResult> GetResultById(string id)
+        {
+            return await this.http.GetFromJsonAsync<TestResult>($"api/TestResult/{id}");
+        }
+
+        ///<inheritdoc/>
+        public async Task<DataFile> GetTraceImage(string id, string imageFile)
+        {
+            return await this.http.GetFromJsonAsync<DataFile>($"api/TestResult/trace/{id}/image/{imageFile}");
+        }
+
+        ///<inheritdoc/>
+        public async Task<IEnumerable<DataFile>> GetTraceImages(string id)
+        {
+            return await this.http.GetFromJsonAsync<IEnumerable<DataFile>>($"api/TestResult/trace/images/{id}");
+        }
+
+        ///<inheritdoc/>
         public async Task<IEnumerable<TestResult>> GetResultsInSessionAsync(string sessionId)
         {
             try
             {
-                var testsInSession = await this.http.GetFromJsonAsync<IEnumerable<TestResult>>($"api/TestResult/{sessionId}");
+                var testsInSession = await this.http.GetFromJsonAsync<IEnumerable<TestResult>>($"api/TestResult/session/{sessionId}");
                 return testsInSession;
             }
             catch (Exception ex)
@@ -64,6 +110,7 @@ namespace Pixel.Automation.Web.Portal.Services
             }
         }
 
+        ///<inheritdoc/>
         public async Task<PagedList<TestResult>> GetTestResultsAsync(TestResultRequest request)
         {
             try
@@ -109,6 +156,7 @@ namespace Pixel.Automation.Web.Portal.Services
             }
         }
 
+        ///<inheritdoc/>
         public async Task UpdateFailureReasonAsync(string sessionId, string testId, string failureReason)
         {
             try

--- a/src/Pixel.Persistence.Core/Enums/TraceLevel.cs
+++ b/src/Pixel.Persistence.Core/Enums/TraceLevel.cs
@@ -1,0 +1,22 @@
+﻿namespace Pixel.Persistence.Core.Enums;
+
+/// <summary>
+/// Represents different levels in to which trace messages captured during execution of test cases can be categorized
+/// </summary>
+public enum TraceLevel
+{
+    /// <summary>
+    /// Indicates that trace message is an informational message
+    /// </summary>
+    Information,
+
+    /// <summary>
+    /// Indicates that trace message is a warning message
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// /Indicates that trace message is an error message
+    /// </summary>
+    Error
+}

--- a/src/Pixel.Persistence.Core/Models/Document.cs
+++ b/src/Pixel.Persistence.Core/Models/Document.cs
@@ -6,22 +6,40 @@ using System.Runtime.Serialization;
 
 namespace Pixel.Persistence.Core.Models;
 
+/// <summary>
+/// Identifies a document to be stored in a document database
+/// </summary>
 public abstract class Document : IDocument<string>
 {
+    /// <summary>
+    /// Identifier of the document
+    /// </summary>
     [BsonId]
     [BsonRepresentation(BsonType.ObjectId)]
     [DataMember(IsRequired = true, Order = 1000)]
     public string Id { get; set; }
 
+    /// <summary>
+    /// Revision of the document
+    /// </summary>
     [DataMember(IsRequired = true, Order = 1010)]
     public int Revision { get; set; } = 1;
 
+    /// <summary>
+    /// Indicates if document is marked deleted
+    /// </summary>
     [DataMember(IsRequired = false, Order = 1020)]
     public bool IsDeleted { get; set; }
 
+    /// <summary>
+    /// Indicates the date when document was created
+    /// </summary>
     [DataMember(IsRequired = true, Order = 1030)]
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Indicates the date when document was last updated
+    /// </summary>
     [DataMember(IsRequired = true, Order = 1040)]
     public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
 }

--- a/src/Pixel.Persistence.Core/Models/TestResult.cs
+++ b/src/Pixel.Persistence.Core/Models/TestResult.cs
@@ -1,46 +1,216 @@
-﻿using MongoDB.Bson.Serialization.Attributes;
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 using Pixel.Persistence.Core.Enums;
 using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Pixel.Persistence.Core.Models
 {
     [BsonIgnoreExtraElements]
+    [DataContract]
     public class TestResult : Document
-    {        
+    {
+        /// <summary>
+        /// Identifier of the session in which the test was executed
+        /// </summary>
+        [BsonRepresentation(BsonType.ObjectId)]
+        [DataMember(IsRequired = true, Order = 20)]
         public string SessionId { get; set; }
-       
+
+        /// <summary>
+        /// Identifier of the project to which test case belongs
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 30)]
         public string ProjectId { get; set; }
-      
+
+        /// <summary>
+        /// Name of the project to which test case belongs
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 40)]
         public string ProjectName { get; set; }
 
-        public string TestId { get; set; }
-       
-        public string TestName { get; set; }
+        /// <summary>
+        /// Version of the project for which test case was executed
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 50)]
+        public string ProjectVersion { get; set; }
 
+        /// <summary>
+        /// Identifier of the fixture to which test belongs
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 60)]
         public string FixtureId { get; set; }
 
+        /// <summary>
+        /// Name of the fixture to which test belongs
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 70)]
         public string FixtureName { get; set; }
 
+        /// <summary>
+        /// Identifier of the test case that was executed
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 80)]
+        public string TestId { get; set; }
+
+        /// <summary>
+        /// Name of the test case that was executed
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 90)]
+        public string TestName { get; set; }
+
+        /// <summary>
+        /// Test case data with which test was executed
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 95)]
+        public string TestData { get; set; }
+
+        /// <summary>
+        /// Result of execution
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 100)]
         public TestStatus Result { get; set; }
 
         /// <summary>
         /// Indicates the order in which test was executed
         /// </summary>
+        [DataMember(IsRequired = true, Order = 110)]
         public int ExecutionOrder { get; set; }
 
         /// <summary>
         /// Date on which test was executed
         /// </summary>
-        public DateTime ExecutedOn { get; set; } 
+        [DataMember(IsRequired = true, Order = 120)]
+        public DateTime ExecutedOn { get; set; }
 
         /// <summary>
         /// Time taken by test to execute in seconds
         /// </summary>
+        [DataMember(IsRequired = true, Order = 130)]
         public double ExecutionTime { get; set; }
 
+        /// <summary>
+        /// Trace message and screenshots capture while executing test case
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 140)]
+        public List<TraceData> Traces { get; set; } = new();
+
+        /// <summary>
+        /// Details of failure in case the test execution failed
+        /// </summary>
+        [DataMember(IsRequired = false, Order = 150)]
         public FailureDetails FailureDetails { get; set; }
 
+        /// <summary>
+        /// Indicates if the test case data has been processed to update various statistics
+        /// </summary>
+        [DataMember(IsRequired = false, Order = 160)]
         public bool IsProcessed { get; set; }
 
+    }
+
+
+    /// <summary>
+    /// Represents a trace data for various steps of automation
+    /// </summary>
+    [DataContract]
+    [JsonDerivedType(typeof(MessageTraceData), typeDiscriminator: nameof(MessageTraceData))]
+    [JsonDerivedType(typeof(ImageTraceData), typeDiscriminator: nameof(ImageTraceData))] 
+    [BsonKnownTypes(typeof(MessageTraceData))]
+    [BsonKnownTypes(typeof(ImageTraceData))]  
+    public abstract class TraceData
+    {
+        [DataMember(IsRequired = true, Order = 10)]
+        public DateTime RecordedAt { get; set; }
+
+        [DataMember(IsRequired = true, Order = 20)]
+        public TraceLevel TraceLevel { get; set; }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        public TraceData()
+        {
+
+        }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="recordedAt"></param>
+        /// <param name="traceLevel"></param>
+        public TraceData(DateTime recordedAt, TraceLevel traceLevel)
+        {
+            this.RecordedAt = recordedAt;
+            this.TraceLevel = traceLevel;
+        }
+    }
+
+    /// <summary>
+    /// Represents a log entry for a trace data for various steps of automation
+    /// </summary>
+    [DataContract]
+    [JsonDerivedType(typeof(MessageTraceData), typeDiscriminator: nameof(MessageTraceData))]
+    public class MessageTraceData : TraceData
+    {
+        /// <summary>
+        /// Trace message
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 20)]
+        public string Messsage { get; set; }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        public MessageTraceData()
+        {
+
+        }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="recordedAt"></param>
+        /// <param name="traceLevel"></param>
+        /// <param name="messsage"></param>
+        public MessageTraceData(DateTime recordedAt, TraceLevel traceLevel, string messsage) : base(recordedAt, traceLevel)
+        {
+            this.Messsage = messsage;
+        }
+    }
+
+    /// <summary>
+    /// Represents a image entry for a trace data for various steps of automation
+    /// </summary>
+    [DataContract]
+    [JsonDerivedType(typeof(ImageTraceData), typeDiscriminator: nameof(ImageTraceData))]
+    public class ImageTraceData : TraceData
+    {
+        /// <summary>
+        /// Trace image file
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 20)]
+        public string ImageFile { get; set; }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        public ImageTraceData()
+        {
+
+        }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="recordedAt"></param>
+        /// <param name="traceLevel"></param>
+        /// <param name="imageFile"></param>
+        public ImageTraceData(DateTime recordedAt, TraceLevel traceLevel, string imageFile) : base(recordedAt, traceLevel)
+        {
+            this.ImageFile = imageFile;
+        }
     }
 }

--- a/src/Pixel.Persistence.Core/Models/TestSession.cs
+++ b/src/Pixel.Persistence.Core/Models/TestSession.cs
@@ -1,4 +1,5 @@
-﻿using MongoDB.Bson.Serialization.Attributes;
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 using Pixel.Persistence.Core.Enums;
 using System;
 using System.Collections.Generic;
@@ -7,12 +8,17 @@ using System.Runtime.InteropServices;
 
 namespace Pixel.Persistence.Core.Models
 {
+    /// <summary>
+    /// TestSession represents an execution of a group of test cases executed in an adhoc manner or using 
+    /// a predefined test template.
+    /// </summary>
     [BsonIgnoreExtraElements]
     public class TestSession : Document
-    {       
+    {
         /// <summary>
         /// Id of the Session Template that was used to start this session
         /// </summary>
+        [BsonRepresentation(BsonType.ObjectId)]
         public string TemplateId { get; set; }
 
         /// <summary>

--- a/src/Pixel.Persistence.Core/Models/TestStatistics.cs
+++ b/src/Pixel.Persistence.Core/Models/TestStatistics.cs
@@ -1,6 +1,4 @@
-﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 

--- a/src/Pixel.Persistence.Core/Models/TraceImageMetaData.cs
+++ b/src/Pixel.Persistence.Core/Models/TraceImageMetaData.cs
@@ -1,0 +1,26 @@
+﻿using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson;
+using System.Runtime.Serialization;
+
+namespace Pixel.Persistence.Core.Models;
+
+/// <summary>
+/// MetaData for a trace image captured during execution of test case
+/// </summary>
+[DataContract]
+public class TraceImageMetaData
+{
+    /// <summary>
+    /// Identifier of the session which executed the test case
+    /// </summary>
+    [BsonRepresentation(BsonType.ObjectId)]
+    [DataMember(IsRequired = true, Order = 10)]
+    public string SessionId { get; set; }
+
+    /// <summary>
+    /// Identifier of the TestResult to which trace image should be associated
+    /// </summary>
+    [BsonRepresentation(BsonType.ObjectId)]
+    [DataMember(IsRequired = true, Order = 20)]
+    public string TestResultId { get; set; }  
+}

--- a/src/Pixel.Persistence.Respository/Interfaces/ITestResultsRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/ITestResultsRepository.cs
@@ -70,6 +70,14 @@ namespace Pixel.Persistence.Respository
         Task AddTraceImage(TraceImageMetaData traceImageMetaData, string fileName, byte[] imageBytes);
 
         /// <summary>
+        /// Get trace image for a given test result and file name
+        /// </summary>
+        /// <param name="testResultId"></param>
+        /// <param name="imageFile"></param>
+        /// <returns></returns>
+        Task<DataFile> GetTraceImage(string testResultId, string imageFile);
+
+        /// <summary>
         /// Get all the trace image files for a given test result
         /// </summary>
         /// <param name="testResultId"></param>

--- a/src/Pixel.Persistence.Respository/Interfaces/ITestResultsRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/ITestResultsRepository.cs
@@ -11,11 +11,18 @@ namespace Pixel.Persistence.Respository
     public interface ITestResultsRepository
     {
         /// <summary>
+        /// Get TestResult with a given identifer
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        Task<TestResult> GetTestResultAsync(string id);
+
+        /// <summary>
         /// Get all the test results captured for a test session
         /// </summary>
         /// <param name="sessionId">SessionId of the Session whose tests needs to be retreived</param>
         /// <returns>Collection of <see cref="TestResult"/> belonging to a <see cref="TestSession"/></returns>
-        Task<IEnumerable<TestResult>> GetTestResultsAsync(string sessionId);
+        Task<IEnumerable<TestResult>> GetTestResultsForSessionAsync(string sessionId);
 
         /// <summary>
         /// Get all the <see cref="TestResult"/> matching the criteria specified by the query
@@ -52,5 +59,21 @@ namespace Pixel.Persistence.Respository
         /// <param name="testId">TestId of the TestResult that needs to be updated</param>
         /// <returns></returns>
         Task MarkTestProcessedAsync(string sessionId, string testId);
+
+        /// <summary>
+        /// Save trace image file for a given test result in to db
+        /// </summary>
+        /// <param name="traceImageMetaData"></param>
+        /// <param name="fileName"></param>
+        /// <param name="imageBytes"></param>
+        /// <returns></returns>
+        Task AddTraceImage(TraceImageMetaData traceImageMetaData, string fileName, byte[] imageBytes);
+
+        /// <summary>
+        /// Get all the trace image files for a given test result
+        /// </summary>
+        /// <param name="testResultId"></param>
+        /// <returns></returns>
+        Task<IEnumerable<DataFile>> GetTraceImages(string testResultId);
     }
 }

--- a/src/Pixel.Persistence.Respository/MongoDbSettings.cs
+++ b/src/Pixel.Persistence.Respository/MongoDbSettings.cs
@@ -38,6 +38,8 @@
 
         string TestResultsCollectionName { get; set; }
 
+        string TraceImagesBucketName { get; set; }
+
         string TestStatisticsCollectionName { get; set; }
 
         string ProjectStatisticsCollectionName { get; set; }
@@ -85,6 +87,8 @@
         public string SessionsCollectionName { get; set; }
 
         public string TestResultsCollectionName { get; set; }
+
+        public string TraceImagesBucketName { get; set; }
 
         public string TestStatisticsCollectionName { get; set; }
 

--- a/src/Pixel.Persistence.Respository/ProjectStatisticsRepository.cs
+++ b/src/Pixel.Persistence.Respository/ProjectStatisticsRepository.cs
@@ -49,7 +49,7 @@ namespace Pixel.Persistence.Respository
         {
             Guard.Argument(sessionId).NotNull().NotEmpty();
             var session = await testSessionRepository.GetTestSessionAsync(sessionId);
-            var testsInSession = await testResultsRepository.GetTestResultsAsync(sessionId);         
+            var testsInSession = await testResultsRepository.GetTestResultsForSessionAsync(sessionId);         
           
             int month = session.SessionStartTime.Month;
             int year = session.SessionStartTime.Year;

--- a/src/Pixel.Persistence.Respository/TestResultsRepository.cs
+++ b/src/Pixel.Persistence.Respository/TestResultsRepository.cs
@@ -1,5 +1,7 @@
 ﻿using Dawn;
+using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.Driver.GridFS;
 using Pixel.Persistence.Core.Enums;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Core.Request;
@@ -12,38 +14,49 @@ namespace Pixel.Persistence.Respository
     public class TestResultsRepository : ITestResultsRepository
     {
         private readonly IMongoCollection<TestResult> testResults;
-        
+        private readonly IGridFSBucket traceImagesBucket;
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="dbSettings"></param>
         public TestResultsRepository(IMongoDbSettings dbSettings)
         {
             var client = new MongoClient(dbSettings.ConnectionString);
             var database = client.GetDatabase(dbSettings.DatabaseName);
             testResults = database.GetCollection<TestResult>(dbSettings.TestResultsCollectionName);
+            traceImagesBucket = new GridFSBucket(database, new GridFSBucketOptions
+            {
+                BucketName = dbSettings.TraceImagesBucketName
+            });
         }
 
+        /// <inheritdoc/>  
         public async Task<IEnumerable<TestResult>> GetTestResultsAsync(TestResultRequest queryParameter)
         {
             Guard.Argument(queryParameter).NotNull();
 
-            var filter = GetFilterCriteria(queryParameter);     
-           
-            if(queryParameter.SortDirection != Core.Enums.SortDirection.None && !string.IsNullOrEmpty(queryParameter.SortBy))
+            var filter = GetFilterCriteria(queryParameter);
+            var projection = Builders<TestResult>.Projection.Exclude(x => x.Traces);
+            if (queryParameter.SortDirection != Core.Enums.SortDirection.None && !string.IsNullOrEmpty(queryParameter.SortBy))
             {
                 var sort = (queryParameter.SortDirection == Core.Enums.SortDirection.Ascending) ? Builders<TestResult>.Sort.Ascending(queryParameter.SortBy ?? nameof(TestResult.ExecutionOrder)) :
                 Builders<TestResult>.Sort.Descending(queryParameter.SortBy ?? nameof(TestResult.ExecutionOrder));
-                var all = testResults.Find(filter).Sort(sort).Skip(queryParameter.Skip).Limit(queryParameter.Take);
+                var all = testResults.Find(filter).Project<TestResult>(projection).Sort(sort).Skip(queryParameter.Skip).Limit(queryParameter.Take);
                 var result = await all.ToListAsync();
                 return result ?? Enumerable.Empty<TestResult>();
             }
             else
             {
                 var defaultSort = Builders<TestResult>.Sort.Ascending(nameof(TestResult.ExecutionOrder));
-                var all = testResults.Find(filter).Sort(defaultSort).Skip(queryParameter.Skip).Limit(queryParameter.Take);
+                var all = testResults.Find(filter).Project<TestResult>(projection).Sort(defaultSort).Skip(queryParameter.Skip).Limit(queryParameter.Take);
                 var result = await all.ToListAsync();
                 return result ?? Enumerable.Empty<TestResult>();
             }
           
         }
 
+        /// <inheritdoc/>  
         public async Task<long> GetCountAsync(TestResultRequest queryParameter)
         {
             Guard.Argument(queryParameter).NotNull();
@@ -90,19 +103,31 @@ namespace Pixel.Persistence.Respository
             return filter;
         }
 
-        public async Task<IEnumerable<TestResult>> GetTestResultsAsync(string sessionId)
+        /// <inheritdoc/>  
+        public async Task<TestResult> GetTestResultAsync(string id)
+        {
+            Guard.Argument(id, nameof(id)).NotNull().NotEmpty();
+            var result = await testResults.FindAsync<TestResult>(s => s.Id.Equals(id));
+            return await result.FirstOrDefaultAsync();
+        }
+
+        /// <inheritdoc/>  
+        public async Task<IEnumerable<TestResult>> GetTestResultsForSessionAsync(string sessionId)
         {
             Guard.Argument(sessionId).NotNull().NotEmpty();
-            var result = await testResults.FindAsync<TestResult>(s => s.SessionId.Equals(sessionId));
-            return await result.ToListAsync();
+            var projection = Builders<TestResult>.Projection.Exclude(x => x.Traces);          
+            var result = await (testResults.Find(s => s.SessionId.Equals(sessionId)).Project<TestResult>(projection)).ToListAsync();           
+            return result;
         }
-        
+
+        /// <inheritdoc/>  
         public async Task AddTestResultAsync(TestResult testResult)
         {
             Guard.Argument(testResult).NotNull();
             await testResults.InsertOneAsync(testResult);
         }
 
+        /// <inheritdoc/>  
         public async Task UpdateFailureReasonAsync(UpdateFailureReasonRequest request)
         {
             Guard.Argument(request).NotNull();
@@ -115,6 +140,7 @@ namespace Pixel.Persistence.Respository
             var result = await testResults.FindOneAndUpdateAsync(filter, update);
         }
 
+        /// <inheritdoc/>  
         public async Task MarkTestProcessedAsync(string sessionId, string testId)
         {
             var filterBuilder = Builders<TestResult>.Filter;
@@ -122,6 +148,46 @@ namespace Pixel.Persistence.Respository
             var updateBuilder = Builders<TestResult>.Update;
             var update = updateBuilder.Set(t => t.IsProcessed, true);
             await testResults.FindOneAndUpdateAsync(filter, update);
-        }       
+        }
+
+        /// <inheritdoc/>  
+        public async Task AddTraceImage(TraceImageMetaData traceImageMetaData, string fileName, byte[] imageBytes)
+        {
+            Guard.Argument(traceImageMetaData, nameof(traceImageMetaData)).NotNull();
+            Guard.Argument(fileName, nameof(fileName)).NotNull().NotEmpty(); ;
+            Guard.Argument(imageBytes, nameof(imageBytes)).NotNull();
+
+            await traceImagesBucket.UploadFromBytesAsync(fileName, imageBytes, new GridFSUploadOptions()
+            {
+                Metadata = new BsonDocument()
+                {
+                    {"sesionId" , traceImageMetaData.SessionId},
+                    {"testResultId" , traceImageMetaData.TestResultId }
+                }
+            });
+        }
+
+        ///<inheritdoc/>
+        public async Task<IEnumerable<DataFile>> GetTraceImages(string testResultId)
+        {
+            Guard.Argument(testResultId, nameof(testResultId)).NotNull().NotEmpty();
+            List<DataFile> controlImages = new();
+            var imageFilter = Builders<GridFSFileInfo>.Filter.Eq(x => x.Metadata["testResultId"], testResultId);
+            using (var cursor = await traceImagesBucket.FindAsync(imageFilter, new GridFSFindOptions()))
+            {
+                var imageFiles = await cursor.ToListAsync();
+
+                foreach (var imageFile in imageFiles)
+                {
+                    var imageBytes = await traceImagesBucket.DownloadAsBytesAsync(imageFile.Id);
+                    controlImages.Add(new ControlImageDataFile()
+                    {
+                        FileName = imageFile.Filename,                        
+                        Bytes = imageBytes
+                    });
+                }
+            }
+            return controlImages;
+        }
     }
 }

--- a/src/Pixel.Persistence.Respository/TestSessionRespository.cs
+++ b/src/Pixel.Persistence.Respository/TestSessionRespository.cs
@@ -3,7 +3,6 @@ using MongoDB.Driver;
 using Pixel.Persistence.Core.Enums;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Core.Request;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Pixel.Persistence.Respository/TestStatisticsRepository.cs
+++ b/src/Pixel.Persistence.Respository/TestStatisticsRepository.cs
@@ -30,7 +30,7 @@ namespace Pixel.Persistence.Respository
         {
             Guard.Argument(sessionId).NotNull().NotEmpty();
             var session = await testSessionRepository.GetTestSessionAsync(sessionId);
-            var testsInSession = await testResultsRepository.GetTestResultsAsync(sessionId);
+            var testsInSession = await testResultsRepository.GetTestResultsForSessionAsync(sessionId);
             var groupedTests = testsInSession.GroupBy(t => t.TestId);
             int month = session.SessionStartTime.Month;
             int year = session.SessionStartTime.Year;

--- a/src/Pixel.Persistence.Services.Api/Controllers/TestResultController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/TestResultController.cs
@@ -116,6 +116,27 @@ namespace Pixel.Persistence.Services.Api.Controllers
         }
 
         /// <summary>
+        /// Get the trace image file with specified name belonging to a given test result
+        /// </summary>
+        /// <param name="testResultId">Identifier of the test result</param>
+        /// <param name="imageFile">Name of the image file</param>
+        /// <returns></returns>
+        [HttpGet("trace/{testResultId}/image/{imageFile}")]
+        public async Task<IActionResult> GetTraceImageFile(string testResultId, string imageFile)
+        {
+            try
+            {
+                var result = await this.testResultsRepository.GetTraceImage(testResultId, imageFile);
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "There was an error while retrieving trace image file : '{0}' for test result : '{1}'", imageFile, testResultId);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        /// <summary>
         /// Add a image trace file for a TestResult
         /// </summary>
         /// <param name="traceImage"></param>

--- a/src/Pixel.Persistence.Services.Api/Controllers/TestResultController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/TestResultController.cs
@@ -1,10 +1,15 @@
 ﻿using Dawn;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Core.Request;
 using Pixel.Persistence.Core.Response;
 using Pixel.Persistence.Respository;
+using Pixel.Persistence.Services.Api.Extensions;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -14,16 +19,26 @@ namespace Pixel.Persistence.Services.Api.Controllers
     [ApiController]
     public class TestResultController : ControllerBase
     {
-
+        private readonly ILogger<TestResultController> logger;
         private readonly ITestResultsRepository testResultsRepository;
 
-        public TestResultController(ITestResultsRepository testResultsRepository)
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="testResultsRepository"></param>
+        public TestResultController(ILogger<TestResultController> logger, ITestResultsRepository testResultsRepository)
         {
-            this.testResultsRepository = testResultsRepository;
+            this.logger = Guard.Argument(logger, nameof(logger)).NotNull().Value;
+            this.testResultsRepository = Guard.Argument(testResultsRepository, nameof(testResultsRepository)).NotNull().Value;
         }
 
-
-        [HttpGet]      
+        /// <summary>
+        /// Get all the TestResult matching the request filter
+        /// </summary>
+        /// <param name="queryParameter"></param>
+        /// <returns></returns>
+        [HttpGet]
         public async Task<PagedList<TestResult>> Get([FromQuery] TestResultRequest queryParameter)
         {
             var count = await testResultsRepository.GetCountAsync(queryParameter);
@@ -31,30 +46,104 @@ namespace Pixel.Persistence.Services.Api.Controllers
             return new PagedList<TestResult>(sessions, (int)count, queryParameter.CurrentPage, queryParameter.PageSize);
         }
 
-
-        // GET: api/TestSession/5
-        [HttpGet("{sessionId}")]      
-        public async Task<ActionResult<IEnumerable<TestResult>>> Get(string sessionId)
+        /// <summary>
+        /// Get TestResult with a given identifier
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        [HttpGet("{id}")]
+        public async Task<TestResult> GetById(string id)
         {
-            var results = await testResultsRepository.GetTestResultsAsync(sessionId);
+            return await testResultsRepository.GetTestResultAsync(id);           ;
+        }
+
+        /// <summary>
+        /// Get all the TestResult belonging to a given session 
+        /// </summary>
+        /// <param name="sessionId"></param>
+        /// <returns></returns>
+        [HttpGet("session/{sessionId}")]
+        public async Task<ActionResult<IEnumerable<TestResult>>> GetAllForSession(string sessionId)
+        {
+            var results = await testResultsRepository.GetTestResultsForSessionAsync(sessionId);
             return results.ToList();
         }
 
-        // POST: api/TestSession
-        [HttpPost]      
+        /// <summary>
+        /// Add a new TestResult 
+        /// </summary>
+        /// <param name="testResult"></param>
+        /// <returns></returns>
+        [HttpPost]
         public async Task<IActionResult> Post([FromBody] TestResult testResult)
         {
             Guard.Argument(testResult).NotNull();
             await testResultsRepository.AddTestResultAsync(testResult);
-            return Ok();
+            return CreatedAtAction(nameof(Get), new { testResultId = testResult.Id }, testResult);
         }
 
-        [HttpPut("failure/reason")]        
+        /// <summary>
+        /// Add a failure reason to a test result
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        [HttpPut("failure/reason")]
         public async Task<IActionResult> Update([FromBody] UpdateFailureReasonRequest request)
         {
             Guard.Argument(request).NotNull();
             await testResultsRepository.UpdateFailureReasonAsync(request);
             return Ok();
+        }
+
+        /// <summary>
+        /// Get all the trace image files belonging to a given test result
+        /// </summary>
+        /// <param name="testResultId"></param>
+        /// <returns></returns>
+        [HttpGet("trace/images/{testResultId}")]
+        public async Task<IActionResult> GetTraceImageFiles(string testResultId)
+        {
+            try
+            {
+                var result =  await this.testResultsRepository.GetTraceImages(testResultId);      
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "There was an error while retrieving trace image files for test result : '{0}'", testResultId);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        /// <summary>
+        /// Add a image trace file for a TestResult
+        /// </summary>
+        /// <param name="traceImage"></param>
+        /// <param name="imageFile"></param>
+        /// <returns></returns>
+        [HttpPost("trace/images")]
+        public async Task<IActionResult> AddTraceImage([FromBody][ModelBinder(typeof(JsonModelBinder), Name = nameof(TraceImageMetaData))] TraceImageMetaData traceImage, [FromForm(Name = "files")] IEnumerable<IFormFile> imageFiles)
+        {
+            Guard.Argument(traceImage, nameof(traceImage)).NotNull();          
+            Guard.Argument(imageFiles, nameof(imageFiles)).NotNull();
+            try
+            {
+                foreach(var imageFile in imageFiles)
+                {
+                    using (var ms = new MemoryStream())
+                    {
+                        imageFile.CopyTo(ms);
+                        var fileBytes = ms.ToArray();
+                        await testResultsRepository.AddTraceImage(traceImage, imageFile.FileName, fileBytes);                       
+                    }                  
+                }
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "There was an error while saving the trace image files for SesionId : '{0}' and TestResultId : '{1}'.", traceImage.SessionId, traceImage.TestResultId);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
         }
     }
 }

--- a/src/Pixel.Persistence.Services.Api/appsettings.json
+++ b/src/Pixel.Persistence.Services.Api/appsettings.json
@@ -75,7 +75,8 @@
     "SessionsCollectionName": "sessions",
     "TestResultsCollectionName": "test-results",
     "TestStatisticsCollectionName": "test-statistics",
-    "ProjectStatisticsCollectionName": "project-statistics"
+    "ProjectStatisticsCollectionName": "project-statistics",
+    "TraceImagesBucketName":  "bucket-trace-images"
   },
   "Quartz": {
   }

--- a/src/Pixel.Persistence.Services.Client/Interfaces/ITestSessionClient.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/ITestSessionClient.cs
@@ -1,4 +1,5 @@
 ﻿using Pixel.Persistence.Core.Models;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Pixel.Persistence.Services.Client
@@ -21,10 +22,19 @@ namespace Pixel.Persistence.Services.Client
         Task UpdateSessionAsync(string sessionId, TestSession testSession);
 
         /// <summary>
-        /// Add a new test result executed in a given session
+        /// Add a new test result executed in a given session.
+        /// Identifier of the test result is returned.
         /// </summary>
         /// <param name="testResult"></param>
         /// <returns></returns>
-        Task AddResultAsync(TestResult testResult);
+        Task<TestResult> AddResultAsync(TestResult testResult);
+
+        /// <summary>
+        /// Add a trace image file for a test result
+        /// </summary>
+        /// <param name="testResult"></param>
+        /// <param name="imageFiles"></param>
+        /// <returns></returns>
+        Task AddTraceImagesAsync(TestResult testResult, IEnumerable<string> imageFiles);
     }
 }

--- a/src/Pixel.Persistence.Services.Client/TestSessionClient.cs
+++ b/src/Pixel.Persistence.Services.Client/TestSessionClient.cs
@@ -1,8 +1,11 @@
 ﻿using Dawn;
+using Pixel.Automation.Core.Interfaces;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Services.Client.Interfaces;
 using RestSharp;
 using Serilog;
+using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Pixel.Persistence.Services.Client
@@ -10,15 +13,17 @@ namespace Pixel.Persistence.Services.Client
     public class TestSessionClient : ITestSessionClient
     {
         private readonly ILogger logger = Log.ForContext<TestSessionClient>();
+        private readonly ISerializer serializer;
         private readonly IRestClientFactory clientFactory;
         
         /// <summary>
         /// constructor
         /// </summary>
         /// <param name="clientFactory"></param>
-        public TestSessionClient(IRestClientFactory clientFactory)
+        public TestSessionClient(IRestClientFactory clientFactory, ISerializer serializer)
         {
-            this.clientFactory = Guard.Argument(clientFactory).NotNull().Value;           
+            this.clientFactory = Guard.Argument(clientFactory).NotNull().Value;
+            this.serializer = Guard.Argument(serializer).NotNull().Value;
         }
 
         ///<inheritdoc/>
@@ -49,7 +54,7 @@ namespace Pixel.Persistence.Services.Client
         }
 
         ///<inheritdoc/>
-        public async Task AddResultAsync(TestResult testResult)
+        public async Task<TestResult> AddResultAsync(TestResult testResult)
         {
             Guard.Argument(testResult).NotNull();
             logger.Debug("Add test result {@TestResult}", testResult);
@@ -57,7 +62,27 @@ namespace Pixel.Persistence.Services.Client
             RestRequest restRequest = new RestRequest("testresult") { Method = Method.Post };
             restRequest.AddJsonBody(testResult);
             var client = this.clientFactory.GetOrCreateClient();
-            var result = await client.ExecuteAsync(restRequest);
+            var result = await client.PostAsync<TestResult>(restRequest);
+            return result;
+        }
+
+        public async Task AddTraceImagesAsync(TestResult testResult, IEnumerable<string> imageFiles)
+        {
+            Guard.Argument(testResult, nameof(testResult)).NotNull();
+            Guard.Argument(imageFiles, nameof(imageFiles)).NotNull();         
+            RestRequest restRequest = new RestRequest($"testresult/trace/images");
+            var traceImageMetaData = new TraceImageMetaData()
+            {              
+                TestResultId = testResult.Id,
+                SessionId = testResult.SessionId
+            };
+            restRequest.AddParameter(nameof(TraceImageMetaData), serializer.Serialize<TraceImageMetaData>(traceImageMetaData), ParameterType.RequestBody);
+            foreach(var imageFile in imageFiles)
+            {
+                restRequest.AddFile("files", imageFile);
+            }
+            var client = this.clientFactory.GetOrCreateClient();
+            var result = await client.ExecuteAsync(restRequest, Method.Post);
             result.EnsureSuccess();
         }
     }

--- a/src/Serilog.Sinks.Pixel.Trace/Serilog.Sinks.Pixel.Trace.csproj
+++ b/src/Serilog.Sinks.Pixel.Trace/Serilog.Sinks.Pixel.Trace.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Serilog.Sinks.Pixel.Trace/TraceSink.cs
+++ b/src/Serilog.Sinks.Pixel.Trace/TraceSink.cs
@@ -1,0 +1,49 @@
+﻿using Pixel.Automation.Core;
+using Pixel.Automation.Core.Enums;
+using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Sinks.Pixel.Trace;
+
+/// <summary>
+/// TraceSink emits the logs to TraceManager which are later processed and saved along with the test case result which was executing
+/// while the logs were emitted.
+/// </summary>
+public class TraceSink : ILogEventSink
+{
+    private readonly IFormatProvider formatProvider;
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="formatProvider"></param>
+    public TraceSink(IFormatProvider formatProvider)
+    {      
+        this.formatProvider = formatProvider;
+    }
+
+    ///<inheritdoc/>
+    public void Emit(LogEvent logEvent)
+    {        
+        if (TraceManager.IsEnabled && logEvent.Properties.ContainsKey(TraceManager.CaptureTrace))
+        {
+            var message = logEvent.RenderMessage(formatProvider);
+            if(Enum.TryParse<TraceLevel>(logEvent.Level.ToString(), out TraceLevel traceLevel))
+            {
+                TraceManager.AddMessage(traceLevel, message);
+            }
+        }       
+    }
+}
+
+/// <summary>
+/// Extension methods for TraceSink configuration
+/// </summary>
+public static class TraceSinkExtensions
+{
+    public static LoggerConfiguration Trace(this LoggerSinkConfiguration loggerConfiguration, IFormatProvider formatProvider = null)
+    {
+        return loggerConfiguration.Sink(new TraceSink(formatProvider));
+    }
+}


### PR DESCRIPTION
**Description**
While executing a test case, capture the logs and screenshots taken as TraceData that can be stored with the TestResult.
The TraceData can be viewed on the dashboard to understand what happened during the execution of a test case.