### PR TITLE
Allow sampling ratio to be configured for open telemetry tracing

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/AppBootStrapper.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AppBootStrapper.cs
@@ -152,9 +152,11 @@ namespace Pixel.Automation.Designer.ViewModels
                 Telemetry.InitializeDefault("pixel-design", Assembly.GetExecutingAssembly().GetName().Version.ToString());
                 string[] enablesSources = configuration.GetSection("OpenTelemetry:Sources").Get<string[]>();
 
+                double.TryParse(configuration["OpenTelemetry:Sampling:Ratio"], out double samplingProbablity);
                 var traceProviderBuilder = Sdk.CreateTracerProviderBuilder()
-                .SetSampler(new TraceIdRatioBasedSampler(0.1))
+                .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingProbablity)))
                 .AddSource(enablesSources).ConfigureResource(resource => resource.AddService("pixel-design")).AddHttpClientInstrumentation();
+               
                 string otlpTraceEndPoint = configuration["OpenTelemetry:Trace:EndPoint"];             
                 if (!string.IsNullOrEmpty(otlpTraceEndPoint))
                 {

--- a/src/Pixel.Automation.Designer.Views/appsettings.json
+++ b/src/Pixel.Automation.Designer.Views/appsettings.json
@@ -40,7 +40,10 @@
     },
     "Sources": [
       "pixel-design"
-    ]
+    ],
+    "Sampling": {
+      "Ratio" : 0.4
+    }
   },
   "userSettings": {
     "theme": "Light",

--- a/src/Pixel.Automation.Test.Runner/Program.cs
+++ b/src/Pixel.Automation.Test.Runner/Program.cs
@@ -41,10 +41,12 @@ namespace Pixel.Automation.Test.Runner
             Telemetry.InitializeDefault("pixel-run", Assembly.GetExecutingAssembly().GetName().Version.ToString());
             string[] enablesSources = configuration.GetSection("OpenTelemetry:Sources").Get<string[]>();
 
+            double.TryParse(configuration["OpenTelemetry:Sampling:Ratio"], out double samplingProbablity);
             var traceProviderBuilder = Sdk.CreateTracerProviderBuilder()
-            .SetSampler(new TraceIdRatioBasedSampler(0.1))
+            .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingProbablity)))
             .AddSource(enablesSources).ConfigureResource(resource => resource.AddService("pixel-run")).AddHttpClientInstrumentation();
             string otlpTraceEndPoint = configuration["OpenTelemetry:Trace:EndPoint"];
+          
             if (!string.IsNullOrEmpty(otlpTraceEndPoint))
             {
                 Enum.TryParse<OtlpExportProtocol>(configuration["OpenTelemetry:TraceExporter:OtlpExportProtocol"] ?? "HttpProtobuf", out OtlpExportProtocol exportProtocol);

--- a/src/Pixel.Automation.Test.Runner/appsettings.json
+++ b/src/Pixel.Automation.Test.Runner/appsettings.json
@@ -43,7 +43,10 @@
     },
     "Sources": [
       "pixel-run"
-    ]
+    ],
+    "Sampling": {
+      "Ratio": 0.4
+    }
   },
   "applicationSettings": {
     "applicationDirectory": "Applications",

--- a/src/Pixel.Persistence.Services.Api/Startup.cs
+++ b/src/Pixel.Persistence.Services.Api/Startup.cs
@@ -41,10 +41,12 @@ namespace Pixel.Persistence.Services.Api
                 .WithTracing(builder =>
                 {
                     string[] enabledSources = Configuration.GetSection("OpenTelemetry:Sources").Get<string[]>();
+                    double.TryParse(Configuration["OpenTelemetry:Sampling:Ratio"], out double samplingProbablity);
+
                     builder.AddSource(enabledSources);
                     builder.AddAspNetCoreInstrumentation();                 
                     builder.AddHttpClientInstrumentation();
-                    //builder.SetSampler(new TraceIdRatioBasedSampler(0.1));
+                    builder.SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingProbablity)));
                     string otlpTraceEndPoint = Configuration["OpenTelemetry:Trace:EndPoint"];
                     if (!string.IsNullOrEmpty(otlpTraceEndPoint))
                     {

--- a/src/Pixel.Persistence.Services.Api/appsettings.json
+++ b/src/Pixel.Persistence.Services.Api/appsettings.json
@@ -47,7 +47,10 @@
     },
     "Sources": [
       "pixel-persistence"
-    ]
+    ],
+    "Sampling": {
+      "Ratio": 0.4
+    }
   },
   "RetentionPolicy": {
     "MaxNumberOfRevisions": 50,


### PR DESCRIPTION
**Description**
Changed opentelemetry sampler to ParentBasedSampler with TraceIdRatioBasedSampler as the root sampler. 
Ratio can be configured for TraceIdRatioBasedSampler now.