### PR TITLE
Webdriver doesn't support saving files as jpeg

### DIFF
--- a/src/Pixel.Automation.Web.Selenium.Components/WebApplicationEntity.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/WebApplicationEntity.cs
@@ -198,7 +198,7 @@ public class WebApplicationEntity : ApplicationEntity
     public override async Task CaptureScreenShotAsync(string filePath)
     {
         var webDriver = this.GetTargetApplicationDetails<WebApplication>().WebDriver;
-        webDriver.TakeScreenshot().SaveAsFile(filePath, ScreenshotImageFormat.Jpeg);
+        webDriver.TakeScreenshot().SaveAsFile(filePath, ScreenshotImageFormat.Png);
         await Task.CompletedTask;
     }
 


### PR DESCRIPTION
Change the file format to png when saving images using webdriver. Png files are very large in size. We will eventually need a way to save to jpeg instead consistent with other plugins.