### PR TITLE
Configure if screen shots can be captured for tracing for an application

### DIFF
--- a/src/Pixel.Automation.Appium.Components/ActorComponents/AppiumActorComponent.cs
+++ b/src/Pixel.Automation.Appium.Components/ActorComponents/AppiumActorComponent.cs
@@ -56,11 +56,14 @@ public abstract class AppiumActorComponent : ActorComponent
     /// </summary>
     /// <returns></returns>
     public async Task CaptureScreenShotAsync()
-    {       
-        string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+    {
         var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
-        await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
-        TraceManager.AddImage(Path.GetFileName(imageFile));
+        if (TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
+        {
+            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+            await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
+            TraceManager.AddImage(Path.GetFileName(imageFile));
+        }       
     }
 }
 

--- a/src/Pixel.Automation.Appium.Components/AppiumApplicationEntity.cs
+++ b/src/Pixel.Automation.Appium.Components/AppiumApplicationEntity.cs
@@ -85,9 +85,12 @@ public class AppiumApplicationEntity : ApplicationEntity
 
     /// </inheritdoc>
     public override async Task CaptureScreenShotAsync(string filePath)
-    {
-        var webDriver = this.GetTargetApplicationDetails<AppiumApplication>().Driver;
-        webDriver.TakeScreenshot().SaveAsFile(filePath, ScreenshotImageFormat.Jpeg);
+    {       
+        if (this.AllowCaptureScreenshot)
+        {
+            var webDriver = this.GetTargetApplicationDetails<AppiumApplication>().Driver;
+            webDriver.TakeScreenshot().SaveAsFile(filePath, ScreenshotImageFormat.Png);
+        }
         await Task.CompletedTask;
     }
 

--- a/src/Pixel.Automation.Core.Components/Entities/ApplicationEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Entities/ApplicationEntity.cs
@@ -18,19 +18,20 @@ namespace Pixel.Automation.Core.Components
     public abstract class ApplicationEntity : Entity, IApplicationEntity
     {
         protected readonly ILogger logger;
+        protected IApplication applicationDetails;
 
         [DataMember(Order = 500)]
         [Display(Name = "Application Id", Order = 10, GroupName = "Application Details")]
         public string ApplicationId { get; set; }
 
-        [DataMember(Order = 210)]
+        [DataMember(Order = 220)]
         [Browsable(false)]
         public string ApplicationFile { get; set; }
 
-       
-        protected IApplication applicationDetails;
-
-
+        [DataMember(Order = 210)]
+        [Display(Name = "Can Capture ScreenShot", Order = 10, GroupName = "Tracing")]
+        public bool AllowCaptureScreenshot { get; set; } = true;
+        
         internal ApplicationEntity()
         {
             this.logger = Log.ForContext(this.GetType());

--- a/src/Pixel.Automation.Core/Interfaces/IApplicationEntity.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IApplicationEntity.cs
@@ -20,6 +20,11 @@ namespace Pixel.Automation.Core.Interfaces
         bool CanUseExisting { get; }
 
         /// <summary>
+        /// Indicates if capturing screenshot is allowed for the application
+        /// </summary>
+        bool AllowCaptureScreenshot { get; }
+
+        /// <summary>
         /// Get the details of target application
         /// </summary>
         /// <returns><see cref="IApplication"/></returns>

--- a/src/Pixel.Automation.Input.Devices.Components/InputDeviceActor.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/InputDeviceActor.cs
@@ -88,10 +88,10 @@ namespace Pixel.Automation.Input.Devices.Components
 
         public override async Task OnCompletionAsync()
         {
-            if (TraceManager.IsEnabled)
+            var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
+            if (TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
             {
-                string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
-                var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
+                string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");                
                 await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
                 TraceManager.AddImage(Path.GetFileName(imageFile));
             }

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/JABActorComponent.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/JABActorComponent.cs
@@ -89,11 +89,14 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
         /// </summary>
         /// <returns></returns>
         public async Task CaptureScreenShotAsync()
-        {            
-            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+        {
             var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
-            await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
-            TraceManager.AddImage(Path.GetFileName(imageFile));
+            if (TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
+            {
+                string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");
+                await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
+                TraceManager.AddImage(Path.GetFileName(imageFile));
+            }
         }
 
         protected void ThrowIfMissingControlEntity()

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/JavaApplicationEntity.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/JavaApplicationEntity.cs
@@ -93,21 +93,24 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
         ///<inheritdoc/>
         public override async Task CaptureScreenShotAsync(string filePath)
         {
-            var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
-            var windowManager = this.EntityManager.GetServiceOfType<IApplicationWindowManager>();
-            var appRectangle = windowManager.GetWindowSize(this.applicationDetails.Hwnd);
-            var screenShotBytes = screenCapture.CaptureArea(appRectangle);
-            using (var memoryStream = new MemoryStream(screenShotBytes))
+            if (this.AllowCaptureScreenshot)
             {
-                using (var bitmap = new Bitmap(memoryStream))
+                var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
+                var windowManager = this.EntityManager.GetServiceOfType<IApplicationWindowManager>();
+                var appRectangle = windowManager.GetWindowSize(this.applicationDetails.Hwnd);
+                var screenShotBytes = screenCapture.CaptureArea(appRectangle);
+                using (var memoryStream = new MemoryStream(screenShotBytes))
                 {
-                    using (FileStream fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write))
+                    using (var bitmap = new Bitmap(memoryStream))
                     {
-                        bitmap.Save(fs, ImageFormat.Png);
+                        using (FileStream fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write))
+                        {
+                            bitmap.Save(fs, ImageFormat.Jpeg);
+                        }
                     }
                 }
-            }
-            await Task.CompletedTask;
+                await Task.CompletedTask;
+            }           
         }
 
     }

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/UIAActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/UIAActorComponent.cs
@@ -91,11 +91,14 @@ namespace Pixel.Automation.UIA.Components
         /// </summary>
         /// <returns></returns>
         public async Task CaptureScreenShotAsync()
-        {          
-            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+        {
             var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
-            await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
-            TraceManager.AddImage(Path.GetFileName(imageFile));
+            if (TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
+            {
+                string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");
+                await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
+                TraceManager.AddImage(Path.GetFileName(imageFile));
+            }
         }
 
         /// <summary>

--- a/src/Pixel.Automation.UIA.Components/WinApplicationEntity.cs
+++ b/src/Pixel.Automation.UIA.Components/WinApplicationEntity.cs
@@ -103,21 +103,24 @@ namespace Pixel.Automation.UIA.Components
         ///<inheritdoc/>
         public override async Task CaptureScreenShotAsync(string filePath)
         {
-            var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
-            var windowManager = this.EntityManager.GetServiceOfType<IApplicationWindowManager>();
-            var appRectangle = windowManager.GetWindowSize(this.applicationDetails.Hwnd);
-            var screenShotBytes = screenCapture.CaptureArea(appRectangle);
-            using (var memoryStream = new MemoryStream(screenShotBytes))
+            if (this.AllowCaptureScreenshot)
             {
-                using (var bitmap = new Bitmap(memoryStream))
+                var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
+                var windowManager = this.EntityManager.GetServiceOfType<IApplicationWindowManager>();
+                var appRectangle = windowManager.GetWindowSize(this.applicationDetails.Hwnd);
+                var screenShotBytes = screenCapture.CaptureArea(appRectangle);
+                using (var memoryStream = new MemoryStream(screenShotBytes))
                 {
-                    using(FileStream fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write))
+                    using (var bitmap = new Bitmap(memoryStream))
                     {
-                        bitmap.Save(fs, ImageFormat.Png);
+                        using (FileStream fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write))
+                        {
+                            bitmap.Save(fs, ImageFormat.Jpeg);
+                        }
                     }
                 }
-            }
-            await Task.CompletedTask;
+                await Task.CompletedTask;
+            }           
         }
     }
 }

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/PlaywrightActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/PlaywrightActorComponent.cs
@@ -93,10 +93,13 @@ public abstract class PlaywrightActorComponent : ActorComponent
     /// <returns></returns>
     public async Task CaptureScreenShotAsync()
     {
-        string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
         var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
-        await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
-        TraceManager.AddImage(Path.GetFileName(imageFile));
+        if (TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
+        {
+            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");
+            await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
+            TraceManager.AddImage(Path.GetFileName(imageFile));
+        }     
     }
 
     protected void ThrowIfMissingControlEntity()

--- a/src/Pixel.Automation.Web.Playwright.Components/WebApplicationEntity.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/WebApplicationEntity.cs
@@ -155,13 +155,16 @@ public class WebApplicationEntity : ApplicationEntity
 
     public override async Task CaptureScreenShotAsync(string filePath)
     {
-        var activePage = this.GetTargetApplicationDetails<WebApplication>().ActivePage;
-        await activePage.ScreenshotAsync(new PageScreenshotOptions
+        if(this.AllowCaptureScreenshot)
         {
-            Path = filePath,
-            Type = ScreenshotType.Jpeg,
-            Quality = 50
-        });
+            var activePage = this.GetTargetApplicationDetails<WebApplication>().ActivePage;
+            await activePage.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = filePath,
+                Type = ScreenshotType.Jpeg,
+                Quality = 80
+            });
+        }        
     }
 
     /// <summary>

--- a/src/Pixel.Automation.Web.Portal/Components/Tests/ImageDialog.razor
+++ b/src/Pixel.Automation.Web.Portal/Components/Tests/ImageDialog.razor
@@ -5,7 +5,7 @@
         @if(imageBytes != null)
         {
            <div class="d-flex justify-center">
-                <MudImage Src="@string.Format("data:image/png;base64,{0}", Convert.ToBase64String(imageBytes))"
+                <MudImage Src="@string.Format("data:image/jpeg;base64,{0}", Convert.ToBase64String(imageBytes))"
                           Fluid="true" Class="rounded-lg ma-4" Height="800" Width="600" />
             </div>             
         }     

--- a/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/SeleniumActorComponent.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/SeleniumActorComponent.cs
@@ -57,10 +57,13 @@ public abstract class SeleniumActorComponent : ActorComponent
     /// <returns></returns>
     public async Task CaptureScreenShotAsync()
     {
-        string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
         var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
-        await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
-        TraceManager.AddImage(Path.GetFileName(imageFile));
+        if(TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
+        {
+            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+            await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
+            TraceManager.AddImage(Path.GetFileName(imageFile));
+        }       
     }
 }
 

--- a/src/Pixel.Automation.Web.Selenium.Components/WebApplicationEntity.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/WebApplicationEntity.cs
@@ -197,8 +197,11 @@ public class WebApplicationEntity : ApplicationEntity
 
     public override async Task CaptureScreenShotAsync(string filePath)
     {
-        var webDriver = this.GetTargetApplicationDetails<WebApplication>().WebDriver;
-        webDriver.TakeScreenshot().SaveAsFile(filePath, ScreenshotImageFormat.Png);
+        if (this.AllowCaptureScreenshot)
+        {
+            var webDriver = this.GetTargetApplicationDetails<WebApplication>().WebDriver;
+            webDriver.TakeScreenshot().SaveAsFile(filePath, ScreenshotImageFormat.Png);
+        }
         await Task.CompletedTask;
     }
 


### PR DESCRIPTION
It might not be always desirable to capture screenshots (maybe due to space constraints or any issues with application screenshot capturing ) when capturing traces for test cases. Allow configuration flag to turn off capturing screenshot for a given application.