### PR TITLE
Update selected project version correctly on publish

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/Screen/AutomationProjectViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Screen/AutomationProjectViewModel.cs
@@ -45,10 +45,19 @@ namespace Pixel.Automation.Designer.ViewModels
         /// </summary>
         public BindableCollection<ProjectVersion> EditableVersions { get; private set; } = new();
 
+        private ProjectVersion selectedVersion;
         /// <summary>
         /// Selected version to open on the UI
         /// </summary>
-        public ProjectVersion SelectedVersion { get; set; }
+        public ProjectVersion SelectedVersion
+        {
+            get => selectedVersion;
+            set
+            {
+                selectedVersion = value;
+                OnPropertyChanged();
+            }
+        }
 
         private bool isOpenInEditor;
         /// <summary>
@@ -78,7 +87,9 @@ namespace Pixel.Automation.Designer.ViewModels
         {
             this.EditableVersions.Clear();
             this.EditableVersions.AddRange(automationProject.ActiveVersions);
+            OnPropertyChanged(nameof(EditableVersions));
             this.SelectedVersion = automationProject.LatestActiveVersion;
+            OnPropertyChanged(nameof(SelectedVersion));
             this.Refresh();
         }
     }

--- a/src/Pixel.Automation.Designer.Views/Screen/HomeView.xaml
+++ b/src/Pixel.Automation.Designer.Views/Screen/HomeView.xaml
@@ -50,7 +50,7 @@
                                     <ComboBox x:Name="EditableVersions" FontSize="12" BorderThickness="0,0,0,0"
                                                   VerticalAlignment="Center" DockPanel.Dock="Left" Margin="12,2,0,0"
                                                   ToolTip="Select version to open"
-                                                  ItemsSource="{Binding EditableVersions}" SelectedItem="{Binding SelectedVersion}"/>                                    
+                                                  ItemsSource="{Binding EditableVersions}" SelectedItem="{Binding SelectedVersion, Mode=TwoWay}"/>                                    
                                     <Button x:Name="OpenProject" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5,0,0,0" 
                                                 DockPanel.Dock="Right" IsEnabled="{Binding IsOpenInEditor, Converter={StaticResource inverseBooleanConverter}}"
                                                 Height="20" Width="20" ToolTip="Open selected version of project"                                 


### PR DESCRIPTION
**Description**
On publishing the latest active version of project, the new active version should be selected by default on home page against that project after publishing last active version of the project.