### PR TITLE
Allow published versions of automation project and prefabs to be opened for edit

### DIFF
--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml
@@ -88,12 +88,21 @@
                         <ContextMenu.Template>
                             <ControlTemplate>
                                 <StackPanel>
-                                    <MenuItem x:Name="Edit" Header="Edit" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action EditPrefab($dataContext)]"></MenuItem>
+                                    <MenuItem x:Name="Edit" Header="Edit" IsEnabled="{Binding IsOpenInEditor, Converter={StaticResource InverseBoolConverter}}"
+                                              cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}"
+                                              cal:Message.Attach="[Event Click] = [Action EditPrefab($dataContext)]"></MenuItem>
                                     <MenuItem x:Name="Manage" Header="Manage" IsEnabled="{Binding IsOpenInEditor, Converter={StaticResource InverseBoolConverter}}"
-                                              cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action ManagePrefab($dataContext)]"></MenuItem>
-                                    <MenuItem x:Name="ShowUsage" Header="Show Usage" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action ShowUsage($dataContext)]"></MenuItem>
-                                    <MenuItem x:Name="MoveToScreen" Header="Move To Screen" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action MoveToScreen($dataContext)]"></MenuItem>
-                                    <MenuItem x:Name="Delete" Header="Delete" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" cal:Message.Attach="[Event Click] = [Action DeletePrefabAsync($dataContext)]" ></MenuItem>
+                                              cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}"
+                                              cal:Message.Attach="[Event Click] = [Action ManagePrefab($dataContext)]"></MenuItem>
+                                    <MenuItem x:Name="ShowUsage" Header="Show Usage" 
+                                              cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}" 
+                                              cal:Message.Attach="[Event Click] = [Action ShowUsage($dataContext)]"></MenuItem>
+                                    <MenuItem x:Name="MoveToScreen" Header="Move To Screen"
+                                              cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}"
+                                              cal:Message.Attach="[Event Click] = [Action MoveToScreen($dataContext)]"></MenuItem>
+                                    <MenuItem x:Name="Delete" Header="Delete" 
+                                              cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}, AncestorLevel=2}}"
+                                              cal:Message.Attach="[Event Click] = [Action DeletePrefabAsync($dataContext)]" ></MenuItem>
                                 </StackPanel>
                             </ControlTemplate>
                         </ContextMenu.Template>

--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionManagerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionManagerView.xaml
@@ -6,8 +6,8 @@
         xmlns:local="clr-namespace:Pixel.Automation.AppExplorer.Views.Prefab"
         xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
         xmlns:converters="clr-namespace:Pixel.Automation.Editor.Core.Converters;assembly=Pixel.Automation.Editor.Core"
-        xmlns:cal="http://www.caliburnproject.org" cal:Bind.AtDesignTime="True"
-        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+        xmlns:cal="http://www.caliburnproject.org" cal:Bind.AtDesignTime="True"    
+        xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
         mc:Ignorable="d" ResizeMode="NoResize" SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterScreen"  GlowBrush="{DynamicResource AccentColorBrush}"
         MinHeight="400" MaxHeight="600" ShowCloseButton="False"
@@ -32,7 +32,17 @@
                   Margin="10" Padding="5" ScrollViewer.HorizontalScrollBarVisibility="Disabled"    
                   AutoGenerateColumns="False"                
                   RowHeaderWidth="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                <DataGrid.Columns>                    
+                <DataGrid.Columns>
+                    <DataGridTemplateColumn Header="">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button x:Name="Edit" Style="{StaticResource EditControlButtonStyle}"  Content="{iconPacks:FontAwesome Kind=EditRegular}"
+                                  cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
+                                  cal:Message.Attach="[Event Click] = [Action OpenForEditAsync($dataContext)]" Margin="5,2,5,2" 
+                                  HorizontalAlignment="Center" ToolTip="Open for edit" />
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                     <DataGridTemplateColumn Header="Version">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>

--- a/src/Pixel.Automation.Designer.ViewModels/Factory/VersionManagerFactory.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Factory/VersionManagerFactory.cs
@@ -1,4 +1,5 @@
-﻿using Dawn;
+﻿using Caliburn.Micro;
+using Dawn;
 using Notifications.Wpf.Core;
 using Pixel.Automation.AppExplorer.ViewModels.Prefab;
 using Pixel.Automation.Core;
@@ -22,11 +23,12 @@ namespace Pixel.Automation.Designer.ViewModels.Factory
         private readonly IPrefabDataManager prefabDataManager;
         private readonly IProjectDataManager projectDataManager;
         private readonly INotificationManager notificationManager;
+        private readonly IEventAggregator eventAggregator;
         private readonly ApplicationSettings applicationSettings;
 
         public VersionManagerFactory(ISerializer serializer, IWorkspaceManagerFactory workspaceManagerFactory, 
             IReferenceManagerFactory referenceManagerFactory, IApplicationDataManager applicationDataManager,
-            IPrefabDataManager prefabDataManager, IProjectDataManager projectDataManager,
+            IPrefabDataManager prefabDataManager, IProjectDataManager projectDataManager, IEventAggregator eventAggregator,
             INotificationManager notificationManager, ApplicationSettings applicationSettings)
         {
             this.serializer = Guard.Argument(serializer, nameof(serializer)).NotNull().Value;
@@ -35,6 +37,7 @@ namespace Pixel.Automation.Designer.ViewModels.Factory
             this.applicationDataManager = Guard.Argument(applicationDataManager, nameof(applicationDataManager)).NotNull().Value;
             this.projectDataManager = Guard.Argument(projectDataManager, nameof(projectDataManager)).NotNull().Value;
             this.prefabDataManager = Guard.Argument(prefabDataManager, nameof(prefabDataManager)).NotNull().Value;
+            this.eventAggregator = Guard.Argument(eventAggregator, nameof(eventAggregator)).NotNull().Value;
             this.notificationManager = Guard.Argument(notificationManager, nameof(notificationManager)).NotNull().Value;
             this.applicationSettings = Guard.Argument(applicationSettings, nameof(applicationSettings)).NotNull();
         }
@@ -42,13 +45,13 @@ namespace Pixel.Automation.Designer.ViewModels.Factory
         public IVersionManager CreatePrefabVersionManager(PrefabProject prefabProject)
         {          
             return new PrefabVersionManagerViewModel(prefabProject, this.workspaceManagerFactory, this.referenceManagerFactory, this.serializer, this.prefabDataManager,
-                this.notificationManager, this.applicationSettings);
+               this.eventAggregator, this.notificationManager, this.applicationSettings);
         }
 
         public IVersionManager CreateProjectVersionManager(AutomationProject automationProject)
         {           
             return new ProjectVersionManagerViewModel(automationProject, this.workspaceManagerFactory, this.referenceManagerFactory, this.serializer, this.projectDataManager, 
-                this.notificationManager, this.applicationSettings);
+               this.eventAggregator, this.notificationManager, this.applicationSettings);
         }
 
         public IVersionManager CreatePrefabReferenceManager(IReferenceManager referenceManager)

--- a/src/Pixel.Automation.Designer.Views/VersionManager/ProjectVersionManagerView.xaml
+++ b/src/Pixel.Automation.Designer.Views/VersionManager/ProjectVersionManagerView.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"            
              xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:converters="clr-namespace:Pixel.Automation.Editor.Core.Converters;assembly=Pixel.Automation.Editor.Core"
              xmlns:cal="http://www.caliburnproject.org" cal:Bind.AtDesignTime="True"          
              mc:Ignorable="d"  ResizeMode="NoResize" SizeToContent="WidthAndHeight"
@@ -32,6 +33,16 @@
                   AutoGenerateColumns="False"                
                   RowHeaderWidth="0" HorizontalAlignment="Left" VerticalAlignment="Top">
                 <DataGrid.Columns>
+                    <DataGridTemplateColumn Header="">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button x:Name="Edit" Style="{StaticResource EditControlButtonStyle}"  Content="{iconPacks:FontAwesome Kind=EditRegular}"
+                                         cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
+                                         cal:Message.Attach="[Event Click] = [Action OpenForEditAsync($dataContext)]" Margin="5,2,5,2" 
+                                         HorizontalAlignment="Center" ToolTip="Open for edit" />    
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                     <DataGridTemplateColumn Header="Version">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>

--- a/src/Pixel.Automation.Editor.Notifications/Notfications/OpenPrefabVersionForEditNotification.cs
+++ b/src/Pixel.Automation.Editor.Notifications/Notfications/OpenPrefabVersionForEditNotification.cs
@@ -1,0 +1,30 @@
+﻿using Pixel.Automation.Core.Models;
+
+namespace Pixel.Automation.Editor.Notifications.Notfications;
+
+/// <summary>
+/// Mediator notification to open a given version of prefab for edit
+/// </summary>
+public class OpenPrefabVersionForEditNotification
+{
+    /// <summary>
+    /// PrefabProject to open for edit
+    /// </summary>
+    public PrefabProject PrefabProject { get; init; }
+
+    /// <summary>
+    /// ProjectVersion to open for edit
+    /// </summary>
+    public PrefabVersion VersionToOpen { get; init; }
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="prefabProject">PrefabProject to open for edit</param>
+    /// <param name="versionToOpen">PrefabVersion to open for edit</param>
+    public OpenPrefabVersionForEditNotification(PrefabProject prefabProject, PrefabVersion versionToOpen)
+    {
+        PrefabProject = prefabProject;
+        VersionToOpen = versionToOpen;
+    }
+}

--- a/src/Pixel.Automation.Editor.Notifications/Notfications/OpenProjectVersionForEditNotification.cs
+++ b/src/Pixel.Automation.Editor.Notifications/Notfications/OpenProjectVersionForEditNotification.cs
@@ -1,0 +1,30 @@
+﻿using Pixel.Automation.Core.Models;
+
+namespace Pixel.Automation.Editor.Notifications.Notfications;
+
+/// <summary>
+/// Mediator notification to open a given version of project for edit
+/// </summary>
+public class OpenProjectVersionForEditNotification
+{
+    /// <summary>
+    /// AutomationProject to open for edit
+    /// </summary>
+    public AutomationProject AutomationProject { get; init; }
+
+    /// <summary>
+    /// ProjectVersion to open for edit
+    /// </summary>
+    public ProjectVersion VersionToOpen { get; init; }
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="automationProject">AutomationProject to open for edit</param>
+    /// <param name="versionToOpen">ProjectVersion to open for edit</param>
+    public OpenProjectVersionForEditNotification(AutomationProject automationProject, ProjectVersion versionToOpen)
+    {
+        AutomationProject = automationProject;
+        VersionToOpen = versionToOpen;
+    }
+}


### PR DESCRIPTION
**Description**
Published versions acts as a bookmark where current state is saved and new version with the same state is created. Any major changes should happen on the new version. However, there can be scenarios where minor changes might have to be done to a version that are already published. Currently, that would require minor version to be created. However, that will duplicate all the data and if the change is very minor personal preference could be to avoid it and edit the published project instead. With this change, we will allow published versions to be edited.