### PR TITLE
Resuse input and output mapping script by default for a given prefab

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabDropHandlerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabDropHandlerViewModel.cs
@@ -2,7 +2,6 @@
 using Dawn;
 using Pixel.Automation.AppExplorer.ViewModels.Prefab;
 using Pixel.Automation.Core;
-using Pixel.Automation.Core.Attributes;
 using Pixel.Automation.Core.Components.Prefabs;
 using Pixel.Automation.Core.Components.TestCase;
 using Pixel.Automation.Core.Interfaces;
@@ -53,20 +52,11 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
                 PrefabId = prefabProjectViewModel.PrefabId,
                 ApplicationId = prefabProjectViewModel.ApplicationId
             };
-
-            //We add and remove prefab entity to drop target so that the ScriptInitializer can correctly generate input and output mapping script location
-            dropTarget.AddComponent(this.prefabEntity);
-            var initializers = prefabEntity.GetType().GetCustomAttributes(typeof(InitializerAttribute), true).OfType<InitializerAttribute>();
-            foreach (var intializer in initializers)
-            {
-                IComponentInitializer componentInitializer = Activator.CreateInstance(intializer.Initializer) as IComponentInitializer;
-                componentInitializer.IntializeComponent(prefabEntity, entityManager);
-            }
-            dropTarget.RemoveComponent(this.prefabEntity);
-
+          
             this.stagedScreens.Clear();
 
-            var prefabVersionSelector = new PrefabVersionSelectorViewModel(this.projectFileSystem, this.prefabFileSystem, entityManager.GetServiceOfType<IReferenceManager>(),
+            var referenceManager = entityManager.GetServiceOfType<IReferenceManager>();
+            var prefabVersionSelector = new PrefabVersionSelectorViewModel(this.projectFileSystem, this.prefabFileSystem, referenceManager,
                 this.prefabEntity, prefabProjectViewModel, dropTarget);
             var prefabInputMappingScript = new PrefabInputMappingScriptEditorViewModel(this.scriptEngine, this.scriptEditorFactory, this.prefabEntity, dropTarget.Model as Entity);
             var prefabOutputMappingScript = new PrefabOutputMappingScriptEditorViewModel(this.scriptEngine, this.scriptEditorFactory, this.prefabEntity, dropTarget.Model as Entity);

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabOutputMappingScriptEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabOutputMappingScriptEditorViewModel.cs
@@ -30,7 +30,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         /// <inheritdoc/>   
         protected override void AddProject(string[] projectReferences)
         {
-            this.scriptEditorFactory.AddProject(GetProjectName(), projectReferences, prefabEntity.GetPrefabDataModelType());
+            this.scriptEditorFactory.AddProject(GetProjectName(), projectReferences, dropTarget.EntityManager.Arguments.GetType());
         }
 
         /// <inheritdoc/>   

--- a/src/Pixel.Automation.Core.Components/Prefabs/PrefabEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Prefabs/PrefabEntity.cs
@@ -15,7 +15,6 @@ namespace Pixel.Automation.Core.Components.Prefabs;
 [DataContract]
 [Serializable]
 [Scriptable(nameof(InputMappingScriptFile), nameof(OutputMappingScriptFile))]
-[Initializer(typeof(ScriptFileInitializer))]
 public class PrefabEntity : Entity
 {
     private readonly ILogger logger = Log.ForContext<PrefabEntity>();
@@ -81,7 +80,7 @@ public class PrefabEntity : Entity
         {
             Debug.Assert(!this.Components.Any(), "There should be no child componets in a Prefab Entity");
             this.LoadPrefab();
-            this.Components.Add(this.prefabEntity);
+            base.AddComponent(this.prefabEntity);           
             IScriptEngine scriptEngine = this.EntityManager.GetScriptEngine();
             var inputMappingAction = await scriptEngine.CreateDelegateAsync<Action<object>>(this.InputMappingScriptFile);
             inputMappingAction.Invoke(prefabDataModel);
@@ -119,6 +118,13 @@ public class PrefabEntity : Entity
             this.Components.Clear();
             this.prefabDataModel = null;
         }   
+    }
+
+    public override async Task OnFaultAsync(IComponent faultingComponent)
+    {
+        this.Components.Clear();
+        this.prefabDataModel = null;
+        await base.OnFaultAsync(faultingComponent);
     }
 
     #region overridden methods

--- a/src/Pixel.Automation.Core/Models/PrefabReference.cs
+++ b/src/Pixel.Automation.Core/Models/PrefabReference.cs
@@ -29,6 +29,16 @@ namespace Pixel.Automation.Core.Models
         public PrefabVersion Version { get; set; }
 
         /// <summary>
+        /// Input mapping script file for the prefab
+        /// </summary>
+        public string InputMappingScriptFile { get; set; }
+       
+        /// <summary>
+        /// Output mapping script file for the prefab
+        /// </summary>
+        public string OutputMappingScriptFile { get; set; }       
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         public PrefabReference()

--- a/src/Pixel.Scripting.Script.Editor/Editor/MultiEditor/DocumentView.xaml
+++ b/src/Pixel.Scripting.Script.Editor/Editor/MultiEditor/DocumentView.xaml
@@ -45,7 +45,7 @@
                                                         HorizontalAlignment="Left" VerticalAlignment="Center" 
                                                         Foreground="{DynamicResource MahApps.Brushes.Accent}" />
                                 <Label Content="{Binding DisplayName}" ToolTip="{Binding DocumentName}"
-                                       DockPanel.Dock="Left" Padding="2"/>
+                                       DockPanel.Dock="Left" Padding="2" cal:Message.Attach="[Event MouseDoubleClick] = [Action OpenDocument($dataContext)]"/>
                                 <iconPacks:PackIconMaterial Kind="Asterisk" Width="8" Height="8"  DockPanel.Dock="Left"
                                        Margin="5,2,2,0" Visibility="{Binding Editor.IsModified, FallbackValue=Collapsed, Converter={StaticResource boolToVisConverter}}"
                                        Foreground="Red" HorizontalAlignment="Left" VerticalAlignment="Center" />


### PR DESCRIPTION
**Description**

### Enhancements
1. When adding a prefab , we generate new input and output mapping script for them. It is possible however to pick an existing script. Based on observation, input and output mapping script was repeated for the prefabs. Hence, we will default input and output mapping script to previously generated scripts when adding a prefab for the second time. It also simplifies upgrading prefab versions as we only need to update prefab version and data sources and prefab input mapping (shared) without touching the test cases if we are only adding new input variables to prefab. Any change in output variables will still require individual test cases to be edited.
 
### Bug Fixes
1. Fixed an issue where it was not possible to open file in code editor to edit. File can be opened to edit by double clicking it now.
2. Fixed an issue where prefab components were not connected to parents in the hierarchy and hence application entity could not be retrieved causing prefab execution to fail.