### PR TITLE
Allow published prefab to be edited only if data model assembly was not loaded

### DIFF
--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionManagerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabVersionManagerView.xaml
@@ -39,7 +39,7 @@
                                 <Button x:Name="Edit" Style="{StaticResource EditControlButtonStyle}"  Content="{iconPacks:FontAwesome Kind=EditRegular}"
                                   cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"
                                   cal:Message.Attach="[Event Click] = [Action OpenForEditAsync($dataContext)]" Margin="5,2,5,2" 
-                                  HorizontalAlignment="Center" ToolTip="Open for edit" />
+                                  HorizontalAlignment="Center" ToolTip="Open for edit" IsEnabled="{Binding CanOpenForEdit}" />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>


### PR DESCRIPTION
**Description**
If a published prefab needs to be edited, we need to make sure that it's data model assembly has not been loaded already. It would prevent data model assembly to be saved to disk again as the dll will be in use by application.