### PR TITLE
Fixtues now have a collection of test case identifiers that belong to it

### DIFF
--- a/src/Pixel.Automation.Core/TestData/TestFixture.cs
+++ b/src/Pixel.Automation.Core/TestData/TestFixture.cs
@@ -74,6 +74,12 @@ namespace Pixel.Automation.Core.TestData
         public TagCollection Tags { get; private set; } = new TagCollection();
 
         /// <summary>
+        /// Collection of identifer of all the test cases that belong to the fixture
+        /// </summary>
+        [DataMember(IsRequired = true, Order = 100)]
+        public List<string> TestCases { get; private set; } = new();
+
+        /// <summary>
         /// Collection of Identifiers of controls used by the test fixture
         /// </summary>
         [DataMember(IsRequired = true, Order = 120)]
@@ -113,6 +119,7 @@ namespace Pixel.Automation.Core.TestData
                 IsMuted = this.IsMuted,             
                 Description = this.Description,
                 Category = this.Category,
+                PostDelay = this.PostDelay,
                 DelayFactor = this.DelayFactor,
                 Tags = this.Tags               
             };

--- a/src/Pixel.Automation.Test.Runner/ProjectManager.cs
+++ b/src/Pixel.Automation.Test.Runner/ProjectManager.cs
@@ -235,12 +235,20 @@ namespace Pixel.Automation.Test.Runner
         {
             foreach (var testFixtureDirectory in Directory.GetDirectories(this.projectFileSystem.TestCaseRepository))
             {
-                var testFixture = this.projectFileSystem.LoadFiles<TestFixture>(testFixtureDirectory).Single();            
+                var testFixture = this.projectFileSystem.LoadFiles<TestFixture>(testFixtureDirectory).Single();   
+                if(testFixture.IsDeleted)
+                {
+                    continue;
+                }
                 this.availableFixtures.Add(testFixture);
                 await this.projectAssetsDataManager.DownloadFixtureDataAsync(testFixture);
                 foreach (var testCaseDirectory in Directory.GetDirectories(testFixtureDirectory))
                 {
                     var testCase = this.projectFileSystem.LoadFiles<TestCase>(testCaseDirectory).Single();
+                    if(testCase.IsDeleted || !testFixture.TestCases.Contains(testCase.TestCaseId))
+                    {
+                        continue;
+                    }
                     testFixture.Tests.Add(testCase);
                     await this.projectAssetsDataManager.DownloadTestDataAsync(testCase);
                 }

--- a/src/Pixel.Persistence.Core/Models/TestFixture.cs
+++ b/src/Pixel.Persistence.Core/Models/TestFixture.cs
@@ -68,15 +68,21 @@ public class TestFixture : Document
     public TagCollection Tags { get; set; } = new TagCollection();
 
     /// <summary>
-    /// Collection of Identifiers of controls used by the test case
+    /// Collection of identifer of all the test cases that belong to the fixture
     /// </summary>
     [DataMember(IsRequired = true, Order = 130)]
+    public List<string> TestCases { get; set; } = new();
+
+    /// <summary>
+    /// Collection of Identifiers of controls used by the test case
+    /// </summary>
+    [DataMember(IsRequired = true, Order = 140)]
     public List<ControlUsage> ControlsUsed { get; set; } = new();
 
     /// <summary>
     /// Collection of Identifiers of Prefabs used by the test case
     /// </summary>
-    [DataMember(IsRequired = true, Order = 140)]
+    [DataMember(IsRequired = true, Order = 150)]
     public List<PrefabUsage> PrefabsUsed { get; set; } = new();
 
     /// <summary>

--- a/src/Unit.Tests/Pixel.Automation.TestExplorer.ViewModels.Tests/TestFixtureViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.TestExplorer.ViewModels.Tests/TestFixtureViewModelFixture.cs
@@ -1,5 +1,7 @@
-﻿using NUnit.Framework;
+﻿using NSubstitute;
+using NUnit.Framework;
 using Pixel.Automation.Core;
+using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.TestData;
 
 namespace Pixel.Automation.TestExplorer.ViewModels.Tests
@@ -121,11 +123,12 @@ namespace Pixel.Automation.TestExplorer.ViewModels.Tests
             var testCaseViewModel = new TestCaseViewModel(testCase);
             TestFixture testFixture = new TestFixture()
             {
-                DisplayName = "TestFixture#1"
+                DisplayName = "TestFixture#1"               
             };
+            testFixture.TestCases.Add(testCase.TestCaseId);
             TestFixtureViewModel testfixtureViewModel = new TestFixtureViewModel(testFixture);
             testfixtureViewModel.Tags.Add("module", "test explorer");
-            testfixtureViewModel.Tests.Add(testCaseViewModel);
+            testfixtureViewModel.AddTestCase(testCaseViewModel, Substitute.For<IProjectFileSystem>());
             testfixtureViewModel.UpdateVisibility(filterText);
             testCaseViewModel.UpdateVisibility(filterText);
 


### PR DESCRIPTION
**Description**
There is no way to establish the test cases that belong to a fixture locally without querying database. Fixtures now have a collection that holds identifiers of test cases that belong to it.