### PR TITLE
Get latest version of test cases and fixture before opening or editing them

### DIFF
--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestCaseViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestCaseViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Pixel.Automation.Core;
+﻿using Dawn;
+using Pixel.Automation.Core;
 using Pixel.Automation.Core.Enums;
 using Pixel.Automation.Core.TestData;
 using System;
@@ -15,7 +16,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
         /// <summary>
         /// Underlying Model for the View
         /// </summary>
-        public TestCase TestCase { get; }    
+        public TestCase TestCase { get; private set; }    
 
         /// <summary>
         /// constructor
@@ -266,6 +267,17 @@ namespace Pixel.Automation.TestExplorer.ViewModels
         public void SetTestDataSource(string testDataSourceId)
         {
             this.TestDataId = testDataSourceId;           
+        }
+
+        /// <summary>
+        /// Replace the underlying TestCase model with a new instance.
+        /// This is required when a new copy of TestCase might be available but we want to reuse the view model.
+        /// </summary>
+        /// <param name="testCase"></param>
+        public void WithTestCase(TestCase testCase)
+        {
+            Guard.Argument(testCase, nameof(TestCase)).NotNull();
+            this.TestCase = testCase;
         }
 
         /// <summary>

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestFixtureViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestFixtureViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Pixel.Automation.Core;
+﻿using Dawn;
+using Pixel.Automation.Core;
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.TestData;
 using System.Collections.ObjectModel;
@@ -15,7 +16,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
         /// <summary>
         /// Underlying Model for the view
         /// </summary>
-        public TestFixture TestFixture { get; }
+        public TestFixture TestFixture { get; private set; }
 
         private readonly ObservableCollection<TestCaseViewModel> tests = new ObservableCollection<TestCaseViewModel>();
         /// <summary>
@@ -145,6 +146,13 @@ namespace Pixel.Automation.TestExplorer.ViewModels
             set => TestFixture.ScriptFile = value;
         }
 
+        /// <summary>
+        /// Number of test cases that belongs to the fixture
+        /// </summary>
+        public int NumberOfTestCases
+        {
+            get => this.TestFixture.TestCases.Count;
+        }
 
         bool isOpenForEdit;
         /// <summary>
@@ -210,6 +218,17 @@ namespace Pixel.Automation.TestExplorer.ViewModels
         public bool IsDirty { get; set; } = false;
 
         /// <summary>
+        /// Replace the underlying TestFixture model with a new instance.
+        /// This is required when a new copy of TestFixture might be available but we want to reuse the view model.
+        /// </summary>
+        /// <param name="testFixture"></param>
+        public void WithTestFixture(TestFixture testFixture)
+        {
+            Guard.Argument(testFixture, nameof(testFixture)).NotNull();
+            this.TestFixture = testFixture;
+        }
+
+        /// <summary>
         /// Check if given test case identifier belongs to the fixture
         /// </summary>
         /// <param name="testCaseId"></param>
@@ -217,6 +236,15 @@ namespace Pixel.Automation.TestExplorer.ViewModels
         public bool HasTestCase(string testCaseId)
         {
             return this.TestFixture.TestCases.Contains(testCaseId);
+        }
+
+        /// <summary>
+        /// Clear the Test Cases view model collection
+        /// </summary>
+        /// <returns></returns>
+        public void ClearTestCases()
+        {
+            this.tests.Clear();
         }
 
         /// <summary>

--- a/src/Pixel.Persistence.Respository/Interfaces/ITestCaseRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/ITestCaseRepository.cs
@@ -18,6 +18,17 @@ public interface ITestCaseRepository
     Task<IEnumerable<TestCase>> GetTestCasesAsync(string projectId, string projectVersion, DateTime laterThan, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Get all the test cases for a given fixture belonging to specified version of project which were modified after specified datetime
+    /// </summary>
+    /// <param name="projectId"></param>
+    /// <param name="projectVersion"></param>
+    /// <param name="fixtureId"></param>
+    /// <param name="laterThan"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<IEnumerable<TestCase>> GetTestCasesAsync(string projectId, string projectVersion, string fixtureId, DateTime laterThan, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Get test cases by Id for a given version of project
     /// </summary>    
     /// <param name="projectId"></param>

--- a/src/Pixel.Persistence.Respository/TestCaseRepository.cs
+++ b/src/Pixel.Persistence.Respository/TestCaseRepository.cs
@@ -59,6 +59,16 @@ public class TestCaseRepository : ITestCaseRepository
     public async Task<IEnumerable<TestCase>> GetTestCasesAsync(string projectId, string projectVersion, DateTime laterThan, CancellationToken cancellationToken)
     {
         var filter = Builders<TestCase>.Filter.Eq(x => x.ProjectId, projectId) & Builders<TestCase>.Filter.Eq(x => x.ProjectVersion, projectVersion) &
+            Builders<TestCase>.Filter.Eq(x => x.IsDeleted, false) & Builders<TestCase>.Filter.Gt(x => x.LastUpdated, laterThan);
+        var tests = await testsCollection.FindAsync(filter, TestCasFindOptions, cancellationToken);
+        return await tests.ToListAsync();
+    }
+
+    /// <inheritdoc/>  
+    public async Task<IEnumerable<TestCase>> GetTestCasesAsync(string projectId, string projectVersion, string fixtureId, DateTime laterThan, CancellationToken cancellationToken)
+    {
+        var filter = Builders<TestCase>.Filter.Eq(x => x.ProjectId, projectId) & Builders<TestCase>.Filter.Eq(x => x.ProjectVersion, projectVersion) &
+            Builders<TestCase>.Filter.Eq(x => x.FixtureId, fixtureId) & Builders<TestCase>.Filter.Eq(x => x.IsDeleted, false) &
             Builders<TestCase>.Filter.Gt(x => x.LastUpdated, laterThan);
         var tests = await testsCollection.FindAsync(filter, TestCasFindOptions, cancellationToken);
         return await tests.ToListAsync();

--- a/src/Pixel.Persistence.Services.Api/Controllers/TestsController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/TestsController.cs
@@ -85,6 +85,24 @@ namespace Pixel.Persistence.Services.Api.Controllers
             }
         }
 
+        [HttpGet("{projectId}/{projectVersion}/{fixtureId}")]
+        public async Task<ActionResult<List<TestCase>>> GetAllForFixtureAsync(string projectId, string projectVersion, string fixtureId, [FromHeader] DateTime laterThan)
+        {
+            try
+            {
+                Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
+                Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
+                Guard.Argument(projectVersion, nameof(fixtureId)).NotNull().NotEmpty();
+                var result = await testsRespository.GetTestCasesAsync(projectId, projectVersion, fixtureId, laterThan, CancellationToken.None) ?? Enumerable.Empty<TestCase>();
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
         [HttpPost("{projectId}/{projectVersion}")]
         public async Task<ActionResult<TestCase>> AddTestCaseAsync(string projectId, string projectVersion, [FromBody] TestCase testCase)
         {

--- a/src/Pixel.Persistence.Services.Client/Interfaces/IProjectDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/IProjectDataManager.cs
@@ -106,7 +106,13 @@ public interface IProjectAssetsDataManager : ITestCaseManager, ITestFixtureManag
 }
 
 public interface ITestCaseManager
-{    
+{
+    /// <summary>
+    /// Get TestCase matching specified testCaseId
+    /// </summary> 
+    /// <param name="testCaseId">Identifier of test case</param>
+    /// <returns></returns>
+    Task<TestCase> GetTestCaseAsync(string testCaseId);       
 
     /// <summary>
     /// Add a new TestCase
@@ -149,10 +155,23 @@ public interface ITestCaseManager
     /// <returns></returns>
     Task DownloadAllTestsAsync();
 
+    /// <summary>
+    /// Download all the test cases for fixture with specified identifier
+    /// </summary>
+    /// <param name="fixtureId">Identifier of the fixture</param>
+    /// <returns></returns>
+    Task DownloadTestCasesForFixtureAsync(string fixtureId);
+
 }
 
 public interface ITestFixtureManager
-{    
+{
+    /// <summary>
+    /// Get TestFixture matching specified fixture id
+    /// </summary> 
+    /// <param name="fixtureId">Identifier of test fixture</param>
+    /// <returns></returns>
+    Task<TestFixture> GetTestFixtureAsync(string fixtureId);
 
     /// <summary>
     /// Add a new TestFixture

--- a/src/Pixel.Persistence.Services.Client/Interfaces/ITestsRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/ITestsRepositoryClient.cs
@@ -35,6 +35,16 @@ public interface ITestsRepositoryClient
     Task<IEnumerable<TestCase>> GetAllForProjectAsync(string projectId, string projectVersion, DateTime laterThan);
 
     /// <summary>
+    /// Get all the TestCase for a fixture belonging to given version of project which were modified since specified time
+    /// </summary>
+    /// <param name="projectId"></param>
+    /// <param name="projectVersion"></param>
+    /// <param name="fixtureId"></param>
+    /// <param name="laterThan"></param>
+    /// <returns></returns>
+    Task<IEnumerable<TestCase>> GetAllForFixtureAsync(string projectId, string projectVersion, string fixtureId, DateTime laterThan);
+
+    /// <summary>
     /// Add a new TestCase to a given version of project
     /// </summary>
     /// <param name="projectId"></param>

--- a/src/Pixel.Persistence.Services.Client/TestsRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/TestsRepositoryClient.cs
@@ -90,6 +90,27 @@ public class TestsRepositoryClient : ITestsRepositoryClient
     }
 
     /// <inheritdoc/>
+    public async  Task<IEnumerable<TestCase>> GetAllForFixtureAsync(string projectId, string projectVersion, string fixtureId, DateTime laterThan)
+    {
+        Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
+        Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
+        Guard.Argument(fixtureId, nameof(fixtureId)).NotNull().NotEmpty();
+
+        RestRequest restRequest = new RestRequest($"tests/{projectId}/{projectVersion}/{fixtureId}");
+        restRequest.AddHeader(nameof(laterThan), laterThan.ToString("O"));
+        var client = this.clientFactory.GetOrCreateClient();
+        var result = await client.ExecuteGetAsync(restRequest);
+        result.EnsureSuccess();
+        using (var stream = new MemoryStream(result.RawBytes))
+        {
+            using (var reader = new StreamReader(stream, Encoding.UTF8))
+            {
+                return serializer.DeserializeContent<List<TestCase>>(reader.ReadToEnd());
+            }
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<TestCase> AddTestCaseAsync(string projectId, string projectVersion, TestCase testCase)
     {
         Guard.Argument(testCase, nameof(testCase)).NotNull();


### PR DESCRIPTION
**Description**

It is possible that a test case or fixture details might be updated e.g. name, description, control used, etc by another user. While opening a test case or fixture, we download the latest version of data files but not the details of test case or fixture itself. We need to get a latest copy of them as well so that we work on the most recent copy.