### PR TITLE
Initialization scripts for prefabs

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
@@ -170,7 +170,7 @@ namespace Pixel.Automation.Designer.ViewModels
         /// configured as the PreferredBrowser on WebApplication.
         /// </summary>
         /// <returns></returns>
-        public async Task EditScriptAsync()
+        public override async Task EditScriptAsync()
         {
             using (var activity = Telemetry.DefaultSource?.StartActivity(nameof(EditScriptAsync), ActivityKind.Internal))
             {

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -109,45 +109,27 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 await File.WriteAllTextAsync(dataModelFile, dataModelInitialContent);
                 logger.Information($"Created data model file : {dataModelFile}");
             }             
-        }      
-
-        /// <summary>
-        /// Execute the Initialization script for Automation process.
-        /// Empty Initialization script is created if script file doesn't exist already.
-        /// </summary>
-        private async Task ExecuteInitializationScript()
-        {
-            try
-            {
-                var fileSystem = this.entityManager.GetCurrentFileSystem();
-                var scriptFile = Path.Combine(fileSystem.ScriptsDirectory, Constants.InitializeEnvironmentScript);
-                if (!File.Exists(scriptFile))
-                {
-                    using (var sw = File.CreateText(scriptFile))
-                    {                       
-                        sw.WriteLine("string dataSourceSuffix = string.Empty;");
-                        sw.WriteLine();
-                        sw.WriteLine("//Default Initialization function");                     
-                        sw.Write("void ");
-                        sw.Write(Constants.DefaultInitFunction);
-                        sw.WriteLine("{");
-                        sw.WriteLine();
-                        sw.WriteLine("}");
-                    };
-                    logger.Information("Created initialization script file : {scriptFile}", scriptFile);
-                }
-                var scriptEngine = this.entityManager.GetScriptEngine();
-                await scriptEngine.ExecuteFileAsync(scriptFile);
-                logger.Information("Executed initialize environment script : {scriptFile}", scriptFile);
-                await scriptEngine.ExecuteScriptAsync(Constants.DefaultInitFunction);
-                logger.Information("Executed default initializer function : {DefaultInitFunction}", Constants.DefaultInitFunction);
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex, $"Failed to execute Initialization script {Constants.InitializeEnvironmentScript}");               
-            }
         }
 
+        protected override void CreateInitializationScriptFile(string scriptFile)
+        {
+            if (!File.Exists(scriptFile))
+            {
+                using (var sw = File.CreateText(scriptFile))
+                {
+                    sw.WriteLine("string dataSourceSuffix = string.Empty;");
+                    sw.WriteLine();
+                    sw.WriteLine("//Default Initialization function");
+                    sw.Write("void ");
+                    sw.Write(Constants.DefaultInitFunction);
+                    sw.WriteLine("{");
+                    sw.WriteLine();
+                    sw.WriteLine("}");
+                };
+                logger.Information("Created initialization script file : {scriptFile}", scriptFile);
+            }
+        }
+        
         private void Initialize()
         {
             logger.Information($"Loading project file for {this.GetProjectName()} now");
@@ -214,15 +196,15 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             }
         }
 
-        ///<inheritdoc/>
-        public async Task DownloadFileByNameAsync(string fileName)
-        {
-            await this.projectDataManager.DownloadProjectDataFileByNameAsync(this.activeProject, this.loadedVersion as ProjectVersion, fileName);
-        }
-
         #endregion methods
 
         #region overridden methods
+
+        ///<inheritdoc/>
+        public override async Task DownloadFileByNameAsync(string fileName)
+        {
+            await this.projectDataManager.DownloadProjectDataFileByNameAsync(this.activeProject, this.loadedVersion as ProjectVersion, fileName);
+        }
 
         ///<inheritdoc/>
         public override async Task AddOrUpdateDataFileAsync(string targetFile)

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/EditorViewModel.cs
@@ -218,6 +218,8 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 
         public abstract Task EditDataModelAsync();
 
+        public abstract Task EditScriptAsync();
+
         protected void UpdateWorkFlowRoot()
         {
             this.WorkFlowRoot.Clear();

--- a/src/Pixel.Automation.Designer.ViewModels/Shell/DesignerWindowViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Shell/DesignerWindowViewModel.cs
@@ -173,13 +173,13 @@ namespace Pixel.Automation.Designer.ViewModels
         {
             get
             {
-                return this.ActiveItem != null && this.ActiveItem is IAutomationEditor;
+                return this.ActiveItem != null && this.ActiveItem is IEditor;
             }
         }
 
         public async Task EditScriptAsync()
         {
-            var activeItem = this.ActiveItem as IAutomationEditor;
+            var activeItem = this.ActiveItem as IEditor;
             if (activeItem == null)
             {
                 return;

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IAutomationEditor.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IAutomationEditor.cs
@@ -17,13 +17,6 @@ namespace Pixel.Automation.Editor.Core.Interfaces
         /// <param name="project"></param>
         Task DoLoad(AutomationProject project, VersionInfo versionInfo = null);
 
-
-        /// <summary>
-        /// Open script editor that can be used to modify the initialization script for the automation project.
-        /// </summary>
-        /// <returns></returns>
-        Task EditScriptAsync();
-
         /// <summary>
         /// Manage prefab references for the project.
         /// </summary>

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IEditor.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IEditor.cs
@@ -23,6 +23,12 @@ namespace Pixel.Automation.Editor.Core.Interfaces
         Task EditDataModelAsync();
 
         /// <summary>
+        /// Open script editor that can be used to modify the initialization script for the automation project.
+        /// </summary>
+        /// <returns></returns>
+        Task EditScriptAsync();
+
+        /// <summary>
         /// Manage control references for the project.
         /// </summary>
         /// <returns></returns>

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IProjectManager.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IProjectManager.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace Pixel.Automation.Editor.Core.Interfaces
 {
+    /// <summary>
+    /// Contract for managing a project
+    /// </summary>
     public interface IProjectManager
     {      
         /// <summary>
@@ -19,6 +22,13 @@ namespace Pixel.Automation.Editor.Core.Interfaces
         /// </summary>
         /// <returns></returns>
         IReferenceManager GetReferenceManager();
+
+        /// <summary>
+        /// Download a file associated with project given it's name
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        Task DownloadFileByNameAsync(string fileName);
 
         /// <summary>
         /// Add a new data file or update an existing one for the loades version of project
@@ -62,14 +72,17 @@ namespace Pixel.Automation.Editor.Core.Interfaces
         Task Save();
     }
 
+    /// <summary>
+    /// Contract for managing an automation project
+    /// </summary>
     public interface IAutomationProjectManager: IProjectManager
     {
         Task<Entity> Load(AutomationProject activeProject, VersionInfo versionToLoad);
-
-        Task DownloadFileByNameAsync(string fileName);
     }
     
-
+    /// <summary>
+    /// Contract for managing a prefab project
+    /// </summary>
     public interface IPrefabProjectManager : IProjectManager
     {
         Task<Entity> Load(PrefabProject prefabProject, VersionInfo versionInfo);

--- a/src/Pixel.Persistence.Services.Client/DataManagers/PrefabDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/DataManagers/PrefabDataManager.cs
@@ -134,6 +134,29 @@ public class PrefabDataManager : IPrefabDataManager
         }
     }
 
+    /// <inheritdoc/>  
+    public async Task DownloadPrefabDataFileByNameAsync(PrefabProject prefabProject, PrefabVersion prefabVersion, string fileName)
+    {
+        Guard.Argument(prefabProject, nameof(prefabProject)).NotNull();
+        Guard.Argument(prefabVersion, nameof(prefabVersion)).NotNull();
+        Guard.Argument(fileName, nameof(fileName)).NotNull().NotEmpty();
+
+        if (IsOnlineMode)
+        {
+            var file = await this.filesClient.DownProjectDataFile(prefabProject.PrefabId, prefabVersion.ToString(), fileName);
+            var prefabsDirectory = Path.Combine(this.applicationFileSystem.GetPrefabProjectDirectory(prefabProject), prefabVersion.ToString());
+            using (MemoryStream ms = new MemoryStream(file.Bytes))
+            {
+                using (FileStream fs = new FileStream(Path.Combine(prefabsDirectory, file.FilePath), FileMode.Create))
+                {
+                    ms.Seek(0, SeekOrigin.Begin);
+                    ms.CopyTo(fs);
+                }
+            }
+            logger.Information("File : '{0}' was downloaded for version : '{1}' of prefab project : '{2}'.", file.FilePath, prefabVersion, prefabProject.PrefabName);
+        }
+    }
+
     /// <inheritdoc/> 
     public async Task DownloadDataModelFilesAsync(PrefabProject prefabProject, PrefabVersion prefabVersion)
     {

--- a/src/Pixel.Persistence.Services.Client/Interfaces/IPrefabDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/IPrefabDataManager.cs
@@ -45,6 +45,12 @@ public interface IPrefabDataManager
     Task DownloadPrefabDataAsync(PrefabProject prefabProject, PrefabVersion prefabVersion);
 
     /// <summary>
+    /// Download a file with specified nme for the version of AutomtionProject being managed
+    /// </summary>
+    /// <returns></returns>
+    Task DownloadPrefabDataFileByNameAsync(PrefabProject prefabProject, PrefabVersion prefabVersion, string fileName);
+
+    /// <summary>
     /// Download dta model files (*.cs) for a given version of prefab
     /// </summary>
     /// <param name="prefabProject"></param>


### PR DESCRIPTION
**Description**
Prefabs can have multiple variables some of which can be internal and should not be exposed in data model used for input and output mapping. Currently, we need to declare even temporary variables as part of data model. To avoid this , allow initialization script file to be used in a prefab.
Additionally, fixed an issue where saving an reopening a prefab project will keep adding duplicate initialization entity block.