### PR TITLE
Save image as Jpeg for webdriver and appium plugin

### DIFF
--- a/src/Pixel.Automation.Appium.Components/ActorComponents/AppiumActorComponent.cs
+++ b/src/Pixel.Automation.Appium.Components/ActorComponents/AppiumActorComponent.cs
@@ -60,7 +60,7 @@ public abstract class AppiumActorComponent : ActorComponent
         var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
         if (TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
         {
-            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");
             await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
             TraceManager.AddImage(Path.GetFileName(imageFile));
         }       

--- a/src/Pixel.Automation.Appium.Components/AppiumApplicationEntity.cs
+++ b/src/Pixel.Automation.Appium.Components/AppiumApplicationEntity.cs
@@ -5,6 +5,7 @@ using OpenQA.Selenium.Support.Extensions;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Arguments;
 using Pixel.Automation.Core.Components;
+using Pixel.Automation.Core.Interfaces;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
@@ -87,11 +88,12 @@ public class AppiumApplicationEntity : ApplicationEntity
     public override async Task CaptureScreenShotAsync(string filePath)
     {       
         if (this.AllowCaptureScreenshot)
-        {
-            var webDriver = this.GetTargetApplicationDetails<AppiumApplication>().Driver;
-            webDriver.TakeScreenshot().SaveAsFile(filePath, ScreenshotImageFormat.Png);
-        }
-        await Task.CompletedTask;
+        {          
+            var imageManager = this.EntityManager.GetServiceOfType<IImageManager>();
+            var appiumDriver = this.GetTargetApplicationDetails<AppiumApplication>().Driver;
+            var screenShot = appiumDriver.TakeScreenshot();
+            await imageManager.SaveAsAsync(screenShot.AsByteArray, filePath, Core.Enums.ImageFormat.Jpeg);
+        }    
     }
 
     async Task<AppiumServiceBuilder> GetServiceBuilder()

--- a/src/Pixel.Automation.Core/Enums/ImageFormat.cs
+++ b/src/Pixel.Automation.Core/Enums/ImageFormat.cs
@@ -1,0 +1,10 @@
+﻿namespace Pixel.Automation.Core.Enums;
+
+/// <summary>
+/// Identifies different types of image formats for working with images
+/// </summary>
+public enum ImageFormat
+{
+    Jpeg,
+    Png
+}

--- a/src/Pixel.Automation.Core/Interfaces/IImageManager.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IImageManager.cs
@@ -1,0 +1,27 @@
+﻿using Pixel.Automation.Core.Enums;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Core.Interfaces;
+
+/// <summary>
+/// Contract for managing image
+/// </summary>
+public interface IImageManager
+{
+    /// <summary>
+    /// Save image at a specified location in specified format
+    /// </summary>
+    /// <param name="imageBytes"></param>
+    /// <param name="saveLocation"></param>
+    /// <param name="format"></param>
+    public void SaveAs(byte[] imageBytes, string saveLocation, ImageFormat format);
+
+    /// <summary>
+    /// Save image asynchronously at a specified location in specified format
+    /// </summary>
+    /// <param name="imageBytes"></param>
+    /// <param name="saveLocation"></param>
+    /// <param name="format"></param>
+    /// <returns></returns>
+    public Task SaveAsAsync(byte[] imageBytes, string saveLocation, ImageFormat format);
+}

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/JavaApplicationEntity.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/JavaApplicationEntity.cs
@@ -6,9 +6,6 @@ using Pixel.Automation.Core.Interfaces;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
-using System.Drawing.Imaging;
-using System.Drawing;
-using System.IO;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
@@ -97,19 +94,10 @@ public class JavaApplicationEntity : ApplicationEntity
         {
             var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
             var windowManager = this.EntityManager.GetServiceOfType<IApplicationWindowManager>();
+            var imageManager = this.EntityManager.GetServiceOfType<IImageManager>();
             var appRectangle = windowManager.GetWindowSize(this.applicationDetails.Hwnd);
             var screenShotBytes = screenCapture.CaptureArea(appRectangle);
-            using (var memoryStream = new MemoryStream(screenShotBytes))
-            {
-                using (var bitmap = new Bitmap(memoryStream))
-                {
-                    using (FileStream fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write))
-                    {
-                        bitmap.Save(fs, ImageFormat.Jpeg);
-                    }
-                }
-            }
-            await Task.CompletedTask;
+            await imageManager.SaveAsAsync(screenShotBytes, filePath, Core.Enums.ImageFormat.Jpeg);
         }           
     }
 

--- a/src/Pixel.Automation.Native.Linux/ImageManager.cs
+++ b/src/Pixel.Automation.Native.Linux/ImageManager.cs
@@ -1,0 +1,53 @@
+﻿using Pixel.Automation.Core.Enums;
+using Pixel.Automation.Core.Interfaces;
+using SixLabors.ImageSharp;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Native.Linux;
+
+/// <summary>
+/// Implementation of <see cref="IImageManager"/> for Linux platform
+/// </summary>
+public class ImageManager : IImageManager
+{
+    /// </inheritdoc>   
+    public void SaveAs(byte[] imageBytes, string saveLocation, ImageFormat format)
+    {
+        using (var memoryStream = new MemoryStream(imageBytes))
+        {
+            using (var image = Image.Load(memoryStream))
+            {
+                switch (format)
+                {
+                    case ImageFormat.Png:
+                        image.SaveAsPng(saveLocation);
+                        break;
+                    case ImageFormat.Jpeg:
+                        image.SaveAsJpeg(saveLocation);
+                        break;
+                }
+            }
+        }
+    }
+
+    /// </inheritdoc>   
+    public async Task SaveAsAsync(byte[] imageBytes, string saveLocation, ImageFormat format)
+    {
+        using (var memoryStream = new MemoryStream(imageBytes))
+        {
+            using (var image = Image.Load(memoryStream))
+            {
+                switch (format)
+                {
+                    case ImageFormat.Png:
+                        await image.SaveAsPngAsync(saveLocation);
+                        break;
+                    case ImageFormat.Jpeg:
+                        await image.SaveAsJpegAsync(saveLocation);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/Pixel.Automation.Native.Linux/Pixel.Automation.Native.Linux.csproj
+++ b/src/Pixel.Automation.Native.Linux/Pixel.Automation.Native.Linux.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
 	  <ProjectReference Include="..\Pixel.Automation.Core\Pixel.Automation.Core.csproj">
 		  <Private>false</Private>
 		  <PrivateAssets>All</PrivateAssets>

--- a/src/Pixel.Automation.Native.Windows/ImageManager.cs
+++ b/src/Pixel.Automation.Native.Windows/ImageManager.cs
@@ -1,0 +1,53 @@
+﻿using Pixel.Automation.Core.Enums;
+using Pixel.Automation.Core.Interfaces;
+using SixLabors.ImageSharp;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Native.Windows;
+
+/// <summary>
+/// Implementation of <see cref="IImageManager"/> for windows platform
+/// </summary>
+public class ImageManager : IImageManager
+{  
+    /// </inheritdoc>   
+    public void SaveAs(byte[] imageBytes, string saveLocation, ImageFormat format)
+    {
+        using (var memoryStream = new MemoryStream(imageBytes))
+        {
+            using (var image = Image.Load(memoryStream))
+            {
+                switch (format)
+                {
+                    case ImageFormat.Png:
+                        image.SaveAsPng(saveLocation);
+                        break;
+                    case ImageFormat.Jpeg:
+                        image.SaveAsJpeg(saveLocation);
+                        break;
+                }
+            }
+        }
+    }
+
+    /// </inheritdoc>   
+    public async Task SaveAsAsync(byte[] imageBytes, string saveLocation, ImageFormat format)
+    {
+        using (var memoryStream = new MemoryStream(imageBytes))
+        {
+            using (var image = Image.Load(memoryStream))
+            {
+                switch (format)
+                {
+                    case ImageFormat.Png:
+                        await image.SaveAsPngAsync(saveLocation);
+                        break;
+                    case ImageFormat.Jpeg:
+                        await image.SaveAsJpegAsync(saveLocation);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/Pixel.Automation.Native.Windows/Pixel.Automation.Native.Windows.csproj
+++ b/src/Pixel.Automation.Native.Windows/Pixel.Automation.Native.Windows.csproj
@@ -23,6 +23,7 @@
 		<PackageReference Include="InputSimulatorStandard" Version="1.0.0">
 			<Private>false</Private>
 		</PackageReference>
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
 		<PackageReference Include="System.Management" Version="7.0.2" />
 		<PackageReference Include="Vanara.Core" Version="3.4.16">
 			<Private>false</Private>

--- a/src/Pixel.Automation.UIA.Components/WinApplicationEntity.cs
+++ b/src/Pixel.Automation.UIA.Components/WinApplicationEntity.cs
@@ -6,9 +6,6 @@ using Pixel.Automation.Core.Interfaces;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.IO;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
@@ -107,19 +104,10 @@ public class WinApplicationEntity : ApplicationEntity
         {
             var screenCapture = this.EntityManager.GetServiceOfType<IScreenCapture>();
             var windowManager = this.EntityManager.GetServiceOfType<IApplicationWindowManager>();
+            var imageManager = this.EntityManager.GetServiceOfType<IImageManager>();
             var appRectangle = windowManager.GetWindowSize(this.applicationDetails.Hwnd);
             var screenShotBytes = screenCapture.CaptureArea(appRectangle);
-            using (var memoryStream = new MemoryStream(screenShotBytes))
-            {
-                using (var bitmap = new Bitmap(memoryStream))
-                {
-                    using (FileStream fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write))
-                    {
-                        bitmap.Save(fs, ImageFormat.Jpeg);
-                    }
-                }
-            }
-            await Task.CompletedTask;
+            await imageManager.SaveAsAsync(screenShotBytes, filePath, Core.Enums.ImageFormat.Jpeg);
         }           
     }
 }

--- a/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/SeleniumActorComponent.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/SeleniumActorComponent.cs
@@ -60,7 +60,7 @@ public abstract class SeleniumActorComponent : ActorComponent
         var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
         if(TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
         {
-            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.png");
+            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");
             await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
             TraceManager.AddImage(Path.GetFileName(imageFile));
         }       

--- a/src/Pixel.Automation.Web.Selenium.Components/WebApplicationEntity.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/WebApplicationEntity.cs
@@ -199,10 +199,11 @@ public class WebApplicationEntity : ApplicationEntity
     {
         if (this.AllowCaptureScreenshot)
         {
+            var imageManager = this.EntityManager.GetServiceOfType<IImageManager>();
             var webDriver = this.GetTargetApplicationDetails<WebApplication>().WebDriver;
-            webDriver.TakeScreenshot().SaveAsFile(filePath, ScreenshotImageFormat.Png);
-        }
-        await Task.CompletedTask;
+            var screenShot =  webDriver.TakeScreenshot();
+            await imageManager.SaveAsAsync(screenShot.AsByteArray, filePath, Core.Enums.ImageFormat.Jpeg);
+        }        
     }
 
     /// <summary>


### PR DESCRIPTION
**Description**
While capturing screen shot for webdriver and appium plugins, save image as jpeg instead of png. Webdriver doesn't support saving image as png. We are using ImageSharp library to save captured byte array as jpeg image.