### PR TITLE
Filter test cases for test data source and option to load all test cases from test explorer

### DIFF
--- a/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataRepositoryViewModel.cs
+++ b/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataRepositoryViewModel.cs
@@ -8,6 +8,7 @@ using Pixel.Automation.Editor.Core;
 using Pixel.Automation.Editor.Core.Helpers;
 using Pixel.Automation.Editor.Core.Interfaces;
 using Pixel.Automation.Editor.Notifications;
+using Pixel.Automation.Editor.Notifications.Notfications;
 using Pixel.Persistence.Services.Client.Interfaces;
 using Pixel.Scripting.Editor.Core.Contracts;
 using Serilog;
@@ -402,6 +403,19 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
                 }
             }         
         }
+
+        /// <summary>
+        /// Broadcast a <see cref="TestFilterNotification"/> which is processed by Test data source explorer to filter and show only matching test cases that use
+        /// this data source.
+        /// </summary>
+        /// <param name="testDataSource">TestData source whose usage needs to be shown</param>
+        /// <returns></returns>
+        public async Task ShowUsage(TestDataSource testDataSource)
+        {
+            Guard.Argument(testDataSource, nameof(testDataSource)).NotNull();
+            await this.eventAggregator.PublishOnUIThreadAsync(new TestFilterNotification("testDataSource", testDataSource.DataSourceId));
+        }
+
 
         #endregion Edit Data Source
 

--- a/src/Pixel.Automation.TestData.Repository.Views/TestDataRepositoryView.xaml
+++ b/src/Pixel.Automation.TestData.Repository.Views/TestDataRepositoryView.xaml
@@ -137,6 +137,7 @@
                                                 <MenuItem x:Name="Edit" Header="Edit" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" cal:Message.Attach="[Event Click] = [Action EditDataSource($dataContext)]"></MenuItem>
                                                 <MenuItem x:Name="Rename" Header="Rename" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" cal:Message.Attach="[Event Click] = [Action ToggleRename($dataContext)]"></MenuItem>
                                                 <MenuItem x:Name="Delete" Header="Delete" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" cal:Message.Attach="[Event Click] = [Action DeleteDataSource($dataContext)]"></MenuItem>
+                                                <MenuItem x:Name="ShowUsage" Header="Show Usage" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" cal:Message.Attach="[Event Click] = [Action ShowUsage($dataContext)]"></MenuItem>
                                             </StackPanel>
                                         </ControlTemplate>
                                     </ContextMenu.Template>

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestCaseViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestCaseViewModel.cs
@@ -396,6 +396,9 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                         case "control":
                             IsVisible = this.TestCase.ControlsUsed.Any(p => p.ControlId.Equals(query[1]));
                             break;
+                        case "testdatasource":
+                            IsVisible = this.TestDataId.Equals(query[1]);
+                            break;
                         default:
                             IsVisible = this.Tags.Contains(query[0]) && this.Tags[query[0]].Equals(query[1]);
                             break;

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
@@ -190,7 +190,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
         /// <returns></returns>
         async Task LoadTestCasesForFixture(TestFixtureViewModel testFixtureViewModel)
         {
-            using (var activity = Telemetry.DefaultSource?.StartActivity(nameof(LoadFixturesAsync), ActivityKind.Internal))
+            using (var activity = Telemetry.DefaultSource?.StartActivity(nameof(LoadTestCasesForFixture), ActivityKind.Internal))
             {
                 try
                 {
@@ -215,7 +215,37 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                     await notificationManager.ShowErrorNotificationAsync(ex);
                 }
             }          
-        }        
+        }
+
+        private bool canLoadAllTestCases = true;
+        public bool CanLoadAllTestCases
+        {
+            get => this.canLoadAllTestCases;
+            set
+            {
+                this.canLoadAllTestCases = value;
+                NotifyOfPropertyChange();
+            }
+        }
+
+        /// <summary>
+        /// Load test cases for all the fixtures
+        /// </summary>
+        /// <returns></returns>
+        public async Task LoadAllTestCases()
+        {
+            using (var activity = Telemetry.DefaultSource?.StartActivity(nameof(LoadAllTestCases), ActivityKind.Internal))
+            {
+                foreach (var fixtureViewModel in this.TestFixtures)
+                {
+                    if (!fixtureViewModel.Tests.Any())
+                    {
+                        await LoadTestCasesForFixture(fixtureViewModel);
+                    }
+                }
+                this.CanLoadAllTestCases = false;
+            }           
+        }
 
         /// <summary>
         /// When a fixture is expanded on view, load all the test cases belonging to it

--- a/src/Pixel.Automation.TestExplorer.Views/MockTestExplorerView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/MockTestExplorerView.xaml
@@ -60,7 +60,12 @@
                                             IsEnabled="false"                      
                                             Style="{StaticResource EditControlButtonStyle}"
                                             Content="{iconPacks:MaterialLight ContentSaveAll}"/>
-                </StackPanel>
+
+                    <Button x:Name="LoadAllTestCases" Margin="0,0,2,0" HorizontalAlignment="Right"  VerticalAlignment="Center"
+                                            Height="20" Width="20" ToolTip="Load all the test cases"    
+                                            IsEnabled="false" Style="{StaticResource EditControlButtonStyle}"
+                                            Content="{iconPacks:Material CircleExpand}"/>
+            </StackPanel>
             </StackPanel>
 
             <TextBox x:Name="Filter" Grid.Row="1" IsEnabled="False"

--- a/src/Pixel.Automation.TestExplorer.Views/TestExplorerView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/TestExplorerView.xaml
@@ -287,6 +287,12 @@
                                             cal:Message.Attach="[Event Click] = [Action SaveAllOpenTests()]"                       
                                             Style="{StaticResource EditControlButtonStyle}"
                                             Content="{iconPacks:MaterialLight ContentSaveAll}"/>
+                <Button x:Name="LoadAllTestCases" Margin="0,0,2,0" HorizontalAlignment="Right"  VerticalAlignment="Center"
+                               Height="20" Width="20" ToolTip="Load all the test cases"    
+                               IsEnabled="{Binding CanLoadAllTestCases, FallbackValue=false}"                                          
+                               cal:Message.Attach="[Event Click] = [Action LoadAllTestCases()]"                       
+                               Style="{StaticResource EditControlButtonStyle}"
+                               Content="{iconPacks:Material CircleExpand}"/>
             </StackPanel>
         </StackPanel>
 


### PR DESCRIPTION
**Description**
1. It is now possible to filter the tests in test explorer that uses a specific test data source by using 'show usage' option on the test data source.
2. Controls, prefabs and test data source have 'show usage' option to filter test cases in test explorer view that use them. Given all the test cases are not loaded, tests that are not loaded will be excluded from filter. Added a button to load all test cases if needed on test explorer so that filtering can be applied on all test cases if needed.
