### PR TITLE
Exit without saving while capturing image control

### DIFF
--- a/src/Pixel.Automation.Editor.Image.Capture/ImageCaptureView.xaml
+++ b/src/Pixel.Automation.Editor.Image.Capture/ImageCaptureView.xaml
@@ -84,8 +84,10 @@
                               cal:Message.Attach="ChangePivotPoint('BottomRight')"></MenuItem>
                     </MenuItem>
                     
-                    <MenuItem x:Name="closeView" Header="Exit"
-                              cal:Message.Attach="CloseView()"></MenuItem>
+                    <MenuItem x:Name="Save" Header="Save"
+                              cal:Message.Attach="Save()"></MenuItem>
+                    <MenuItem x:Name="Exit" Header="Exit"
+                              cal:Message.Attach="Exit()"></MenuItem>
                 </ContextMenu>
             </Canvas.ContextMenu>
 

--- a/src/Pixel.Automation.Editor.Image.Capture/ImageCaptureViewModel.cs
+++ b/src/Pixel.Automation.Editor.Image.Capture/ImageCaptureViewModel.cs
@@ -195,12 +195,17 @@ namespace Pixel.Automation.Editor.Image.Capture
             offsetPointer.SetValue(Canvas.TopProperty, (double)this.Offset.Y);
 
         
-        } 
-    
-        public async Task CloseView()
+        }
+
+        public async Task Save()
         {
             this.controlIdentity.BoundingBox = this.TemplateBoundingBox;
             await this.TryCloseAsync(true);
+        }
+
+        public async Task Exit()
+        {           
+            await this.TryCloseAsync(false);
         }
 
         [System.Runtime.InteropServices.DllImport("gdi32.dll")]


### PR DESCRIPTION
**Description**
It should be possible to exit without saving while trying to capture an image control