### PR TITLE
Filter client instrumentation to certain url's matching configure regular expression

### DIFF
--- a/src/Pixel.Automation.Designer.Views/appsettings.json
+++ b/src/Pixel.Automation.Designer.Views/appsettings.json
@@ -42,8 +42,13 @@
       "pixel-design"
     ],
     "Sampling": {
-      "Ratio" : 0.4
-    }
+      "Ratio": 1.0
+    },
+    "FilterRequests": [
+      ".*\/status",
+      ".*\/session",
+      ".*\/ingest"
+    ]
   },
   "userSettings": {
     "theme": "Light",

--- a/src/Pixel.Automation.Test.Runner/Program.cs
+++ b/src/Pixel.Automation.Test.Runner/Program.cs
@@ -21,6 +21,7 @@ using System;
 using OpenTelemetry.Trace;
 using OpenTelemetry.Resources;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace Pixel.Automation.Test.Runner
 {
@@ -40,11 +41,34 @@ namespace Pixel.Automation.Test.Runner
 
             Telemetry.InitializeDefault("pixel-run", Assembly.GetExecutingAssembly().GetName().Version.ToString());
             string[] enablesSources = configuration.GetSection("OpenTelemetry:Sources").Get<string[]>();
+            string[] filterHttpRequests = configuration.GetSection("OpenTelemetry:FilterRequests").Get<string[]>() ?? Array.Empty<string>();
+            Regex[] filterHttpRequestsMatcher = new Regex[filterHttpRequests.Length];
+            for (int i = 0; i < filterHttpRequests.Length; i++)
+            {
+                filterHttpRequestsMatcher[i] = new Regex(filterHttpRequests[i], RegexOptions.Compiled);
+            }
 
             double.TryParse(configuration["OpenTelemetry:Sampling:Ratio"], out double samplingProbablity);
             var traceProviderBuilder = Sdk.CreateTracerProviderBuilder()
             .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingProbablity)))
-            .AddSource(enablesSources).ConfigureResource(resource => resource.AddService("pixel-run")).AddHttpClientInstrumentation();
+            .AddSource(enablesSources).ConfigureResource(resource => resource.AddService("pixel-run"))
+            .AddHttpClientInstrumentation(options =>
+             {
+                 if (filterHttpRequestsMatcher.Any())
+                 {
+                     options.FilterHttpRequestMessage = (message) =>
+                     {
+                         foreach (var pattern in filterHttpRequestsMatcher)
+                         {
+                             if (pattern.IsMatch(message.RequestUri.OriginalString))
+                             {
+                                 return false;
+                             }
+                         }
+                         return true;
+                     };
+                 }
+             });
             string otlpTraceEndPoint = configuration["OpenTelemetry:Trace:EndPoint"];
           
             if (!string.IsNullOrEmpty(otlpTraceEndPoint))

--- a/src/Pixel.Automation.Test.Runner/Program.cs
+++ b/src/Pixel.Automation.Test.Runner/Program.cs
@@ -22,6 +22,7 @@ using OpenTelemetry.Trace;
 using OpenTelemetry.Resources;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace Pixel.Automation.Test.Runner
 {

--- a/src/Pixel.Automation.Test.Runner/appsettings.json
+++ b/src/Pixel.Automation.Test.Runner/appsettings.json
@@ -46,7 +46,12 @@
     ],
     "Sampling": {
       "Ratio": 0.4
-    }
+    },
+    "FilterRequests": [
+      ".*\/status",
+      ".*\/session",
+      ".*\/ingest"
+    ]
   },
   "applicationSettings": {
     "applicationDirectory": "Applications",


### PR DESCRIPTION
**Description**
We don't want to capture http client instrumentation for requests to webdriver. It should be hence possible to ignore certain url's from http client instrumentation via configuration.