### PR TITLE
Add a camera icon on top right for image controls for visual hint

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Control/ControlDescriptionViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Control/ControlDescriptionViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using Pixel.Automation.Core;
 using Pixel.Automation.Core.Controls;
 using Pixel.Automation.Core.Interfaces;
-using System;
 using System.ComponentModel;
 using System.IO;
 using System.Windows.Media;
@@ -103,6 +102,14 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Control
             set => this.controlDescription.ControlDetails = value;
         }
 
+        /// <summary>
+        /// Indicates if the control is an image control
+        /// </summary>
+        [Browsable(false)]
+        public bool IsImageControl
+        {
+            get => this.ControlDetails is IImageControlIdentity;
+        }
       
         ImageSource imageSource;
         /// <summary>

--- a/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml
@@ -11,7 +11,7 @@
              d:DesignHeight="450" d:DesignWidth="800">
 
     <UserControl.Resources>
-        
+        <BooleanToVisibilityConverter x:Key="boolToVisibilityConverter"/>
         <Style x:Key="ControlLabel" TargetType="{x:Type TextBox}">
             <Setter Property="IsReadOnly" Value="True"></Setter>
             <Setter Property="HorizontalAlignment" Value="Center"></Setter>
@@ -84,8 +84,13 @@
                     </ContextMenu>
                 </StackPanel.ContextMenu>
                 <Border x:Name="ControlBorder" BorderBrush="{DynamicResource MahApps.Brushes.Accent3}" Background="Transparent" BorderThickness="2" CornerRadius="4">
-                    <Image x:Name="ControlImage" Source="{Binding ImageSource}" Stretch="Uniform" Margin="5" Width="148" Height="80"
-                                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    <StackPanel Orientation="Horizontal">
+                        <Image x:Name="ControlImage" Source="{Binding ImageSource}" Stretch="Uniform" Margin="5" Width="148" Height="80"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <iconPacks:PackIconMaterial Visibility="{Binding IsImageControl, Converter={StaticResource boolToVisibilityConverter}}"
+                          Width="20" Height="20" Margin="-20,-3,0,0" Padding="4"                                  
+                          Kind="CameraOutline" Foreground="{DynamicResource MahApps.Brushes.Accent3}" /> 
+                    </StackPanel>                
                 </Border>
                 <TextBox x:Name="ControlName" Text="{Binding ControlName}"   Margin="5"  Style="{StaticResource ControlLabel}" IsHitTestVisible="True" HorizontalAlignment="Stretch"
                                          cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}"

--- a/src/Pixel.Automation.Designer.Views/Resources/Control.Components.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Control.Components.xaml
@@ -8,13 +8,23 @@
     <converters:BitmapConverter x:Key="bitMapConverter"/>
    
     <HierarchicalDataTemplate x:Key="ControlTemplate" ItemsSource="{Binding ComponentCollection}">        
-                <DockPanel LastChildFill="True" MinWidth="220" Width="224" Grid.Row="2"
-                   HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsHitTestVisible="True">
-            <Image DockPanel.Dock="Left" Margin="10" Source="{Binding Model.ControlDescription.ControlImage, Converter={StaticResource bitMapConverter}}"
+        <StackPanel MinWidth="220" Width="224" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsHitTestVisible="True">
+            <Image Margin="10" Source="{Binding Model.ControlDescription.ControlImage, Converter={StaticResource bitMapConverter}}"
                         HorizontalAlignment="Center" Stretch="Uniform" 
                         Height="50">              
             </Image>
-        </DockPanel>       
+        </StackPanel>       
+    </HierarchicalDataTemplate>
+
+    <HierarchicalDataTemplate x:Key="ImageControlTemplate" ItemsSource="{Binding ComponentCollection}">
+        <StackPanel MinWidth="220" Width="224" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsHitTestVisible="True">
+            <Image Margin="10" Source="{Binding Model.ControlDescription.ControlImage, Converter={StaticResource bitMapConverter}}"
+                      HorizontalAlignment="Center" Stretch="Uniform" 
+                      Height="50">
+            </Image>
+            <iconPacks:PackIconMaterial Width="20" Height="20" Margin="0,-76,-94,0" Padding="4" HorizontalAlignment="Right"                              
+                     Kind="CameraOutline" Foreground="{DynamicResource MahApps.Brushes.Accent3}" />
+        </StackPanel>
     </HierarchicalDataTemplate>
 
     <Style TargetType="TreeViewItem" x:Key="ControlComponentStyle">

--- a/src/Pixel.Automation.Designer.Views/Resources/TemplateMapping.xml
+++ b/src/Pixel.Automation.Designer.Views/Resources/TemplateMapping.xml
@@ -111,7 +111,7 @@
 	</ComponentTemplate>
 	<ComponentTemplate>
 		<Name>ImageControlEntity</Name>
-		<DataTemplateKey>ControlTemplate</DataTemplateKey>
+		<DataTemplateKey>ImageControlTemplate</DataTemplateKey>
 		<StyleKey>ControlComponentStyle</StyleKey>
 	</ComponentTemplate>
 	<ComponentTemplate>


### PR DESCRIPTION
**Description**
Image based controls on control explorer and image control entity on designer now have a camera icon visible on top right to visually distinguish them from api based controls.