### PR TITLE
Options state and edit changes for fixture and tests

### DIFF
--- a/src/Pixel.Automation.TestExplorer.ViewModels/EditTestCaseViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/EditTestCaseViewModel.cs
@@ -139,6 +139,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                     this.testCase.IsMuted = CopyOfTestCase.IsMuted;
                     this.testCase.Order = CopyOfTestCase.Order;
                     this.testCase.DelayFactor = CopyOfTestCase.DelayFactor;
+                    this.testCase.PostDelay = CopyOfTestCase.PostDelay;
                     this.testCase.Priority = CopyOfTestCase.Priority;
                     this.testCase.Tags.Clear();
                     foreach (var item in this.TagCollection.Tags)

--- a/src/Pixel.Automation.TestExplorer.ViewModels/EditTestFixtureViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/EditTestFixtureViewModel.cs
@@ -142,6 +142,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                     this.testFixture.IsMuted = CopyOfTestFixture.IsMuted;
                     this.testFixture.Order = CopyOfTestFixture.Order;
                     this.testFixture.DelayFactor = CopyOfTestFixture.DelayFactor;
+                    this.testFixture.PostDelay = CopyOfTestFixture.PostDelay;
                     this.testFixture.Tags.Clear();
                     foreach (var item in this.TagCollection.Tags)
                     {

--- a/src/Pixel.Automation.TestExplorer.Views/TestExplorerView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/TestExplorerView.xaml
@@ -120,7 +120,7 @@
                                                 cal:Message.Attach="[Event Click] = [Action SaveTestCaseDataAsync($dataContext)]"/>
                                             <MenuItem x:Name="SaveAndClose" Header="Save and Close"  IsEnabled="{Binding IsOpenForEdit}"                                           
                                                 cal:Message.Attach="[Event Click] = [Action CloseTestCaseAsync($dataContext,'true')]"/>
-                                            <MenuItem x:Name="Edit" Header="Edit Details"                                       
+                                            <MenuItem x:Name="Edit" Header="Edit Details"  IsEnabled="{Binding CanOpenForEdit}"                                      
                                                 cal:Message.Attach="[Event Click] = [Action EditTestCaseAsync($dataContext)]"/>
                                             <MenuItem x:Name="EditScript" Header="Edit Script" IsEnabled="{Binding IsOpenForEdit}"                                    
                                                 cal:Message.Attach="[Event Click] = [Action EditTestScriptAsync($dataContext)]"/>
@@ -199,7 +199,7 @@
                                                 cal:Message.Attach="[Event Click] = [Action CloseTestFixtureAsync($dataContext,'true')]"/>
                                         <MenuItem x:Name="AddTestCase" Header="Add Test"                                       
                                             cal:Message.Attach="[Event Click] = [Action AddTestCaseAsync($dataContext)]"/>
-                                        <MenuItem x:Name="Edit" Header="Edit Details"                                       
+                                        <MenuItem x:Name="Edit" Header="Edit Details"  IsEnabled="{Binding CanOpenForEdit}"                                     
                                             cal:Message.Attach="[Event Click] = [Action EditTestFixtureAsync($dataContext)]"/>
                                         <MenuItem x:Name="EditScript" Header="Edit Script" IsEnabled="{Binding IsOpenForEdit}"                                        
                                             cal:Message.Attach="[Event Click] = [Action EditTestFixtureScriptAsync($dataContext)]"/>

--- a/src/Pixel.Automation.TestExplorer.Views/TestExplorerView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/TestExplorerView.xaml
@@ -189,7 +189,7 @@
                                 <ItemsPresenter x:Name="ItemsHost"/>
                                 <Expander.ContextMenu>
                                     <ContextMenu cal:Action.TargetWithoutContext="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource Self}}">
-                                        <MenuItem x:Name="OpenTestFixture" Header="Open"                                       
+                                        <MenuItem x:Name="OpenTestFixture" Header="Open" IsEnabled="{Binding CanOpenForEdit}"                                 
                                             cal:Message.Attach="[Event Click] = [Action OpenTestFixtureAsync($dataContext)]"/>
                                         <MenuItem x:Name="CloseTestFixture" Header="Close"  IsEnabled="{Binding IsOpenForEdit}"                                            
                                                 cal:Message.Attach="[Event Click] = [Action CloseTestFixtureAsync($dataContext,'false')]"/>


### PR DESCRIPTION
**Description**
1. Post delay value is not updated when editing fixture or test cases
2. Open menu option on fixture should be disabled if fixture is already open
3. Fixture and test cases details should not be allowed to be edited if they are open 