### PR TITLE
Don't execute default init function for scripts when loading prefab

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -90,7 +90,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 ConfigureScriptEditor(this.referenceManager, dataModel);
                 this.entityManager.Arguments = dataModel;
 
-                await ExecuteInitializationScript();
+                await ExecuteInitializationScript(executeDefaultInitFunc : true);
                 ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);
                 Initialize();
                 SetupInitializationScriptProject(dataModel);
@@ -176,7 +176,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 ConfigureScriptEditor(this.referenceManager, dataModel);
                 this.entityManager.Arguments = dataModel;
                 SetupInitializationScriptProject(dataModel);
-                await ExecuteInitializationScript();
+                await ExecuteInitializationScript(executeDefaultInitFunc: true);
                 ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);
                 this.RootEntity.ResetHierarchy();
                 serializer.Serialize(this.projectFileSystem.ProcessFile, this.RootEntity, typeProvider.GetKnownTypes());

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -85,7 +85,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 ConfigureScriptEditor(this.referenceManager, dataModel);
                 this.entityManager.Arguments = dataModel;
 
-                await ExecuteInitializationScript();
+                await ExecuteInitializationScript(executeDefaultInitFunc: false);
                 ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);
                 Initialize();
                 SetupInitializationScriptProject(dataModel);

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
@@ -194,7 +194,9 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
         /// Execute the Initialization script for Automation process.
         /// Empty Initialization script is created if script file doesn't exist already.
         /// </summary>
-        protected async Task ExecuteInitializationScript()
+        /// <param name="executeDefaultInitFunc">Default init function will be executed if true</param>
+        /// <returns></returns>
+        protected async Task ExecuteInitializationScript(bool executeDefaultInitFunc)
         {
             try
             {
@@ -204,8 +206,11 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 var scriptEngine = this.entityManager.GetScriptEngine();
                 await scriptEngine.ExecuteFileAsync(scriptFile);
                 logger.Information("Executed initialize environment script : {scriptFile}", scriptFile);
-                await scriptEngine.ExecuteScriptAsync(Constants.DefaultInitFunction);
-                logger.Information("Executed default initializer function : {DefaultInitFunction}", Constants.DefaultInitFunction);
+                if(executeDefaultInitFunc)
+                {
+                    await scriptEngine.ExecuteScriptAsync(Constants.DefaultInitFunction);
+                    logger.Information("Executed default initializer function : {DefaultInitFunction}", Constants.DefaultInitFunction);
+                }            
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
**Description**
Prefabs don't have init functions and it should not be executed when trying to load a prefab