### PR TITLE
Capture screenshot on actor execution

### DIFF
--- a/src/Pixel.Automation.Appium.Components/ActorComponents/AppiumActorComponent.cs
+++ b/src/Pixel.Automation.Appium.Components/ActorComponents/AppiumActorComponent.cs
@@ -39,6 +39,29 @@ public abstract class AppiumActorComponent : ActorComponent
 
     }
 
+    /// <summary>
+    /// Take a screen shot if capturing screenshot is enabled after Act method finishes
+    /// </summary>
+    /// <returns></returns>
+    public override async Task OnCompletionAsync()
+    {
+        if (TraceManager.IsEnabled)
+        {
+            await CaptureScreenShotAsync();
+        }
+    }
+
+    /// <summary>
+    /// Capture screenshot of the active page
+    /// </summary>
+    /// <returns></returns>
+    public async Task CaptureScreenShotAsync()
+    {       
+        string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+        var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
+        await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
+        TraceManager.AddImage(Path.GetFileName(imageFile));
+    }
 }
 
 /// <summary>

--- a/src/Pixel.Automation.Appium.Components/AppiumApplicationEntity.cs
+++ b/src/Pixel.Automation.Appium.Components/AppiumApplicationEntity.cs
@@ -1,5 +1,7 @@
-﻿using OpenQA.Selenium.Appium;
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Service;
+using OpenQA.Selenium.Support.Extensions;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Arguments;
 using Pixel.Automation.Core.Components;
@@ -79,6 +81,14 @@ public class AppiumApplicationEntity : ApplicationEntity
             webApplicationDetails.Driver = null;
             await Task.CompletedTask;
         }
+    }
+
+    /// </inheritdoc>
+    public override async Task CaptureScreenShotAsync(string filePath)
+    {
+        var webDriver = this.GetTargetApplicationDetails<AppiumApplication>().Driver;
+        webDriver.TakeScreenshot().SaveAsFile(filePath, ScreenshotImageFormat.Jpeg);
+        await Task.CompletedTask;
     }
 
     async Task<AppiumServiceBuilder> GetServiceBuilder()

--- a/src/Pixel.Automation.Core.Components/Entities/ApplicationEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Entities/ApplicationEntity.cs
@@ -102,14 +102,16 @@ namespace Pixel.Automation.Core.Components
         public abstract Task LaunchAsync();
 
         ///<inheritdoc/>
-        public abstract Task CloseAsync();      
-
+        public abstract Task CloseAsync();
+        
         ///<inheritdoc/>
         public virtual void UseExisting(ApplicationProcess application)
         {
             throw new NotSupportedException($"{this.GetType().Name} doesn't support attaching to an already running process.");
         }
 
+        ///<inheritdoc/>
+        public abstract Task CaptureScreenShotAsync(string filePath);
 
         /// <summary>
         /// Add the default control locator for this Application type as a child component whenever ApplicationEntity is added to the AutomationProcess

--- a/src/Pixel.Automation.Core.Components/Processors/EntityProcessor.cs
+++ b/src/Pixel.Automation.Core.Components/Processors/EntityProcessor.cs
@@ -87,6 +87,7 @@ namespace Pixel.Automation.Core.Components.Processors
                                     actor.IsExecuting = true;
                                     await actor.ActAsync();
                                     await AddDelay(this.postDelayAmount);
+                                    await actor.OnCompletionAsync();
                                 }
                                 catch (Exception ex)
                                 {

--- a/src/Pixel.Automation.Core/Component/Component.cs
+++ b/src/Pixel.Automation.Core/Component/Component.cs
@@ -288,6 +288,15 @@ namespace Pixel.Automation.Core
         /// </summary>
         public abstract Task ActAsync();
 
+        /// <summary>
+        /// OnExecutedAsync will be executed after ActAsync is completed
+        /// </summary>
+        /// <returns></returns>
+        public virtual async Task OnCompletionAsync()
+        {
+            await Task.CompletedTask;
+        }
+
         /// <inheritdoc/>
         public override void ResetComponent()
         {

--- a/src/Pixel.Automation.Core/Interfaces/IApplicationEntity.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IApplicationEntity.cs
@@ -52,12 +52,19 @@ namespace Pixel.Automation.Core.Interfaces
         /// <summary>
         /// Close the Application
         /// </summary>
-        Task CloseAsync();
+        Task CloseAsync();        
 
         /// <summary>
         /// Use an existing application which might already be launched.
         /// </summary>
         /// <param name="targetApplication">Identified application instance</param>
         void UseExisting(ApplicationProcess targetApplication);
+
+        /// <summary>
+        /// Capture screen shot of the application window
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <returns></returns>
+        Task CaptureScreenShotAsync(string filePath);
     }
 }

--- a/src/Pixel.Automation.Input.Devices.Components/InputDeviceActor.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/InputDeviceActor.cs
@@ -7,6 +7,7 @@ using Pixel.Automation.Core.Interfaces;
 using Serilog;
 using System;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -85,6 +86,16 @@ namespace Pixel.Automation.Input.Devices.Components
             throw new ElementNotFoundException("Control could not be located");
         }
 
+        public override async Task OnCompletionAsync()
+        {
+            if (TraceManager.IsEnabled)
+            {
+                string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+                var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
+                await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
+                TraceManager.AddImage(Path.GetFileName(imageFile));
+            }
+        }
 
         protected void ThrowIfMissingControlEntity()
         {

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/JABActorComponent.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/JABActorComponent.cs
@@ -5,6 +5,7 @@ using Pixel.Automation.Core.Exceptions;
 using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using WindowsAccessBridgeInterop;
@@ -71,6 +72,29 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
             return control;
         }
 
+        /// <summary>
+        /// Take a screen shot if capturing screenshot is enabled after Act method finishes
+        /// </summary>
+        /// <returns></returns>
+        public override async Task OnCompletionAsync()
+        {
+            if (TraceManager.IsEnabled)
+            {
+                await CaptureScreenShotAsync();
+            }
+        }
+
+        /// <summary>
+        /// Capture screenshot of the active page
+        /// </summary>
+        /// <returns></returns>
+        public async Task CaptureScreenShotAsync()
+        {            
+            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+            var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
+            await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
+            TraceManager.AddImage(Path.GetFileName(imageFile));
+        }
 
         protected void ThrowIfMissingControlEntity()
         {

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/JavaApplicationEntity.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/JavaApplicationEntity.cs
@@ -2,9 +2,13 @@
 using Pixel.Automation.Core.Arguments;
 using Pixel.Automation.Core.Components;
 using Pixel.Automation.Core.Exceptions;
+using Pixel.Automation.Core.Interfaces;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Drawing.Imaging;
+using System.Drawing;
+using System.IO;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
@@ -84,6 +88,26 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
                 logger.Information($"Application : {javaApplicationDetails.ApplicationName} was closed");
                 await Task.CompletedTask;
             }
+        }
+
+        ///<inheritdoc/>
+        public override async Task CaptureScreenShotAsync(string filePath)
+        {
+            var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
+            var windowManager = this.EntityManager.GetServiceOfType<IApplicationWindowManager>();
+            var appRectangle = windowManager.GetWindowSize(this.applicationDetails.Hwnd);
+            var screenShotBytes = screenCapture.CaptureArea(appRectangle);
+            using (var memoryStream = new MemoryStream(screenShotBytes))
+            {
+                using (var bitmap = new Bitmap(memoryStream))
+                {
+                    using (FileStream fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write))
+                    {
+                        bitmap.Save(fs, ImageFormat.Png);
+                    }
+                }
+            }
+            await Task.CompletedTask;
         }
 
     }

--- a/src/Pixel.Automation.RestApi.Components/RestApiApplicationEntity.cs
+++ b/src/Pixel.Automation.RestApi.Components/RestApiApplicationEntity.cs
@@ -98,4 +98,9 @@ public class RestApiApplicationEntity : ApplicationEntity
         await Task.CompletedTask;
     }
 
+    /// </inheritdoc>
+    public override async Task CaptureScreenShotAsync(string filePath)
+    {
+        await Task.CompletedTask;
+    }
 }

--- a/src/Pixel.Automation.RunTime/ArgumentProcessor.cs
+++ b/src/Pixel.Automation.RunTime/ArgumentProcessor.cs
@@ -73,7 +73,7 @@ namespace Pixel.Automation.RunTime
                                                       
                     if (typeof(T).IsAssignableFrom(result?.GetType()))
                     {
-                        logger.Information("{0} operation completed on {argument}", nameof(GetValueAsync), argument);
+                        logger.Debug("{0} operation completed on {argument}", nameof(GetValueAsync), argument);
                         return (T)result;                       
                     }
                    
@@ -82,7 +82,7 @@ namespace Pixel.Automation.RunTime
                 
                 case ArgumentMode.Scripted:
                     var fn = await scriptEngine.CreateDelegateAsync<Func<T>>(argument.ScriptFile);
-                    logger.Information("{0} operation completed on {argument}", nameof(GetValueAsync), argument);
+                    logger.Debug("{0} operation completed on {argument}", nameof(GetValueAsync), argument);
                     return fn();                        
                
                 default:
@@ -144,7 +144,7 @@ namespace Pixel.Automation.RunTime
                 default:
                     throw new InvalidOperationException($"Argument mode : {argument.Mode} is not supported");
             }
-            logger.Information("{0} operation completed on {argument}", nameof(SetValueAsync), argument);
+            logger.Debug("{0} operation completed on {argument}", nameof(SetValueAsync), argument);
         }
 
         private object GetNestedPropertyValue(object root, IEnumerable<string> nestedProperties)

--- a/src/Pixel.Automation.RunTime/ControlLoader.cs
+++ b/src/Pixel.Automation.RunTime/ControlLoader.cs
@@ -49,7 +49,7 @@ namespace Pixel.Automation.RunTime
             if(this.Controls.ContainsKey(controlId))
             {
                 this.Controls.Remove(controlId);
-                logger.Information("Control with Id : {0} removed from cache", controlId);
+                logger.Debug("Control with Id : {0} removed from cache", controlId);
             }
         }
 
@@ -64,7 +64,7 @@ namespace Pixel.Automation.RunTime
             var controlReferences = this.GetControlReferences();
             var controlVersionInUse = controlReferences.GetControlVersionInUse(applicationId, controlId);
             var controlFile = Path.Combine(applicationSettings.ApplicationDirectory, applicationId, Constants.ControlsDirectory, controlId, controlVersionInUse.ToString(),  $"{controlId}.dat");
-            logger.Information("Control with applicationId {0} && controlId : {1} and version : {2} has been loaded.", applicationId, controlId, controlVersionInUse);
+            logger.Debug("Control with applicationId {0} && controlId : {1} and version : {2} has been loaded.", applicationId, controlId, controlVersionInUse);
             return this.fileSystem.LoadFile<ControlDescription>(controlFile);
         }
 

--- a/src/Pixel.Automation.RunTime/TestRunner.cs
+++ b/src/Pixel.Automation.RunTime/TestRunner.cs
@@ -467,6 +467,7 @@ namespace Pixel.Automation.RunTime
                                         actor.IsExecuting = true;
                                         await actor.ActAsync();
                                         await AddDelay(this.postDelayAmount);
+                                        await actor.OnCompletionAsync();
                                     }
                                     catch (Exception ex)
                                     {

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/UIAActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/UIAActorComponent.cs
@@ -8,6 +8,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Pixel.Windows.Automation;
+using System.IO;
 
 namespace Pixel.Automation.UIA.Components
 {
@@ -71,6 +72,30 @@ namespace Pixel.Automation.UIA.Components
 
             AutomationElement control = targetControl.GetApiControl<AutomationElement>();
             return control;
+        }
+
+        /// <summary>
+        /// Take a screen shot if capturing screenshot is enabled after Act method finishes
+        /// </summary>
+        /// <returns></returns>
+        public override async Task OnCompletionAsync()
+        {
+            if (TraceManager.IsEnabled)
+            {
+                await CaptureScreenShotAsync();
+            }
+        }
+
+        /// <summary>
+        /// Capture screenshot of the active page
+        /// </summary>
+        /// <returns></returns>
+        public async Task CaptureScreenShotAsync()
+        {          
+            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+            var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
+            await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
+            TraceManager.AddImage(Path.GetFileName(imageFile));
         }
 
         /// <summary>

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/PlaywrightActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/PlaywrightActorComponent.cs
@@ -55,7 +55,6 @@ public abstract class PlaywrightActorComponent : ActorComponent
 
     }
 
-
     /// <summary>
     /// Retrieve the target control specified either as an <see cref="Argument"/> or a parent <see cref="WebControlEntity"/>
     /// </summary>
@@ -76,6 +75,29 @@ public abstract class PlaywrightActorComponent : ActorComponent
         return targetControl.GetApiControl<ILocator>();
     }
 
+    /// <summary>
+    /// Take a screen shot if capturing screenshot is enabled after Act method finishes
+    /// </summary>
+    /// <returns></returns>
+    public override async Task OnCompletionAsync()
+    {
+        if (TraceManager.IsEnabled)
+        {
+            await CaptureScreenShotAsync();
+        }
+    }
+
+    /// <summary>
+    /// Capture screenshot of the active page
+    /// </summary>
+    /// <returns></returns>
+    public async Task CaptureScreenShotAsync()
+    {
+        string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+        var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
+        await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
+        TraceManager.AddImage(Path.GetFileName(imageFile));
+    }
 
     protected void ThrowIfMissingControlEntity()
     {

--- a/src/Pixel.Automation.Web.Playwright.Components/WebApplicationEntity.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/WebApplicationEntity.cs
@@ -153,6 +153,17 @@ public class WebApplicationEntity : ApplicationEntity
         webApplicationDetails.Playwright = null;
     }
 
+    public override async Task CaptureScreenShotAsync(string filePath)
+    {
+        var activePage = this.GetTargetApplicationDetails<WebApplication>().ActivePage;
+        await activePage.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Path = filePath,
+            Type = ScreenshotType.Jpeg,
+            Quality = 50
+        });
+    }
+
     /// <summary>
     /// Get BrowserTypeLaunchOptions for browser
     /// </summary>        

--- a/src/Pixel.Automation.Web.Playwright.Components/WebControlEntity.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/WebControlEntity.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Playwright;
-using Pixel.Automation.Core.Arguments;
-using Pixel.Automation.Core.Components;
+﻿using Pixel.Automation.Core.Components;
 using Pixel.Automation.Core.Controls;
 using Pixel.Automation.Core.Enums;
 using Serilog;

--- a/src/Pixel.Automation.Web.Playwright.Components/WebControlIdentity.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/WebControlIdentity.cs
@@ -85,7 +85,7 @@ namespace Pixel.Automation.Web.Playwright.Components
 
         public override string ToString()
         {
-            return $"{this.Name} -> Identifier:{this.Identifier}|SearchScope:{this.SearchScope}";
+            return $"{this.Name} -> Identifier:{this.Identifier} | SearchScope:{this.SearchScope}";
         }
     }
 }

--- a/src/Pixel.Automation.Web.Playwright.Components/WebControlLocatorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/WebControlLocatorComponent.cs
@@ -179,7 +179,7 @@ public class WebControlLocatorComponent : ServiceComponent, IControlLocator, ICo
                 foundControl = ApplicationDetails.ActivePage.Locator(webControlIdentity.Identifier);
             }
         }
-        logger.Information($"{webControlIdentity} has been located");
+        logger.Information("Control : '{0}' was located" , webControlIdentity);
         return foundControl;
     }
 

--- a/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/SeleniumActorComponent.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/SeleniumActorComponent.cs
@@ -39,6 +39,29 @@ public abstract class SeleniumActorComponent : ActorComponent
 
     }
 
+    /// <summary>
+    /// Take a screen shot if capturing screenshot is enabled after Act method finishes
+    /// </summary>
+    /// <returns></returns>
+    public override async Task OnCompletionAsync()
+    {
+        if (TraceManager.IsEnabled)
+        {
+            await CaptureScreenShotAsync();
+        }
+    }
+
+    /// <summary>
+    /// Capture screenshot of the active page
+    /// </summary>
+    /// <returns></returns>
+    public async Task CaptureScreenShotAsync()
+    {
+        string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+        var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
+        await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
+        TraceManager.AddImage(Path.GetFileName(imageFile));
+    }
 }
 
 /// <summary>

--- a/src/Pixel.Automation.Web.Selenium.Components/WebApplicationEntity.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/WebApplicationEntity.cs
@@ -3,6 +3,7 @@ using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Edge;
 using OpenQA.Selenium.Firefox;
 using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.Extensions;
 using Pixel.Automation.Core.Arguments;
 using Pixel.Automation.Core.Components;
 using Pixel.Automation.Core.Interfaces;
@@ -194,6 +195,12 @@ public class WebApplicationEntity : ApplicationEntity
         }
     }
 
+    public override async Task CaptureScreenShotAsync(string filePath)
+    {
+        var webDriver = this.GetTargetApplicationDetails<WebApplication>().WebDriver;
+        webDriver.TakeScreenshot().SaveAsFile(filePath, ScreenshotImageFormat.Jpeg);
+        await Task.CompletedTask;
+    }
 
     /// <summary>
     /// Get DriverOptions for WebDriver based on PreferredBrowser

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Entities/ApplicationEntityTest.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Entities/ApplicationEntityTest.cs
@@ -18,6 +18,11 @@ namespace Pixel.Automation.Core.Components.Tests
             public override async Task CloseAsync()
             {
                 throw new System.NotImplementedException();
+            }          
+
+            public override async Task CaptureScreenShotAsync(string filePath)
+            {
+                throw new System.NotImplementedException();
             }
         }
 


### PR DESCRIPTION
**Description**
Capture a screenshot of the application after actor is executed. Not all actors will have this supported. However, most of the actors that act on application controls have this enabled. 
This helps us to generate a better trace which contains both logs and screenshots to understand what happened during execution of test case.