### PR TITLE
Groups for test data source and project references file to store fixtures and data sources belonging to project

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Control/ControlExplorerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Control/ControlExplorerViewModel.cs
@@ -285,6 +285,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Control
             return controlsList;
         }
        
+        /// <summary>
         /// Move a control from one screen to another
         /// </summary>
         /// <param name="controlDescription"></param>

--- a/src/Pixel.Automation.Core/FileSystem/IFileSystem.cs
+++ b/src/Pixel.Automation.Core/FileSystem/IFileSystem.cs
@@ -161,6 +161,13 @@ namespace Pixel.Automation.Core.Interfaces
         TestFixtureFiles GetTestFixtureFiles(TestFixture fixture);
 
         /// <summary>
+        /// Get TestDataSource from local storage given it's identifier
+        /// </summary>
+        /// <param name="dataSourceId"></param>
+        /// <returns></returns>
+        TestDataSource GetTestDataSourceById(string dataSourceId);
+
+        /// <summary>
         /// Load TestDataSources available on local storage
         /// </summary>
         /// <returns></returns>

--- a/src/Pixel.Automation.Core/FileSystem/ProjectFileSystem.cs
+++ b/src/Pixel.Automation.Core/FileSystem/ProjectFileSystem.cs
@@ -88,6 +88,18 @@ namespace Pixel.Automation.Core
             return new TestFixtureFiles(fixture, this.TestCaseRepository);
         }
 
+        /// <InheritDoc/> 
+        public TestDataSource GetTestDataSourceById(string dataSourceId)
+        {
+            string dataSourceFile = Path.Combine(this.TestDataRepository, $"{dataSourceId}.dat");
+            if(!File.Exists(dataSourceFile))
+            {
+                throw new FileNotFoundException($"Test data source file {dataSourceFile} doesn't exist.");
+            }
+            var testDataSource = serializer.Deserialize<TestDataSource>(dataSourceFile);
+            return testDataSource;
+        }
+
         /// <InheritDoc/>      
         public IEnumerable<TestDataSource> GetTestDataSources()
         {

--- a/src/Pixel.Automation.Core/FrameworkEx.cs
+++ b/src/Pixel.Automation.Core/FrameworkEx.cs
@@ -1,6 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Pixel.Automation.Core
 {
-   public delegate Task AsyncEventHandler<TEventArgs>(object? sender, TEventArgs e);
+    public delegate Task AsyncEventHandler<in TEventArgs>(object sender, TEventArgs e) where TEventArgs : EventArgs;
 }

--- a/src/Pixel.Automation.Core/Interfaces/IProject.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IProject.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Pixel.Automation.Core.Interfaces;
 
-internal interface IProject
+public interface IProject
 {
     /// <summary>
     /// Identifier of the Project

--- a/src/Pixel.Automation.Core/Models/GroupedCollection.cs
+++ b/src/Pixel.Automation.Core/Models/GroupedCollection.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Pixel.Automation.Core.Models;
+
+/// <summary>
+/// Pair of key and a collection
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class KeyCollectionPair<T> where T : class
+{
+    /// <summary>
+    /// Name of the group
+    /// </summary>
+    public string GroupName { get; set; }
+
+    /// <summary>
+    /// Collection belonging to the group
+    /// </summary>
+    public List<T> Collection { get; set; } = new();
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    public KeyCollectionPair()
+    {
+
+    }
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="groupName"></param>
+    public KeyCollectionPair(string groupName)
+    {
+        this.GroupName = groupName;
+    }
+
+    /// <inheritdoc/> 
+    public override bool Equals(object obj)
+    {
+        if(obj is KeyCollectionPair<T> keyCollectionPair)
+        {
+            return keyCollectionPair.GroupName.Equals(this.GroupName) && keyCollectionPair.Collection.SequenceEqual(this.Collection);
+        }
+        return base.Equals(obj);
+    }
+
+    /// <inheritdoc/> 
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(GroupName.GetHashCode());
+    }
+}
+
+/// <summary>
+/// GroupedCollection<typeparamref name="T"/> is a collection of <see cref="KeyCollectionPair{T}"/>. Only <see cref="KeyCollectionPair{T}"/> with unique group name can be added to this collection.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class GroupedCollection<T> : IList<KeyCollectionPair<T>> where T : class
+{
+    private List<KeyCollectionPair<T>> collection = new();  
+
+    /// <summary>
+    /// Get <see cref="KeyCollectionPair{T}"/> having the specifed group name
+    /// </summary>
+    /// <param name="groupName"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    public KeyCollectionPair<T> this[string groupName]
+    {
+        get
+        {
+            if(this.collection.Any(c => c.GroupName.Equals(groupName)))
+            {
+                return collection.Single(c => c.GroupName.Equals(groupName));
+            }
+            throw new ArgumentException($"KeyCollectionPair with group name : '{groupName}' doesn't exist.");
+        }       
+    }
+
+    /// <summary>
+    /// Check if an entry exists for specified group name
+    /// </summary>
+    /// <param name="groupName"></param>
+    /// <returns></returns>
+    public bool ContainsGroup(string groupName)
+    {
+        return collection.Any(c => c.GroupName.Equals(groupName));
+    }
+
+    /// <inheritdoc/> 
+    public KeyCollectionPair<T> this[int index]
+    {
+        get => collection[index];
+        set => collection[index] = value;
+    }
+
+    /// <inheritdoc/> 
+    public int Count =>  collection.Count;
+
+    /// <inheritdoc/> 
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc/> 
+    public void Add(KeyCollectionPair<T> item)
+    {
+        if(!collection.Any(c => c.GroupName.Equals(item.GroupName)))
+        {
+            collection.Add(item);
+            return;
+        }
+        throw new ArgumentException($"KeyCollectionPair already exists with group name : '{item.GroupName}'");
+    }
+
+    /// <inheritdoc/> 
+    public void Clear()
+    {
+        collection.Clear();
+    }
+
+    /// <inheritdoc/> 
+    public bool Contains(KeyCollectionPair<T> item)
+    {
+        return collection.Contains(item);
+    }
+
+    /// <inheritdoc/> 
+    public void CopyTo(KeyCollectionPair<T>[] array, int arrayIndex)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc/> 
+    public IEnumerator<KeyCollectionPair<T>> GetEnumerator()
+    {
+        return collection.GetEnumerator();
+    }
+
+    /// <inheritdoc/> 
+    public int IndexOf(KeyCollectionPair<T> item)
+    {
+        return collection.IndexOf(item);
+    }
+
+    /// <inheritdoc/> 
+    public void Insert(int index, KeyCollectionPair<T> item)
+    {
+        collection.Insert(index, item);
+    }
+
+    /// <inheritdoc/> 
+    public bool Remove(KeyCollectionPair<T> item)
+    {
+       return collection.Remove(item);
+    }
+
+    /// <inheritdoc/> 
+    public void RemoveAt(int index)
+    {
+       collection.RemoveAt(index);  
+    }
+
+    /// <inheritdoc/> 
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+       return (collection as IEnumerable).GetEnumerator();
+    }
+}

--- a/src/Pixel.Automation.Core/Models/ProjectReferences.cs
+++ b/src/Pixel.Automation.Core/Models/ProjectReferences.cs
@@ -1,18 +1,28 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Pixel.Automation.Core.Interfaces;
 
-namespace Pixel.Automation.Core.Models
+namespace Pixel.Automation.Core.Models;
+
+/// <summary>
+/// Resources belonging to or used by <see cref="IProject"/>
+/// </summary>
+[DataContract]
+public class ProjectReferences
 {
-    [DataContract]
-    public class ProjectReferences
-    {
-        [DataMember(IsRequired = true, Order = 20)]
-        public EditorReferences EditorReferences { get; set; } = new EditorReferences();
+    [DataMember(IsRequired = true, Order = 10)]
+    public EditorReferences EditorReferences { get; set; } = new EditorReferences();
 
-        [DataMember(IsRequired = true, Order = 20)]
-        public List<ControlReference> ControlReferences { get; set; } = new();
+    [DataMember(IsRequired = true, Order = 20)]
+    public List<ControlReference> ControlReferences { get; set; } = new();
 
-        [DataMember(IsRequired = true, Order = 30)]
-        public List<PrefabReference> PrefabReferences { get; set; } = new();
-    }
+    [DataMember(IsRequired = true, Order = 30)]
+    public List<PrefabReference> PrefabReferences { get; set; } = new();
+
+    [DataMember(IsRequired = true, Order = 40)]
+    public List<string> Fixtures { get; set; } = new();
+
+    [DataMember(IsRequired = true, Order = 50)]
+    public GroupedCollection<string> TestDataSources { get; set; } = new();
+ 
 }

--- a/src/Pixel.Automation.Core/ProjectLoadedEventArgs.cs
+++ b/src/Pixel.Automation.Core/ProjectLoadedEventArgs.cs
@@ -1,0 +1,38 @@
+﻿using Pixel.Automation.Core.Models;
+using System;
+
+namespace Pixel.Automation.Core;
+
+/// <summary>
+/// Event Args for project loaded event 
+/// </summary>
+public class ProjectLoadedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Name of the project
+    /// </summary>
+    public string ProjectName { get; init; }
+
+    /// <summary>
+    /// Identifier of the project
+    /// </summary>
+    public string ProjectId { get; init; }
+
+    /// <summary>
+    /// Version of the project
+    /// </summary>
+    public VersionInfo ProjectVersion { get; init; }
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="projectName"></param>
+    /// <param name="projectId"></param>
+    /// <param name="projectVersion"></param>
+    public ProjectLoadedEventArgs(string projectName, string projectId, VersionInfo projectVersion)
+    {
+        this.ProjectName = projectName;
+        this.ProjectId = projectId;
+        this.ProjectVersion = projectVersion;
+    }
+}

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -94,6 +94,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);
                 Initialize();
                 SetupInitializationScriptProject(dataModel);
+                await OnProjectLoaded(activeProject, versionToLoad);
                 return this.RootEntity;
             }           
         }   

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -89,7 +89,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);
                 Initialize();
                 SetupInitializationScriptProject(dataModel);
-
+                await OnProjectLoaded(prefabProject, versionToLoad);
                 return this.RootEntity;
             }           
         }

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
@@ -1,6 +1,7 @@
 ﻿using Dawn;
 using Pixel.Automation.Core;
 using Pixel.Automation.Core.Interfaces;
+using Pixel.Automation.Core.Models;
 using Pixel.Automation.Editor.Core.Interfaces;
 using Pixel.Automation.Reference.Manager.Contracts;
 using Pixel.Persistence.Services.Client;
@@ -37,7 +38,6 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             set => this.entityManager.RootEntity = value;
         }
 
-
         public ProjectManager(ISerializer serializer, IEntityManager entityManager, IFileSystem fileSystem, ITypeProvider typeProvider, IArgumentTypeProvider argumentTypeProvider,
             ICodeEditorFactory codeEditorFactory, IScriptEditorFactory scriptEditorFactory, IScriptEngineFactory scriptEngineFactory,
             ICodeGenerator codeGenerator, IApplicationDataManager applicationDataManager)
@@ -52,6 +52,17 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             this.scriptEngineFactory = Guard.Argument(scriptEngineFactory, nameof(scriptEngineFactory)).NotNull().Value;    
             this.codeGenerator = Guard.Argument(codeGenerator, nameof(codeGenerator)).NotNull().Value;
             this.applicationDataManager = Guard.Argument(applicationDataManager, nameof(applicationDataManager)).NotNull().Value;            
+        }
+
+        public event AsyncEventHandler<ProjectLoadedEventArgs> ProjectLoaded;
+
+        protected virtual async Task OnProjectLoaded(IProject project, VersionInfo versionInfo)
+        {
+            var handler = this.ProjectLoaded;
+            if(handler != null)
+            { 
+                await this.ProjectLoaded(this, new ProjectLoadedEventArgs(project.Name, project.ProjectId, versionInfo));               
+            }
         }
 
         #region abstract methods

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IProjectManager.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IProjectManager.cs
@@ -10,7 +10,12 @@ namespace Pixel.Automation.Editor.Core.Interfaces
     /// Contract for managing a project
     /// </summary>
     public interface IProjectManager
-    {      
+    {
+        /// <summary>
+        /// Event handler that is triggered when the project is loaded
+        /// </summary>
+        event AsyncEventHandler<ProjectLoadedEventArgs> ProjectLoaded;
+
         /// <summary>
         /// Get the file systemm for the project
         /// </summary>

--- a/src/Pixel.Automation.Reference.Manager/Contracts/IReferenceManager.cs
+++ b/src/Pixel.Automation.Reference.Manager/Contracts/IReferenceManager.cs
@@ -1,12 +1,11 @@
-﻿using Dawn;
-using Pixel.Automation.Core.Interfaces;
+﻿using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.Models;
 
 namespace Pixel.Automation.Reference.Manager.Contracts;
 
 /// <summary>
-/// IReferenceManager defines the contract for retrieving assmbly references and imports for code editor, script editor and script engine associated
-/// with automation or prefab projects
+/// Manage resources owned or used by an <see cref="IProject"/> e.g. fixtures and test data sources belonging to project in addition to assmbly references and imports for code editor, script editor and script engine and controls
+/// used in the project
 /// </summary>
 public interface IReferenceManager
 {
@@ -59,13 +58,7 @@ public interface IReferenceManager
     /// </summary>
     /// <returns></returns>
     ControlReferences GetControlReferences();
-
-    /// <summary>
-    /// Get the <see cref="PrefabReferences"/> for the project
-    /// </summary>
-    /// <returns></returns>
-    PrefabReferences GetPrefabReferences();
-
+   
     /// <summary>
     /// Set the <see cref="ProjectReferences"/> for the ReferenceManager.
     /// </summary>
@@ -98,7 +91,86 @@ public interface IReferenceManager
     /// </summary>
     /// <param name="controlReferences"></param>
     /// <returns></returns>
-    Task UpdateControlReferencesAsync(IEnumerable<ControlReference> controlReferences);
+    Task UpdateControlReferencesAsync(IEnumerable<ControlReference> controlReferences);  
+
+    /// <summary>
+    /// Get identifiers of all the fixtures owned by the project
+    /// </summary>
+    /// <returns></returns>
+    IEnumerable<string> GetAllFixtures();
+
+    /// <summary>
+    /// Add an entry for identifier of the fixture to the project (locally)
+    /// </summary>
+    /// <param name="fixtureId">Identifier of the fixture to be added</param>
+    /// <returns></returns>
+    void AddFixture(string fixtureId);
+
+    /// <summary>
+    /// Remove identifier entry of the fixture from the project (locally)
+    /// </summary>
+    /// <param name="fixtureId">Identifier of the fixture to be deleted</param>
+    /// <returns></returns>
+    void DeleteFixture(string fixtureId);
+
+    /// <summary>
+    /// Get identifiers of all the test data source that belong to a group given it's group key
+    /// </summary>
+    /// <param name="groupKey">Group to which the test data source belongs</param>
+    /// <returns></returns>
+    IEnumerable<string> GetTestDataSources(string groupKey);
+
+    /// <summary>
+    /// Add an entry for identifer of the test data source to the project (locally)
+    /// </summary>
+    /// <param name="groupKey">Group to which the test data source belongs</param>
+    /// <param name="testDataSourceId">Identifier of the test data source</param>
+    /// <returns></returns>
+    void AddTestDataSource(string groupKey, string testDataSourceId);
+
+    /// <summary>
+    /// Remove test data source identifier from the specific group  (locally)
+    /// </summary>
+    /// <param name="groupKey"></param>
+    /// <param name="testDataSourceId"></param>
+    /// <returns></returns>
+    void DeleteTestDataSource(string groupKey, string testDataSourceId);
+
+    /// <summary>
+    /// Get all the available test data source groups 
+    /// </summary>
+    /// <returns></returns>
+    IEnumerable<string> GetTestDataSourceGroups();
+
+    /// <summary>
+    /// Add a new group for test data source
+    /// </summary>
+    /// <param name="groupKey">name of the group</param>
+    /// <returns></returns>
+    Task AddTestDataSourceGroupAsync(string groupKey);
+
+    /// <summary>
+    /// Rename a test data source group
+    /// </summary>
+    /// <param name="currentKey">current group name</param>
+    /// <param name="newKey">new group name</param>
+    /// <returns></returns>
+    Task RenameTestDataSourceGroupAsync(string currentKey, string newKey);
+
+    /// <summary>
+    /// Move a test data souce to a new group
+    /// </summary>
+    /// <param name="testDataSourceId">Identifier of the test data source</param>
+    /// <param name="currentGroup">Name of current group</param>
+    /// <param name="newGroup">Name of new group</param>
+    /// <returns></returns>
+    Task MoveTestDataSourceToGroupAsync(string testDataSourceId, string currentGroup, string newGroup);
+
+    /// <summary>
+    /// Get the <see cref="PrefabReferences"/> for the project
+    /// </summary>
+    /// <returns></returns>
+    PrefabReferences GetPrefabReferences();
 
     /// <summary>
     /// Add a new PrefabReference to the version of project being managed

--- a/src/Pixel.Automation.Reference.Manager/Pixel.Automation.Reference.Manager.csproj
+++ b/src/Pixel.Automation.Reference.Manager/Pixel.Automation.Reference.Manager.csproj
@@ -14,8 +14,4 @@
     <ProjectReference Include="..\Pixel.Persistence.Services.Client\Pixel.Persistence.Services.Client.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Contracts\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Pixel.Automation.TestData.Repository.ViewModels/MoveToGroupViewModel.cs
+++ b/src/Pixel.Automation.TestData.Repository.ViewModels/MoveToGroupViewModel.cs
@@ -1,0 +1,123 @@
+﻿using Caliburn.Micro;
+using Dawn;
+using Notifications.Wpf.Core;
+using Pixel.Automation.Core.TestData;
+using Pixel.Automation.Editor.Core;
+using Pixel.Automation.Editor.Core.Helpers;
+using Pixel.Automation.Reference.Manager.Contracts;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.TestData.Repository.ViewModels;
+
+/// <summary>
+/// Allow users to pick a new group name for data source
+/// </summary>
+public class MoveToGroupViewModel : SmartScreen
+{
+    private readonly ILogger logger = Log.ForContext<MoveToGroupViewModel>();
+
+    private readonly IReferenceManager referenceManager;
+    private readonly INotificationManager notificationManager;
+    private readonly TestDataSource dataSource;
+    private readonly string currentGroup;
+
+    /// <summary>
+    /// Available screen names
+    /// </summary>
+    public BindableCollection<string> Groups { get; private set; } = new();
+      
+    private string selectedGroup;
+    /// <summary>
+    /// Selected group name
+    /// </summary>
+    public string SelectedGroup
+    {
+        get => this.selectedGroup;
+        set
+        {
+            this.selectedGroup = value;
+            ValidateGroupName(selectedGroup);
+            NotifyOfPropertyChange(nameof(SelectedGroup));
+            NotifyOfPropertyChange(nameof(CanMoveToGroup));
+        }
+    }
+
+    /// <summary>
+    /// Name of the test data source which needs to be moved
+    /// </summary>
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// Check if the data souce can be moved to selected group
+    /// </summary>
+    public bool CanMoveToGroup
+    {
+        get
+        {
+            return !this.HasErrors && !string.IsNullOrEmpty(this.SelectedGroup);
+        }
+    }
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="groups"></param>
+    /// <param name="currentGroup"></param>
+    public MoveToGroupViewModel(TestDataSource testDataSource, IEnumerable<string> groups, string currentGroup,
+        IReferenceManager referenceManager, INotificationManager notificationManaager)
+    {
+        this.DisplayName = "Move To Screen";
+        Guard.Argument(groups, nameof(groups)).NotNull();       
+        this.dataSource = Guard.Argument(testDataSource, nameof(testDataSource)).NotNull();
+        this.currentGroup = Guard.Argument(currentGroup, nameof(currentGroup)).NotNull().NotWhiteSpace();      
+        this.referenceManager = Guard.Argument(referenceManager, nameof(referenceManager)).NotNull().Value;
+        this.notificationManager = Guard.Argument(notificationManaager, nameof(notificationManaager)).NotNull().Value;
+        this.Groups.AddRange(groups.Except(new[] { currentGroup }));
+        this.SelectedGroup = this.Groups.FirstOrDefault();
+        this.Name = this.dataSource.Name;
+    }
+
+    /// <summary>
+    /// Check if new group name is valid
+    /// </summary>
+    /// <param name="groupName"></param>
+    private void ValidateGroupName(string groupName)
+    {
+        ClearErrors(nameof(SelectedGroup));
+        ValidateRequiredProperty(nameof(SelectedGroup), groupName);
+    }
+
+    /// <summary>
+    /// Close the dialog with true result
+    /// </summary>
+    /// <returns></returns>
+    public async Task MoveToGroup()
+    {
+        try
+        {
+            if (this.CanMoveToGroup)
+            {
+                await this.referenceManager.MoveTestDataSourceToGroupAsync(this.dataSource.DataSourceId, this.currentGroup, this.SelectedGroup);
+                await this.TryCloseAsync(true);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "There was an error while moving data source : '{0}' to another group", this.dataSource.Name);         
+            await notificationManager.ShowErrorNotificationAsync(ex);
+        }
+    }
+
+    /// <summary>
+    /// Close the dialog with false result
+    /// </summary>
+    public async void Cancel()
+    {
+        await this.TryCloseAsync(false);
+    }
+}

--- a/src/Pixel.Automation.TestData.Repository.ViewModels/NewDataSourceGroupViewModel.cs
+++ b/src/Pixel.Automation.TestData.Repository.ViewModels/NewDataSourceGroupViewModel.cs
@@ -1,0 +1,105 @@
+﻿using Dawn;
+using Notifications.Wpf.Core;
+using Pixel.Automation.Editor.Core;
+using Pixel.Automation.Editor.Core.Helpers;
+using Pixel.Automation.Reference.Manager.Contracts;
+using Serilog;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.TestData.Repository.ViewModels;
+
+/// <summary>
+/// View model used to create a new group for test data source
+/// </summary>
+public class NewDataSourceGroupViewModel : SmartScreen
+{
+    private readonly ILogger logger = Log.ForContext<NewDataSourceGroupViewModel>();
+
+    private readonly IReferenceManager referenceManager;
+    private readonly INotificationManager notificationManager;
+
+    private string groupName;
+    /// <summary>
+    /// Name of the group to be created
+    /// </summary>
+    public string GroupName
+    {
+        get => groupName;
+        set
+        {
+            groupName = value;
+            ValidateGroupName(value);
+            NotifyOfPropertyChange(() => GroupName);
+            NotifyOfPropertyChange(() => CanCreateGroup);
+        }
+    }
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="referenceManager"></param>
+    public NewDataSourceGroupViewModel(IReferenceManager referenceManager, INotificationManager notificationManager)
+    {
+        this.DisplayName = "Create New Test Data Source Group";
+        this.referenceManager = Guard.Argument(referenceManager).NotNull().Value;
+        this.notificationManager = Guard.Argument(notificationManager).NotNull().Value;
+    }
+
+    /// <summary>
+    /// Create new group and close the view with true result
+    /// </summary>
+    /// <returns></returns>
+    public async Task CreateNewGroup()
+    {
+        if (this.CanCreateGroup)
+        {
+            try
+            {
+                await this.referenceManager.AddTestDataSourceGroupAsync(this.GroupName);
+                await this.TryCloseAsync(true);
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "There was an error while create data source group : '{0}'", this.GroupName);
+                await notificationManager.ShowErrorNotificationAsync(ex);
+            }
+        }
+    }
+
+    /// <summary>
+    /// True if the group caan be created
+    /// </summary>
+    public bool CanCreateGroup
+    {
+        get
+        {
+            return !this.HasErrors && !string.IsNullOrEmpty(this.GroupName) && IsNameAvailable(this.GroupName);
+        }
+    }
+
+    private void ValidateGroupName(string groupName)
+    {
+        ClearErrors(nameof(GroupName));
+        ValidateRequiredProperty(nameof(GroupName), groupName);
+        ValidatePattern("[A-Za-z]{3,}", nameof(GroupName), groupName, "Name must contain only alphabets and should be atleast 3 characters in length.");
+        if (!IsNameAvailable(groupName))
+        {
+            this.AddOrAppendErrors(nameof(GroupName), $"Group already exists with name {GroupName}");
+        }
+    }
+
+    private bool IsNameAvailable(string groupName)
+    {
+        return !this.referenceManager.GetTestDataSourceGroups().Any(a => a.Equals(groupName));
+    }
+
+    /// <summary>
+    /// Close the view with false result
+    /// </summary>
+    public async void Cancel()
+    {
+        await this.TryCloseAsync(false);
+    }
+}

--- a/src/Pixel.Automation.TestData.Repository.ViewModels/RenameDataSourceGroupViewModel.cs
+++ b/src/Pixel.Automation.TestData.Repository.ViewModels/RenameDataSourceGroupViewModel.cs
@@ -1,0 +1,118 @@
+﻿using Dawn;
+using Notifications.Wpf.Core;
+using Pixel.Automation.Editor.Core;
+using Pixel.Automation.Editor.Core.Helpers;
+using Pixel.Automation.Reference.Manager.Contracts;
+using Serilog;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.TestData.Repository.ViewModels;
+
+public class RenameDataSourceGroupViewModel : SmartScreen
+{
+    private readonly ILogger logger = Log.ForContext<RenameDataSourceGroupViewModel>();
+
+    private readonly IReferenceManager referenceManager;
+    private readonly INotificationManager notificationManager;
+
+    /// <summary>
+    /// Current name of the group
+    /// </summary>
+    public string GroupName { get; private set; }
+
+    private string newGroupName;
+    /// <summary>
+    /// New name of the group
+    /// </summary>
+    public string NewGroupName
+    {
+        get => newGroupName;
+        set
+        {
+            newGroupName = value;
+            ValidateGroupName(value);
+            NotifyOfPropertyChange(() => NewGroupName);
+            NotifyOfPropertyChange(() => CanRenameGroup);
+        }
+    }
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="referenceManager"></param>
+    /// <param name="groupName"></param>
+    public RenameDataSourceGroupViewModel(string groupName, IReferenceManager referenceManager, INotificationManager notificationManager)
+    {
+        this.DisplayName = "Rename Group";
+        this.referenceManager = Guard.Argument(referenceManager, nameof(referenceManager)).NotNull().Value;
+        this.GroupName = Guard.Argument(groupName, nameof(groupName)).NotNull().NotEmpty();
+        this.notificationManager = Guard.Argument(notificationManager).NotNull().Value;
+    }
+
+    /// <summary>
+    /// Rename group to a new value and close the view with true result
+    /// </summary>
+    /// <returns></returns>
+    public async Task RenameGroup()
+    {
+        if (this.CanRenameGroup)
+        {
+            try
+            {
+                await this.referenceManager.RenameTestDataSourceGroupAsync(this.GroupName, this.NewGroupName);
+                await this.TryCloseAsync(true);
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "There was an error while renaming data source group : '{0}'", this.GroupName);
+                await notificationManager.ShowErrorNotificationAsync(ex);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Check if it is possible to rename group
+    /// </summary>
+    public bool CanRenameGroup
+    {
+        get
+        {
+            return !this.HasErrors && !string.IsNullOrEmpty(this.NewGroupName) && IsNameAvailable(this.NewGroupName);
+        }
+    }
+
+    /// <summary>
+    /// Validate screen name
+    /// </summary>
+    /// <param name="newGroupName"></param>
+    private void ValidateGroupName(string newGroupName)
+    {
+        ClearErrors(nameof(NewGroupName));
+        ValidateRequiredProperty(nameof(NewGroupName), newGroupName);
+        ValidatePattern("[A-Za-z]{3,}", nameof(NewGroupName), newGroupName, "Name must contain only alphabets and should be atleast 3 characters in length.");
+        if (!IsNameAvailable(newGroupName))
+        {
+            this.AddOrAppendErrors(nameof(NewGroupName), $"Group already exists with name {NewGroupName}");
+        }
+    }
+
+    /// <summary>
+    /// Check if new screen name is available
+    /// </summary>
+    /// <param name="screenName"></param>
+    /// <returns></returns>
+    private bool IsNameAvailable(string screenName)
+    {
+        return !this.referenceManager.GetTestDataSourceGroups().Any(a => a.Equals(screenName));
+    }
+
+    /// <summary>
+    /// Close the view with false result
+    /// </summary>
+    public async void Cancel()
+    {
+        await this.TryCloseAsync(false);
+    }
+}

--- a/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataSourceViewModel.cs
+++ b/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataSourceViewModel.cs
@@ -35,6 +35,14 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
         public TestDataSource TestDataSource { get; }
 
         /// <summary>
+        /// Identifier of the TestDataSource
+        /// </summary>
+        public string DataSourceId
+        {
+            get => this.TestDataSource.DataSourceId;
+        }
+
+        /// <summary>
         /// Name of the data source
         /// </summary>
         public string Name

--- a/src/Pixel.Automation.TestData.Repository.Views/MoveToGroupView.xaml
+++ b/src/Pixel.Automation.TestData.Repository.Views/MoveToGroupView.xaml
@@ -1,0 +1,44 @@
+﻿<Controls:MetroWindow x:Class="Pixel.Automation.TestData.Repository.Views.MoveToGroupView"
+                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                      xmlns:cal="http://www.caliburnproject.org"
+                      xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+                      cal:Bind.AtDesignTime="True"
+                      ResizeMode="NoResize" SizeToContent="WidthAndHeight"
+                      WindowStartupLocation="CenterScreen"  ShowCloseButton="False"
+                      mc:Ignorable="d"  GlowBrush="{DynamicResource AccentColorBrush}"
+                      d:DesignHeight="600" d:DesignWidth="800">
+    <Controls:MetroWindow.Resources>
+        <ResourceDictionary>
+            <Thickness x:Key="ControlMargin">0 5 0 0</Thickness>
+        </ResourceDictionary>
+    </Controls:MetroWindow.Resources>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="10px"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="10px"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+        </Grid.RowDefinitions>
+        <DockPanel LastChildFill="True" MinWidth="320" Grid.Row="0">
+            <Label Content="Name" MinWidth="80" DockPanel.Dock="Left" ></Label>
+            <TextBlock DockPanel.Dock="Right" Margin="{StaticResource ControlMargin}"
+                         Text="{Binding Name, Mode=OneWay}" VerticalAlignment="Top"
+                         Controls:TextBoxHelper.Watermark="Test Data Source Name"
+                         Controls:TextBoxHelper.UseFloatingWatermark="True"                                                   
+                         ToolTip="Name of Test Data Source" />
+        </DockPanel>
+        <DockPanel LastChildFill="True" MinWidth="320" Grid.Row="2">
+            <Label Content="Group" DockPanel.Dock="Left" MinWidth="80"></Label>
+            <ComboBox ItemsSource="{Binding Groups}" DockPanel.Dock="Right"
+                  SelectedItem="{Binding SelectedGroup}" ToolTip="Group to move test data source to"/>
+        </DockPanel>
+        <DockPanel LastChildFill="False" Margin="0,5,0,0"  Grid.Row="4">
+            <Button x:Name="Cancel" Content="CANCEL" Width="100" DockPanel.Dock="Right"  Margin="10,0,0,0" Style="{DynamicResource MahApps.Styles.Button.Square}"/>
+            <Button x:Name="MoveToGroup" Content="OK" DockPanel.Dock="Right" Width="100"  Style="{DynamicResource MahApps.Styles.Button.Square.Accent}"/>
+        </DockPanel>
+    </Grid>
+</Controls:MetroWindow>

--- a/src/Pixel.Automation.TestData.Repository.Views/MoveToGroupView.xaml.cs
+++ b/src/Pixel.Automation.TestData.Repository.Views/MoveToGroupView.xaml.cs
@@ -1,0 +1,12 @@
+﻿namespace Pixel.Automation.TestData.Repository.Views;
+
+/// <summary>
+/// Interaction logic for MoveToGroupView.xaml
+/// </summary>
+public partial class MoveToGroupView
+{
+    public MoveToGroupView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Pixel.Automation.TestData.Repository.Views/NewDataSourceGroupView.xaml
+++ b/src/Pixel.Automation.TestData.Repository.Views/NewDataSourceGroupView.xaml
@@ -1,0 +1,34 @@
+﻿<Controls:MetroWindow x:Class="Pixel.Automation.TestData.Repository.Views.NewDataSourceGroupView"
+                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                      xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+                      ResizeMode="NoResize" SizeToContent="WidthAndHeight"
+             WindowStartupLocation="CenterScreen"  ShowCloseButton="False"
+             IsMinButtonEnabled="False" GlowBrush="{DynamicResource AccentColorBrush}">
+    <Controls:MetroWindow.Resources>
+        <ResourceDictionary>
+            <Thickness x:Key="ControlMargin">10 10 10 10</Thickness>
+        </ResourceDictionary>
+    </Controls:MetroWindow.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+        </Grid.RowDefinitions>
+        <DockPanel LastChildFill="True" MinWidth="320" Grid.Row="0" Margin="10,20,10,20">
+            <Label Content="Name" MinWidth="80" DockPanel.Dock="Left" VerticalAlignment="Center" ></Label>
+            <TextBox DockPanel.Dock="Right" VerticalAlignment="Center"
+                         Text="{Binding GroupName,ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
+                         Controls:TextBoxHelper.Watermark="Group Name"
+                         Controls:TextBoxHelper.UseFloatingWatermark="True"
+                         Controls:TextBoxHelper.IsWaitingForData="True"                                   
+                         ToolTip="Group Name" />
+        </DockPanel>
+        <DockPanel LastChildFill="False"  Grid.Row="1">
+            <Border DockPanel.Dock="Top" BorderThickness="1" Height="1" HorizontalAlignment="Stretch" 
+                    Width="{Binding Path=Width,RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type DockPanel}}}" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+            <Button x:Name="Cancel" Content="CANCEL" Width="100" DockPanel.Dock="Right"  Margin="{StaticResource ControlMargin}" Style="{DynamicResource MahApps.Styles.Button.Square}"/>
+            <Button x:Name="CreateNewGroup" Content="CREATE" DockPanel.Dock="Right" Width="100" Margin="0,10,0,10"  Style="{DynamicResource MahApps.Styles.Button.Square.Accent}"/>
+        </DockPanel>
+    </Grid>
+</Controls:MetroWindow>

--- a/src/Pixel.Automation.TestData.Repository.Views/NewDataSourceGroupView.xaml.cs
+++ b/src/Pixel.Automation.TestData.Repository.Views/NewDataSourceGroupView.xaml.cs
@@ -1,0 +1,12 @@
+﻿namespace Pixel.Automation.TestData.Repository.Views;
+
+/// <summary>
+/// Interaction logic for NewDataSourceGroupView.xaml
+/// </summary>
+public partial class NewDataSourceGroupView
+{
+    public NewDataSourceGroupView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Pixel.Automation.TestData.Repository.Views/RenameDataSourceGroupView.xaml
+++ b/src/Pixel.Automation.TestData.Repository.Views/RenameDataSourceGroupView.xaml
@@ -1,0 +1,44 @@
+﻿<Controls:MetroWindow x:Class="Pixel.Automation.TestData.Repository.Views.RenameDataSourceGroupView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             ResizeMode="NoResize" SizeToContent="WidthAndHeight"
+             WindowStartupLocation="CenterScreen"  ShowCloseButton="False"
+             IsMinButtonEnabled="False" GlowBrush="{DynamicResource AccentColorBrush}">
+    <Controls:MetroWindow.Resources>
+        <ResourceDictionary>
+            <Thickness x:Key="ControlMargin">10 10 10 10</Thickness>
+        </ResourceDictionary>
+    </Controls:MetroWindow.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+        </Grid.RowDefinitions>
+        <DockPanel LastChildFill="True" MinWidth="320" Grid.Row="0" Margin="15,20,15,20">
+            <Label Content="Group Name" MinWidth="80" DockPanel.Dock="Left" VerticalAlignment="Center" ></Label>
+            <TextBox DockPanel.Dock="Right" VerticalAlignment="Center" IsReadOnly="True"
+                         Text="{Binding GroupName, Mode=OneTime}" Margin="5,0,0,0"
+                         Controls:TextBoxHelper.Watermark="Current Group Name"
+                         Controls:TextBoxHelper.UseFloatingWatermark="True"                                                        
+                         ToolTip="Current value of group Name" />
+        </DockPanel>
+        <DockPanel LastChildFill="True" MinWidth="320" Grid.Row="1" Margin="15,20,15,20">
+            <Label Content="New Name" MinWidth="80" DockPanel.Dock="Left" VerticalAlignment="Center" ></Label>
+            <TextBox DockPanel.Dock="Right" VerticalAlignment="Center" Margin="5,0,0,0"
+                         Text="{Binding NewGroupName,ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
+                         Controls:TextBoxHelper.Watermark="New Group Name"
+                         Controls:TextBoxHelper.UseFloatingWatermark="True"
+                         Controls:TextBoxHelper.IsWaitingForData="True"                                   
+                         ToolTip="New value of screen name" />
+        </DockPanel>
+        <DockPanel LastChildFill="False"  Grid.Row="2">
+            <Border DockPanel.Dock="Top" BorderThickness="1" Height="1" HorizontalAlignment="Stretch" 
+                    Width="{Binding Path=Width,RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type DockPanel}}}" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+            <Button x:Name="Cancel" Content="CANCEL" Width="100" DockPanel.Dock="Right"  Margin="{StaticResource ControlMargin}" Style="{DynamicResource MahApps.Styles.Button.Square}"/>
+            <Button x:Name="RenameGroup" Content="RENAME" DockPanel.Dock="Right" Width="100" Margin="0,10,0,10"  Style="{DynamicResource MahApps.Styles.Button.Square.Accent}"/>
+        </DockPanel>
+    </Grid>
+</Controls:MetroWindow>
+

--- a/src/Pixel.Automation.TestData.Repository.Views/RenameDataSourceGroupView.xaml.cs
+++ b/src/Pixel.Automation.TestData.Repository.Views/RenameDataSourceGroupView.xaml.cs
@@ -1,0 +1,12 @@
+﻿namespace Pixel.Automation.TestData.Repository.Views;
+
+/// <summary>
+/// Interaction logic for RenameDataSourceGroupView.xaml
+/// </summary>
+public partial class RenameDataSourceGroupView
+{
+    public RenameDataSourceGroupView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Pixel.Automation.TestData.Repository.Views/TestDataRepositoryView.xaml
+++ b/src/Pixel.Automation.TestData.Repository.Views/TestDataRepositoryView.xaml
@@ -137,6 +137,7 @@
                                                 <MenuItem x:Name="Edit" Header="Edit" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" cal:Message.Attach="[Event Click] = [Action EditDataSource($dataContext)]"></MenuItem>
                                                 <MenuItem x:Name="Rename" Header="Rename" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" cal:Message.Attach="[Event Click] = [Action ToggleRename($dataContext)]"></MenuItem>
                                                 <MenuItem x:Name="Delete" Header="Delete" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" cal:Message.Attach="[Event Click] = [Action DeleteDataSource($dataContext)]"></MenuItem>
+                                                <MenuItem x:Name="MoveToGroup" Header="Move To Group" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" cal:Message.Attach="[Event Click] = [Action MoveToGroup($dataContext)]"></MenuItem>
                                                 <MenuItem x:Name="ShowUsage" Header="Show Usage" cal:Action.TargetWithoutContext="{Binding Path=DataContext, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" cal:Message.Attach="[Event Click] = [Action ShowUsage($dataContext)]"></MenuItem>
                                             </StackPanel>
                                         </ControlTemplate>
@@ -169,7 +170,21 @@
                   controls:TextBoxHelper.Watermark="Search"   Grid.Column="0" HorizontalAlignment="Left"
                   Width="250"/>
                 <Separator Width="1" Margin="10,0,0,0" BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
-                <Button x:Name="Add" Click="AddDataSourceClick" HorizontalAlignment="Right" Margin="0,0,10,0" Style="{StaticResource AddButton}"/>
+                <Button x:Name="AddDataSource" Click="AddDataSourceClick" HorizontalAlignment="Right" Margin="0,0,10,0" Style="{StaticResource AddButton}"/>
+                <Separator Width="1" Margin="10,0,0,0" BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+                <ComboBox x:Name="Screens" ItemsSource="{Binding Groups}" SelectedItem="{Binding SelectedGroup}" MinWidth="180" Style="{DynamicResource MahApps.Styles.ComboBox}"/>
+                <Separator Width="1" Margin="10,0,0,0" BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>              
+                <Button x:Name="AddTestDataGroup" Margin="0,0,2,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"                                          
+                             Height="28" Width="28" ToolTip="Create a new test data source group"                                                                                    
+                             cal:Message.Attach="[Event Click] = [Action CreateGroup()]"
+                             Style="{StaticResource EditControlButtonStyle}"
+                             Content="{iconPacks:Material PlusCircleOutline, Width=24, Height=24}"/>
+                <Separator Width="1" Margin="10,0,0,0" BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+                <Button x:Name="RenameTestDataGroup" Margin="0,0,2,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"                                          
+                             Height="26" Width="26" ToolTip="Rename test data source group name"                                                                                    
+                             cal:Message.Attach="[Event Click] = [Action RenameGroup()]"
+                             Style="{StaticResource EditControlButtonStyle}"
+                             Content="{iconPacks:FontAwesome PencilAltSolid, Width=24, Height=24}"/>
             </StackPanel>
 
             <ListBox  x:Name="TestDataSourceCollection"  ItemsSource="{Binding TestDataSourceCollection}" SelectedItem="{Binding SelectedTestDataSource}"

--- a/src/Pixel.Persistence.Core/Models/GroupedCollection.cs
+++ b/src/Pixel.Persistence.Core/Models/GroupedCollection.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Pixel.Persistence.Core.Models;
+
+/// <summary>
+/// Pair of key and a collection
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class KeyCollectionPair<T> where T : class
+{
+    /// <summary>
+    /// Name of the group
+    /// </summary>
+    public string GroupName { get; set; }
+
+    /// <summary>
+    /// Collection belonging to the group
+    /// </summary>
+    public List<T> Collection { get; set; } = new();
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    public KeyCollectionPair()
+    {
+
+    }
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="groupName"></param>
+    public KeyCollectionPair(string groupName)
+    {
+        this.GroupName = groupName;
+    }
+
+    /// <inheritdoc/> 
+    public override bool Equals(object obj)
+    {
+        if (obj is KeyCollectionPair<T> keyCollectionPair)
+        {
+            return keyCollectionPair.GroupName.Equals(this.GroupName) && keyCollectionPair.Collection.SequenceEqual(this.Collection);
+        }
+        return base.Equals(obj);
+    }
+
+    /// <inheritdoc/> 
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(GroupName.GetHashCode());
+    }
+}
+
+/// <summary>
+/// GroupedCollection<typeparamref name="T"/> is a collection of <see cref="KeyCollectionPair{T}"/>. Only <see cref="KeyCollectionPair{T}"/> with unique group name can be added to this collection.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class GroupedCollection<T> : IList<KeyCollectionPair<T>> where T : class
+{
+    private List<KeyCollectionPair<T>> collection = new();
+
+    /// <inheritdoc/> 
+    public KeyCollectionPair<T> this[int index]
+    {
+        get => collection[index];
+        set => collection[index] = value;
+    }
+
+    /// <inheritdoc/> 
+    public int Count => collection.Count;
+
+    /// <inheritdoc/> 
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc/> 
+    public void Add(KeyCollectionPair<T> item)
+    {
+        if (!collection.Any(c => c.GroupName.Equals(item.GroupName)))
+        {
+            collection.Add(item);
+            return;
+        }
+        throw new ArgumentException($"KeyCollectionPair already exists with group name : '{item.GroupName}'");
+    }
+
+    /// <inheritdoc/> 
+    public void Clear()
+    {
+        collection.Clear();
+    }
+
+    /// <inheritdoc/> 
+    public bool Contains(KeyCollectionPair<T> item)
+    {
+        return collection.Contains(item);
+    }
+
+    /// <inheritdoc/> 
+    public void CopyTo(KeyCollectionPair<T>[] array, int arrayIndex)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    /// <inheritdoc/> 
+    public IEnumerator<KeyCollectionPair<T>> GetEnumerator()
+    {
+        return collection.GetEnumerator();
+    }
+
+    /// <inheritdoc/> 
+    public int IndexOf(KeyCollectionPair<T> item)
+    {
+        return collection.IndexOf(item);
+    }
+
+    /// <inheritdoc/> 
+    public void Insert(int index, KeyCollectionPair<T> item)
+    {
+        collection.Insert(index, item);
+    }
+
+    /// <inheritdoc/> 
+    public bool Remove(KeyCollectionPair<T> item)
+    {
+        return collection.Remove(item);
+    }
+
+    /// <inheritdoc/> 
+    public void RemoveAt(int index)
+    {
+        collection.RemoveAt(index);
+    }
+
+    /// <inheritdoc/> 
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return (collection as IEnumerable).GetEnumerator();
+    }
+}

--- a/src/Pixel.Persistence.Core/Models/References/ProjectReferences.cs
+++ b/src/Pixel.Persistence.Core/Models/References/ProjectReferences.cs
@@ -20,5 +20,12 @@ namespace Pixel.Persistence.Core.Models
 
         [DataMember(IsRequired = true, Order = 50)]
         public List<PrefabReference> PrefabReferences { get; set; } = new();
+
+        [DataMember(IsRequired = true, Order = 60)]
+        public List<string> Fixtures { get; set; } = new();
+              
+        [DataMember(IsRequired = true, Order = 70)]
+        public GroupedCollection<string> TestDataSources { get; set; } = new();
+
     }
 }

--- a/src/Pixel.Persistence.Respository/Interfaces/IReferencesRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/IReferencesRepository.cs
@@ -81,7 +81,7 @@ public interface IReferencesRepository
     /// <param name="controlReference"></param>
     /// <returns></returns>
     Task<bool> HasPrefabReference(string projectId, string projectVersion, PrefabReference prefabReference);
-    
+
     /// <summary>
     /// Add PrefabReference for a given version of project
     /// </summary>
@@ -99,5 +99,72 @@ public interface IReferencesRepository
     /// <param name="prefabReference"></param>
     /// <returns></returns>
     Task UpdatePrefabReference(string projectId, string projectVersion, PrefabReference prefabReference);
+
+    /// <summary>
+    /// Add an entry for the fixtureId to the project references file. 
+    /// </summary>
+    /// <param name="projectId">Identifier of the project</param>
+    /// <param name="projectVersion">Version of the project</param>
+    /// <param name="fixtureId">Identifier of the fixture to add</param>
+    /// <returns></returns>
+    Task AddFixtureAsync(string projectId, string projectVersion, string fixtureId);
+
+    /// <summary>
+    /// Remove fixtureId from the project references file.
+    /// </summary>
+    /// <param name="projectId">Identifier of the project</param>
+    /// <param name="projectVersion">Version of the project</param>
+    /// <param name="fixtureId">Identifier of the fixture to remove</param>
+    /// <returns></returns>
+    Task DeleteFixtureAsync(string projectId, string projectVersion, string fixtureId);
+
+    /// <summary>
+    /// Add a new group for the test data source
+    /// </summary>
+    /// <param name="projectId">Identifier of the project</param>
+    /// <param name="projectVersion">Version of the project</param>
+    /// <param name="groupName">Name of the group to add</param>
+    /// <returns></returns>
+    Task AddDataSourceGroupAsync(string projectId, string projectVersion, string groupName);
+
+    /// <summary>
+    /// Rename an existing group for the test data source
+    /// </summary>
+    /// <param name="projectId">Identifier of the project</param>
+    /// <param name="projectVersion">Version of the project</param>
+    /// <param name="currentKey">Name of the existing group</param>
+    /// <param name="newKey">New name of the group</param>
+    /// <returns></returns>
+    Task RenameDataSourceGroupAsync(string projectId, string projectVersion, string currentKey, string newKey);
+
+    /// <summary>
+    /// Add a test data source identifier to specified group
+    /// </summary>
+    /// <param name="projectId"></param>
+    /// <param name="projectVersion"></param>
+    /// <param name="groupName"></param>
+    /// <param name="testDataSourceId"></param>
+    /// <returns></returns>
+    Task AddDataSourceToGroupAsync(string projectId, string projectVersion, string groupName, string testDataSourceId);
+
+    /// <summary>
+    /// Move data source from one group to another
+    /// </summary>
+    /// <param name="projectId"></param>
+    /// <param name="projectVersion"></param>
+    /// <param name="testDataSourceId"></param>
+    /// <param name="currentGroup"></param>
+    /// <param name="newGroup"></param>
+    /// <returns></returns>
+    Task MoveDataSourceToGroupAsync(string projectId, string projectVersion, string testDataSourceId, string currentGroup, string newGroup);
+
+    /// <summary>
+    /// Delete test data source identifier from specified group
+    /// </summary>
+    /// <param name="projectId"></param>
+    /// <param name="projectVersion"></param>    
+    /// <param name="testDataSourceId"></param>
+    /// <returns></returns>
+    Task DeleteDataSourceAsync(string projectId, string projectVersion, string testDataSourceId);
 
 }

--- a/src/Pixel.Persistence.Respository/Interfaces/ITestDataRepository.cs
+++ b/src/Pixel.Persistence.Respository/Interfaces/ITestDataRepository.cs
@@ -44,7 +44,7 @@ namespace Pixel.Persistence.Respository.Interfaces
         /// <param name="dataSource"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task AddDataSourceAsync(string projectId, string projectVersion, TestDataSource dataSource, CancellationToken cancellationToken);
+        Task AddDataSourceAsync(string projectId, string projectVersion, string groupName, TestDataSource dataSource, CancellationToken cancellationToken);
 
         /// <summary>
         /// Add multiple TestDataSources to a given version of project

--- a/src/Pixel.Persistence.Services.Api/Controllers/ReferencesController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/ReferencesController.cs
@@ -1,11 +1,10 @@
 ﻿using Dawn;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Schema;
 using Pixel.Persistence.Core.Models;
 using Pixel.Persistence.Respository;
 using Pixel.Persistence.Respository.Interfaces;
-using System.Security;
+using System;
 using System.Threading.Tasks;
 
 namespace Pixel.Persistence.Services.Api.Controllers
@@ -88,6 +87,52 @@ namespace Pixel.Persistence.Services.Api.Controllers
         {
             await this.referencesRepository.SetEditorReferences(projectId, projectVersion, editorReferences);
             return Ok();
+        }
+
+
+        [HttpPost("datasources/{projectId}/{projectVersion}/group/new/{groupName}")]
+        public async Task<IActionResult> AddDataSourceGroup(string projectId, string projectVersion, string groupName)
+        {
+            try
+            {
+                await this.referencesRepository.AddDataSourceGroupAsync(projectId, projectVersion, groupName);
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return BadRequest(ex.Message);
+            }
+        }
+
+        [HttpPost("datasources/{projectId}/{projectVersion}/group/rename/{currentKey}/to/{newKey}")]
+        public async Task<IActionResult> RenameDataSourceGroup(string projectId, string projectVersion, string currentKey, string newKey)
+        {
+            try
+            {
+                await this.referencesRepository.RenameDataSourceGroupAsync(projectId, projectVersion, currentKey, newKey);
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return BadRequest(ex.Message);
+            }
+        }
+
+        [HttpPost("datasources/{projectId}/{projectVersion}/{dataSourceId}/move/{currentGroup}/to/{newGroup}")]
+        public async Task<IActionResult> MoveDataSourceToGroup(string projectId, string projectVersion, string dataSourceId, string currentGroup, string newGroup)
+        {
+            try
+            {       
+                await this.referencesRepository.MoveDataSourceToGroupAsync(projectId, projectVersion, dataSourceId, currentGroup, newGroup);
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                return BadRequest(ex.Message);
+            }
         }
     }
 }

--- a/src/Pixel.Persistence.Services.Api/Controllers/TestDataController.cs
+++ b/src/Pixel.Persistence.Services.Api/Controllers/TestDataController.cs
@@ -77,15 +77,15 @@ namespace Pixel.Persistence.Services.Api.Controllers
             }
         }
 
-        [HttpPost("{projectId}/{projectVersion}")]
-        public async Task<ActionResult<TestDataSource>> AddDataSourceAsync(string projectId, string projectVersion, [FromBody] TestDataSource dataSource)
+        [HttpPost("{projectId}/{projectVersion}/{groupName}")]
+        public async Task<ActionResult<TestDataSource>> AddDataSourceAsync(string projectId, string projectVersion, string groupName, [FromBody] TestDataSource dataSource)
         {
             try
             {
                 Guard.Argument(dataSource, nameof(dataSource)).NotNull();
                 dataSource.ProjectId = Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
                 dataSource.ProjectVersion = Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
-                await testDataRepository.AddDataSourceAsync(projectId, projectVersion, dataSource, CancellationToken.None);
+                await testDataRepository.AddDataSourceAsync(projectId, projectVersion, groupName, dataSource, CancellationToken.None);
                 return Ok();
             }
             catch (Exception ex)

--- a/src/Pixel.Persistence.Services.Client/DataManagers/ProjectDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/DataManagers/ProjectDataManager.cs
@@ -702,12 +702,12 @@ public class TestAndFixtureAndTestDataManager : IProjectAssetsDataManager
     #region Test Data Source
 
     /// <inheritdoc/>  
-    public async Task<TestDataSource> AddTestDataSourceAsync(TestDataSource dataSource)
+    public async Task<TestDataSource> AddTestDataSourceAsync(string groupName, TestDataSource dataSource)
     {
         this.projectFileSystem.SaveToFile<TestDataSource>(dataSource, projectFileSystem.TestDataRepository, $"{dataSource.DataSourceId}.dat");
         if (IsOnlineMode)
         {
-            await this.testDataRepositoryClient.AddDataSourceAsync(this.automationProject.ProjectId, this.projectVersion.ToString(), dataSource);
+            await this.testDataRepositoryClient.AddDataSourceAsync(this.automationProject.ProjectId, this.projectVersion.ToString(), groupName, dataSource);
             await SaveTestDataSourceDataAsync(dataSource);
         }
         logger.Information("Added test data source : '{0}' to version : '{1}' of automation project : '{2}'.", dataSource.Name, projectVersion, automationProject.Name);

--- a/src/Pixel.Persistence.Services.Client/Interfaces/IProjectDataManager.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/IProjectDataManager.cs
@@ -217,13 +217,14 @@ public interface ITestFixtureManager
 
 public interface ITestDataManager
 {
-    
+
     /// <summary>
-    /// Add a new Test Data Source
+    /// Add a new Test Data Source to specified group
     /// </summary>
-    /// <param name="testCase"></param>
+    /// <param name="dataSource">Test data source to be added</param>
+    /// <param name="groupName">Name of the group to which data source should be added</param>
     /// <returns></returns>
-    Task<TestDataSource> AddTestDataSourceAsync(TestDataSource dataSource);
+    Task<TestDataSource> AddTestDataSourceAsync(string groupName, TestDataSource dataSource);
 
     /// <summary>
     /// Update an existing Test Data Source

--- a/src/Pixel.Persistence.Services.Client/Interfaces/IReferencesRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/IReferencesRepositoryClient.cs
@@ -49,4 +49,29 @@ public  interface IReferencesRepositoryClient
     /// <returns></returns>
     Task SetEditorReferencesAsync(string projectId, string projectVersion, EditorReferences editorReferences);
 
+
+    /// <summary>
+    /// Add a new group for test data source
+    /// </summary>
+    /// <param name="groupKey">name of the group</param>
+    /// <returns></returns>
+    Task AddTestDataSourceGroupAsync(string projectId, string projectVersion, string groupKey);
+
+    /// <summary>
+    /// Rename a test data source group
+    /// </summary>
+    /// <param name="currentKey">current group name</param>
+    /// <param name="newKey">new group name</param>
+    /// <returns></returns>
+    Task RenameTestDataSourceGroupAsync(string projectId, string projectVersion, string currentKey, string newKey);
+
+    /// <summary>
+    /// Move a test data souce to a new group
+    /// </summary>
+    /// <param name="testDataSourceId">Identifier of the test data source</param>
+    /// <param name="currentGroup">Name of current group</param>
+    /// <param name="newGroup">Name of new group</param>
+    /// <returns></returns>
+    Task MoveTestDataSourceToGroupAsync(string projectId, string projectVersion, string testDataSourceId, string currentGroup, string newGroup);
+
 }

--- a/src/Pixel.Persistence.Services.Client/Interfaces/ITestDataRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/Interfaces/ITestDataRepositoryClient.cs
@@ -39,9 +39,10 @@ namespace Pixel.Persistence.Services.Client
         /// </summary>
         /// <param name="projectId"></param>
         /// <param name="projectVersion"></param>
+        /// <param name="groupName"></param>
         /// <param name="testData"></param>
         /// <returns></returns>
-        Task<TestDataSource> AddDataSourceAsync(string projectId, string projectVersion, TestDataSource testData);
+        Task<TestDataSource> AddDataSourceAsync(string projectId, string projectVersion, string groupName, TestDataSource testData);
 
         /// <summary>
         /// Update an existing TestDataSource for a given version of project

--- a/src/Pixel.Persistence.Services.Client/ReferencesRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/ReferencesRepositoryClient.cs
@@ -98,5 +98,46 @@ public class ReferencesRepositoryClient : IReferencesRepositoryClient
         var client = this.clientFactory.GetOrCreateClient();
         await client.PostAsync<EditorReferences>(restRequest);
     }
-   
+
+    /// <inheritdoc/>  
+    public async Task AddTestDataSourceGroupAsync(string projectId, string projectVersion, string groupKey)
+    {
+        Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
+        Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
+        Guard.Argument(groupKey, nameof(groupKey)).NotNull();
+        
+        RestRequest restRequest = new RestRequest($"references/datasources/{projectId}/{projectVersion}/group/new/{groupKey}");     
+        var client = this.clientFactory.GetOrCreateClient();    
+        var result = await client.ExecuteAsync(restRequest, Method.Post);
+        result.EnsureSuccess();
+    }
+
+    /// <inheritdoc/>  
+    public async Task RenameTestDataSourceGroupAsync(string projectId, string projectVersion, string currentKey, string newKey)
+    {
+        Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
+        Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
+        Guard.Argument(currentKey, nameof(currentKey)).NotNull().NotWhiteSpace();
+        Guard.Argument(newKey, nameof(newKey)).NotNull().NotWhiteSpace();
+
+        RestRequest restRequest = new RestRequest($"references/datasources/{projectId}/{projectVersion}/group/rename/{currentKey}/to/{newKey}");
+        var client = this.clientFactory.GetOrCreateClient();
+        var result = await client.ExecuteAsync(restRequest, Method.Post);
+        result.EnsureSuccess();
+    }
+
+    /// <inheritdoc/>  
+    public async Task MoveTestDataSourceToGroupAsync(string projectId, string projectVersion, string testDataSourceId, string currentGroup, string newGroup)
+    {
+        Guard.Argument(projectId, nameof(projectId)).NotNull().NotEmpty();
+        Guard.Argument(projectVersion, nameof(projectVersion)).NotNull().NotEmpty();
+        Guard.Argument(testDataSourceId, nameof(testDataSourceId)).NotNull().NotEmpty();
+        Guard.Argument(currentGroup, nameof(currentGroup)).NotNull().NotWhiteSpace();
+        Guard.Argument(newGroup, nameof(newGroup)).NotNull().NotWhiteSpace();
+
+        RestRequest restRequest = new RestRequest($"references/datasources/{projectId}/{projectVersion}/{testDataSourceId}/move/{currentGroup}/to/{newGroup}");
+        var client = this.clientFactory.GetOrCreateClient();
+        var result = await client.ExecuteAsync(restRequest, Method.Post);
+        result.EnsureSuccess();
+    }
 }

--- a/src/Pixel.Persistence.Services.Client/TestDataRepositoryClient.cs
+++ b/src/Pixel.Persistence.Services.Client/TestDataRepositoryClient.cs
@@ -91,10 +91,10 @@ public class TestDataRepositoryClient : ITestDataRepositoryClient
     }
 
     /// <inheritdoc/>
-    public async Task<TestDataSource> AddDataSourceAsync(string projectId, string projectVersion, TestDataSource testData)
+    public async Task<TestDataSource> AddDataSourceAsync(string projectId, string projectVersion, string groupName, TestDataSource testData)
     {
         Guard.Argument(testData).NotNull();
-        RestRequest restRequest = new RestRequest($"testdata/{projectId}/{projectVersion}");
+        RestRequest restRequest = new RestRequest($"testdata/{projectId}/{projectVersion}/{groupName}");
         restRequest.AddJsonBody(testData);
         var client = this.clientFactory.GetOrCreateClient();
         var result = await client.PostAsync<TestDataSource>(restRequest);


### PR DESCRIPTION
**Description**
1. It is now possible to create groups for test data source. This will improve project load time when there are huge number of data sources. Also, grouping should help to manage them better. Search might have to be improved as it works on data sources loaded in view only.
2. Whenever a new fixture or data source is created or delete, an entry will be made in the project references file. This will act as the source of truth for fixtures and data sources belonging to a particular version of the project.