### PR TITLE
Multiple bug fixes

### DIFF
--- a/src/Pixel.Automation.Test.Runner/Program.cs
+++ b/src/Pixel.Automation.Test.Runner/Program.cs
@@ -144,10 +144,10 @@ namespace Pixel.Automation.Test.Runner
                         .WithExample(new[] { "run", "template", "template-name", "--list"  })
                         .WithExample(new[] { "run", "template", "template-name", "1.0.0.0" });
                         run.AddCommand<ExecuteAdhocTestCommand>("adhoc").WithDescription("Execute tests without using a template")
-                        .WithExample(new[] { "run", "adhoc", "project-name", "project-version", "true", "InitializationScript.csx" })
-                         .WithExample(new[] { "run", "adhoc", "project-name", "project-version", "true", "InitializationScript.csx", "--list" })
+                        .WithExample(new[] { "run", "adhoc", "project-name", "project-version", "true", "InitializeDefault()" })
+                         .WithExample(new[] { "run", "adhoc", "project-name", "project-version", "true", "InitializeDefault()", "--list" })
                         .WithExample(new[] { "run", "adhoc", "project-name", "project-version", "\"fixture.Name.Equals(\"fixture-name\") &&" +
-                        " test.Name.Contains(\"test-prefix\")\"", "InitializationScript.csx" });
+                        " test.Name.Contains(\"test-prefix\")\"", "InitializeDefault()" });
                     });
                     config.AddBranch<TemplateSettings>("template", template =>
                     {

--- a/src/Pixel.Automation.Test.Runner/TestSelector.cs
+++ b/src/Pixel.Automation.Test.Runner/TestSelector.cs
@@ -46,9 +46,16 @@ namespace Pixel.Automation.Test.Runner
             this.testSelector = await scriptEngine.CreateDelegateAsync<Func<TestFixture, TestCase, bool>>("Selector.csx");
         }
 
+        /// <summary>
+        /// Checks if a test case should be run. If the fixture is muted or test case is muted or test case doesn't have a data source linked to it or
+        /// the test selector script returns false, test case wouldn't be considered eligibile to run.
+        /// </summary>
+        /// <param name="fixture"></param>
+        /// <param name="testCase"></param>
+        /// <returns></returns>
         public bool CanRunTest(TestFixture fixture, TestCase testCase)
         {
-            return !fixture.IsMuted && !testCase.IsMuted && this.testSelector.Invoke(fixture, testCase);
+            return !fixture.IsMuted && !testCase.IsMuted && !string.IsNullOrEmpty(testCase.TestDataId) && this.testSelector.Invoke(fixture, testCase);
         }
     }
 }

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestCaseViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestCaseViewModel.cs
@@ -409,7 +409,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                             IsVisible = this.TestCase.ControlsUsed.Any(p => p.ControlId.Equals(query[1]));
                             break;
                         case "testdatasource":
-                            IsVisible = this.TestDataId.Equals(query[1]);
+                            IsVisible = this.TestDataId?.Equals(query[1]) ?? false;
                             break;
                         default:
                             IsVisible = this.Tags.Contains(query[0]) && this.Tags[query[0]].Equals(query[1]);

--- a/src/Pixel.Automation.UIA.Scrapper/Pixel.Automation.UIA.Scrapper.csproj
+++ b/src/Pixel.Automation.UIA.Scrapper/Pixel.Automation.UIA.Scrapper.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="MouseKeyHook" Version="5.6.0" />		
+		<PackageReference Include="MouseKeyHook" Version="5.7.1" />		
 		<PackageReference Include="Caliburn.Micro" Version="4.0.212">
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
**Description**
1. Added null check for testdata when filtering test cases in test explorer
2. Test cases should not be eligible to be run if there is no data source assigned to it
3. Updated adhoc test execution help examples to use init function instead of init scripts
4. Updated MouseKeyHook package version to 5.7.1