### PR TITLE
Generate the data model assembly again on editing a published project or prefab

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -263,6 +263,12 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                     parentEntity.AddComponent(testFixtureEntity);
                 }
 
+                //when saving a published version, we need to recompile the data model assembly and save in references directory
+                if(this.loadedVersion.IsPublished)
+                {
+                    CompileDataModelAssemblyForVersion(this.loadedVersion.Version);
+                }
+
                 await this.projectDataManager.SaveProjectDataAsync(this.activeProject, this.loadedVersion as ProjectVersion);
             }            
         }

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -287,7 +287,14 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                     prefabProcessor.RemoveComponent(this.prefabEntity.Parent);
                     this.prefabFileSystem.CreateOrReplaceTemplate(this.RootEntity);
                     prefabProcessor.AddComponent(this.prefabEntity.Parent);
-                }                                      
+                }
+
+                //when saving a published version, we need to recompile the data model assembly and save in references directory
+                if (this.loadedVersion.IsPublished)
+                {
+                    CompileDataModelAssemblyForVersion(this.loadedVersion.Version);
+                }
+
                 await this.prefabDataManager.SavePrefabDataAsync(this.prefabProject, this.loadedVersion);
             }
             catch (Exception ex)

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
@@ -66,7 +66,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
         /// Get the namespace of the project
         /// </summary>
         /// <returns></returns>
-        protected abstract string GetProjectNamespace();
+        protected abstract string GetProjectNamespace();    
 
         /// <summary>
         /// Add initialization script file if it doesn't exist
@@ -284,6 +284,20 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 throw new Exception($"DataModel file : {dataModelName}.cs could not be located in {this.fileSystem.DataModelDirectory}");
             }
         }        
+
+        /// <summary>
+        /// Compile data model assembly for specified version of project. This is required when we have opened a published version to edit.
+        /// When we save the published version, data model assembly in references directory needs to be replaced.
+        /// </summary>
+        protected void CompileDataModelAssemblyForVersion(Version version)
+        {            
+            string assemblyName = $"{GetProjectNamespace()}.v{version.Major}.{version.Minor}";
+            using (var compilationResult = this.codeEditorFactory.CompileProject(GetProjectName(), assemblyName))
+            {
+                compilationResult.SaveAssemblyToDisk(this.fileSystem.ReferencesDirectory);
+            }
+            logger.Information("Data model assembly '{0}' was generated", assemblyName);
+        }
        
         /// <summary>
         /// Check project temp folder for any existing assemblies and extract the iteration number that was used for naming that assembly.


### PR DESCRIPTION
**Description**
We earlier allowed published projects and prefabs to be edited. However, we will need to generate the data model assembly for the prefab or project again after it is edited as it is possible that data model could be modified. Additionally, if data model assembly of a published prefab is already loaded, it should not be possible to open it for edit.