### PR TITLE
Prefabs can't be created by drag drop anymore

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/NewPrefabViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Prefab/NewPrefabViewModel.cs
@@ -1,0 +1,109 @@
+﻿using Dawn;
+using Pixel.Automation.AppExplorer.ViewModels.Application;
+using Pixel.Automation.Core;
+using Pixel.Automation.Core.Interfaces;
+using Pixel.Automation.Core.Models;
+using Pixel.Automation.Editor.Core;
+using Pixel.Persistence.Services.Client.Interfaces;
+using Serilog;
+using System.Diagnostics;
+using System.IO;
+
+namespace Pixel.Automation.AppExplorer.ViewModels.Prefab;
+
+public class NewPrefabViewModel : SmartScreen
+{
+    private readonly ILogger logger = Log.ForContext<NewPrefabViewModel>();
+
+    private readonly ApplicationDescriptionViewModel application;  
+    private readonly IPrefabDataManager prefabDataManager;  
+    private List<PrefabProject> existingProjects = new List<PrefabProject>();
+
+    public PrefabProject NewProject { get; }
+
+    public string Name
+    {
+        get => this.NewProject.Name;
+        set
+        {
+            value = value ?? string.Empty;
+            this.NewProject.Name = value;
+            ValidateProjectName(value);
+            NotifyOfPropertyChange(() => Name);
+            NotifyOfPropertyChange(() => CanCreateNewProject);
+        }
+    }
+
+    public NewPrefabViewModel(ApplicationDescriptionViewModel application, IPrefabDataManager prefabDataManager)
+    {
+        this.DisplayName = "Create New Project";
+
+        this.application = Guard.Argument(application, nameof(application)).NotNull().Value;        
+        this.prefabDataManager = Guard.Argument(prefabDataManager, nameof(prefabDataManager)).NotNull().Value;       
+        Version defaultVersion = new Version(1, 0, 0, 0);
+        this.NewProject = new PrefabProject()
+        {
+            ApplicationId = application.ApplicationId
+        };
+        this.NewProject.AvailableVersions.Add(new VersionInfo(defaultVersion) { IsActive = true });
+
+        this.existingProjects.AddRange(this.prefabDataManager.GetAllPrefabs(this.application.ApplicationId));
+
+    }
+
+    public async Task CreatePrefabProject()
+    {
+        using (var activity = Telemetry.DefaultSource?.StartActivity(nameof(CreatePrefabProject), ActivityKind.Internal))
+        {
+            try
+            {
+                this.NewProject.Name = this.NewProject.Name.Trim();
+                this.NewProject.Namespace = $"{Constants.NamespacePrefix}.{this.NewProject.Name.Replace(' ', '.')}";
+                activity?.SetTag("ProjectName", this.NewProject.Name);
+                activity?.SetTag("Namespace", this.NewProject.Namespace);              
+                await this.prefabDataManager.AddPrefabToScreenAsync(this.NewProject, application.ScreenCollection.SelectedScreen.ScreenId);   
+                logger.Information("Created new prefab project : '{0}' for application : '{1}'", this.Name, this.application.ApplicationName);
+                await this.TryCloseAsync(true);
+            }
+            catch (Exception ex)
+            {
+                logger.Warning("There was an error while trying to create new project : {0}", this.NewProject.Name);
+                logger.Error(ex.Message, ex);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                await this.TryCloseAsync(false);
+            }
+        }
+    }
+
+    public bool CanCreateNewProject
+    {
+        get
+        {
+            return !this.HasErrors && !string.IsNullOrEmpty(this.Name) && !!IsNameAvailable(this.Name);
+        }
+
+    }
+
+    public void ValidateProjectName(string projectName)
+    {
+        ClearErrors(nameof(Name));
+        ValidateRequiredProperty(nameof(Name), projectName);
+        ValidatePattern("^([A-Za-z]|[_ ]){4,}$", nameof(Name), projectName, "Name must contain only alphabets or ' ' or '_' and should be atleast 4 characters in length.");
+        if (!IsNameAvailable(projectName))
+        {
+            this.AddOrAppendErrors(nameof(Name), "An application already exists with this name");
+        }
+
+    }
+
+    private bool IsNameAvailable(string projectName)
+    {
+        return !this.existingProjects.Any(a => a.Name.Equals(projectName));
+    }
+
+    public async void Cancel()
+    {
+        await this.TryCloseAsync(false);
+    }
+
+}

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDragHandler.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabBuilder/PrefabDragHandler.cs
@@ -7,42 +7,41 @@ using Pixel.Automation.Editor.Core.ViewModels;
 using Serilog;
 using System.Windows;
 
-namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder
-{
-    public class PrefabDragHandler : IDropTarget
-    {
-        private readonly ILogger logger = Log.ForContext<PrefabDragHandler>();
-        public void DragOver(IDropInfo dropInfo)
-        {
-            if (dropInfo.Data != null)
-            {
-                if (dropInfo.Data is EntityComponentViewModel ecvm)
-                {
-                    if ((ecvm.Model is PrefabEntity) || (ecvm.Model is Entity e
-                        && e.GetFirstComponentOfType<PrefabEntity>(SearchScope.Descendants, false) != null))
-                    {                       
-                        return;
-                    }
-                    dropInfo.DropTargetAdorner = DropTargetAdorners.Highlight;
-                    dropInfo.Effects = DragDropEffects.Copy;
-                }
-            }
-        }
+namespace Pixel.Automation.AppExplorer.ViewModels.PrefabBuilder;
 
-        public void Drop(IDropInfo dropInfo)
-        {
-            try
-            {
-                if (dropInfo.Data is EntityComponentViewModel sourceItem)
-                {
-                    var prefabExplorer = (dropInfo.VisualTarget as FrameworkElement).DataContext as PrefabExplorerViewModel;
-                    _ = prefabExplorer.CreatePrefab(sourceItem.Model as Entity);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex, ex.Message);
-            }
-        }
-    }
-}
+//public class PrefabDragHandler : IDropTarget
+//{
+//    private readonly ILogger logger = Log.ForContext<PrefabDragHandler>();
+//    public void DragOver(IDropInfo dropInfo)
+//    {
+//        if (dropInfo.Data != null)
+//        {
+//            if (dropInfo.Data is EntityComponentViewModel ecvm)
+//            {
+//                if ((ecvm.Model is PrefabEntity) || (ecvm.Model is Entity e
+//                    && e.GetFirstComponentOfType<PrefabEntity>(SearchScope.Descendants, false) != null))
+//                {                       
+//                    return;
+//                }
+//                dropInfo.DropTargetAdorner = DropTargetAdorners.Highlight;
+//                dropInfo.Effects = DragDropEffects.Copy;
+//            }
+//        }
+//    }
+
+//    public void Drop(IDropInfo dropInfo)
+//    {
+//        try
+//        {
+//            if (dropInfo.Data is EntityComponentViewModel sourceItem)
+//            {
+//                var prefabExplorer = (dropInfo.VisualTarget as FrameworkElement).DataContext as PrefabExplorerViewModel;
+//                _ = prefabExplorer.CreatePrefab(sourceItem.Model as Entity);
+//            }
+//        }
+//        catch (Exception ex)
+//        {
+//            logger.Error(ex, ex.Message);
+//        }
+//    }
+//}

--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/NewPrefabView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/NewPrefabView.xaml
@@ -1,0 +1,37 @@
+﻿<Controls:MetroWindow x:Class="Pixel.Automation.AppExplorer.Views.Prefab.NewPrefabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"               
+             mc:Ignorable="d"  ResizeMode="NoResize" SizeToContent="WidthAndHeight"
+             WindowStartupLocation="CenterScreen"  ShowCloseButton="False"
+             IsMinButtonEnabled="False" Title="Create New Prefab" GlowBrush="{DynamicResource AccentColorBrush}">
+    <Controls:MetroWindow.Resources>
+        <ResourceDictionary>
+            <Thickness x:Key="ControlMargin">10 10 10 10</Thickness>
+        </ResourceDictionary>
+    </Controls:MetroWindow.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+        </Grid.RowDefinitions>
+        <DockPanel LastChildFill="True" MinWidth="320" Grid.Row="0" Margin="10,20,10,20">
+            <Label Content="Name" MinWidth="80" DockPanel.Dock="Left" VerticalAlignment="Center" ></Label>
+            <TextBox DockPanel.Dock="Right" VerticalAlignment="Center"
+                         Text="{Binding Name,ValidatesOnNotifyDataErrors=True,UpdateSourceTrigger=PropertyChanged}"
+                         Controls:TextBoxHelper.Watermark="Prefab Name"
+                         Controls:TextBoxHelper.UseFloatingWatermark="True"
+                         Controls:TextBoxHelper.IsWaitingForData="True"                                   
+                         ToolTip="Project Name" />
+        </DockPanel>
+        <DockPanel LastChildFill="False"  Grid.Row="1">
+            <Border DockPanel.Dock="Top" BorderThickness="1" Height="1" HorizontalAlignment="Stretch" 
+                    Width="{Binding Path=Width,RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type DockPanel}}}" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+            <Button x:Name="Cancel" Content="CANCEL" Width="100" DockPanel.Dock="Right"  Margin="{StaticResource ControlMargin}" Style="{DynamicResource MahApps.Styles.Button.Square}"/>
+            <Button x:Name="CreatePrefabProject" Content="CREATE" DockPanel.Dock="Right" Width="100" Margin="0,10,0,10"  Style="{DynamicResource MahApps.Styles.Button.Square.Accent}"/>
+        </DockPanel>
+    </Grid>
+</Controls:MetroWindow>
+

--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/NewPrefabView.xaml.cs
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/NewPrefabView.xaml.cs
@@ -1,0 +1,12 @@
+﻿namespace Pixel.Automation.AppExplorer.Views.Prefab;
+
+/// <summary>
+/// Interaction logic for NewPrefabView.xaml
+/// </summary>
+public partial class NewPrefabView
+{
+    public NewPrefabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml
@@ -150,8 +150,14 @@
                 <Button x:Name="BackButton" Margin="0,0,2,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"                                          
                                             Height="28" Width="28" ToolTip="Go back to application view"                                                                                      
                                             cal:Message.Attach="[Event Click] = [Action GoBack()]"
-                                            Style="{StaticResource BackButton}"/>             
-              
+                                            Style="{StaticResource BackButton}"/>
+                <Separator Width="1" Margin="10,0,0,0" BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
+                <Button x:Name="AddPrefabButton" Margin="0,0,2,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"                                          
+                            Height="28" Width="28" ToolTip="Create a new prefab project"                                                                                    
+                            cal:Message.Attach="[Event Click] = [Action AddPrefab(ApplicationIcon.DataContext)]"
+                            Style="{StaticResource EditControlButtonStyle}"
+                            Content="{iconPacks:Entypo AddToList, Width=24, Height=24}"/>
+
             </StackPanel>
             <Separator Width="1" Margin="10,0,10,0" BorderThickness="2" BorderBrush="{DynamicResource MahApps.Brushes.Accent}" DockPanel.Dock="Left"/>
             <!-- Screen management on right-->
@@ -175,8 +181,7 @@
       
         <ListBox  x:Name="Prefabs" Grid.Row="1" SelectedItem="{Binding SelectedPrefab}"
                           ItemTemplate="{StaticResource PrefabItemTemplate}"
-                          ItemContainerStyle="{StaticResource PrefabListBoxItem}"
-                          dd:DragDrop.IsDropTarget="True"  dd:DragDrop.DropHandler="{Binding PrefabDragHandler}"
+                          ItemContainerStyle="{StaticResource PrefabListBoxItem}"                       
                           dd:DragDrop.IsDragSource="True" 
                           Width="{Binding Path=Width, RelativeSource={RelativeSource AncestorType={x:Type StackPanel}}}"
                           MinHeight="300"

--- a/src/Pixel.Automation.Core/Models/PrefabProject.cs
+++ b/src/Pixel.Automation.Core/Models/PrefabProject.cs
@@ -18,7 +18,7 @@ namespace Pixel.Automation.Core.Models
 
         [DataMember(IsRequired = true, Order = 20)]
         [Browsable(false)]
-        public string ProjectId { get; set; }
+        public string ProjectId { get; set; } = Guid.NewGuid().ToString();
 
         /// <summary>
         /// Display name that should be visible in Prefab Repository

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
@@ -194,7 +194,7 @@ namespace Pixel.Automation.Designer.ViewModels
                 try
                 {
                     await projectManager.Save();
-                    await notificationManager.ShowSuccessNotificationAsync("Project was saved.");
+                    await notificationManager.ShowSuccessNotificationAsync($"Project : '{this.PrefabProject.Name}' was saved.");
                 }
                 catch (Exception ex)
                 {

--- a/src/Pixel.Automation.Designer.ViewModels/Modules/ViewModules.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Modules/ViewModules.cs
@@ -32,8 +32,8 @@ namespace Pixel.Automation.Designer.ViewModels.Modules
           
             Kernel.Bind<IControlEditorFactory>().To<ControlEditorFactory>();
            
-            Kernel.Bind<IPrefabBuilder>().To<PrefabBuilderViewModel>();
-            Kernel.Bind<IPrefabBuilderFactory>().ToFactory();
+            //Kernel.Bind<IPrefabBuilder>().To<PrefabBuilderViewModel>();
+            //Kernel.Bind<IPrefabBuilderFactory>().ToFactory();
 
             Kernel.Bind<IArgumentExtractor>().To<ArgumentExtractor>().InSingletonScope();
             Kernel.Bind<IScriptExtactor>().To<ScriptExtractor>().InSingletonScope();

--- a/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
+++ b/src/Pixel.Automation.Designer.Views/Resources/Styles.xaml
@@ -47,7 +47,7 @@
             <Setter.Value>
                 <ControlTemplate>
                     <StackPanel Orientation="Horizontal">
-                        <Rectangle Fill="{DynamicResource MahApps.Brushes.Accent}" Width="28" Height="28">
+                        <Rectangle Fill="{DynamicResource MahApps.Brushes.Accent}" Width="24" Height="24">
                             <Rectangle.OpacityMask>
                                 <VisualBrush Visual="{iconPacks:FontAwesome Kind=ArrowAltCircleLeftRegular}" Stretch="Fill" />
                             </Rectangle.OpacityMask>

--- a/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Prefab/PrefabExplorerViewModelFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.AppExplorer.ViewModels.Tests/Prefab/PrefabExplorerViewModelFixture.cs
@@ -26,8 +26,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         private IEventAggregator eventAggregator;
         private IVersionManagerFactory versionManagerFactory;
         private IApplicationDataManager applicationDataManager;
-        private IPrefabDataManager prefabDataManager;
-        private IPrefabBuilderFactory prefabBuilderFactory;
+        private IPrefabDataManager prefabDataManager;     
 
         [OneTimeSetUp]
         public void SetUp()
@@ -35,8 +34,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
             windowManager = Substitute.For<IWindowManager>();
             notificationManager = Substitute.For<INotificationManager>();
             eventAggregator = Substitute.For<IEventAggregator>();
-            versionManagerFactory = Substitute.For<IVersionManagerFactory>();
-            prefabBuilderFactory = Substitute.For<IPrefabBuilderFactory>();          
+            versionManagerFactory = Substitute.For<IVersionManagerFactory>();                   
             applicationDataManager = Substitute.For<IApplicationDataManager>();
             prefabDataManager = Substitute.For<IPrefabDataManager>();
 
@@ -52,11 +50,10 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         public void ValidateThatPrefabExplorerViewModelCanBeCorrectlyInitialized()
         {
             var prefabExplorer = new PrefabExplorerViewModel(eventAggregator, windowManager, notificationManager,
-                versionManagerFactory, applicationDataManager, prefabDataManager, prefabBuilderFactory);
+                versionManagerFactory, applicationDataManager, prefabDataManager);
 
             Assert.AreEqual("Prefab Explorer", prefabExplorer.DisplayName);
-            Assert.AreEqual(0, prefabExplorer.Prefabs.Count);
-            Assert.IsNotNull(prefabExplorer.PrefabDragHandler);
+            Assert.AreEqual(0, prefabExplorer.Prefabs.Count);      
             Assert.IsNull(prefabExplorer.SelectedPrefab);
         }
 
@@ -68,7 +65,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         public void ValidateThatPrefabsAreLoadedWhenApplicationIsActivated()
         {
             var prefabExplorer = new PrefabExplorerViewModel(eventAggregator, windowManager, notificationManager,
-                versionManagerFactory, applicationDataManager, prefabDataManager, prefabBuilderFactory);
+                versionManagerFactory, applicationDataManager, prefabDataManager);
             var applicationDescription = CreateApplicationDescription();
             prefabExplorer.SetActiveApplication(CreateApplicationDescriptionViewModel(applicationDescription));
 
@@ -96,7 +93,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
             versionManagerFactory.CreatePrefabVersionManager(Arg.Any<PrefabProject>()).Returns(versionManager);
             
             var prefabExplorer = new PrefabExplorerViewModel(eventAggregator, windowManager, notificationManager,
-                versionManagerFactory, applicationDataManager, prefabDataManager, prefabBuilderFactory);
+                versionManagerFactory, applicationDataManager, prefabDataManager);
             var applicationDescription = CreateApplicationDescription();
             prefabExplorer.SetActiveApplication(CreateApplicationDescriptionViewModel(applicationDescription));
             var prefabToManage = prefabExplorer.Prefabs.First();
@@ -113,8 +110,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Tests
         {
             windowManager.ClearReceivedCalls();
             eventAggregator.ClearReceivedCalls();
-            versionManagerFactory.ClearReceivedCalls();
-            prefabBuilderFactory.ClearReceivedCalls();
+            versionManagerFactory.ClearReceivedCalls();        
             applicationDataManager.ClearReceivedCalls();
         }
 

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/PrefabDescriptionFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Models/PrefabDescriptionFixture.cs
@@ -16,7 +16,7 @@ namespace Pixel.Automation.Core.Tests.Models
             var prefabProject = new PrefabProject(prefabRoot);
 
             Assert.AreEqual(null, prefabProject.ApplicationId);
-            Assert.AreEqual(null, prefabProject.ProjectId);
+            Assert.IsNotNull(prefabProject.ProjectId);
             Assert.AreEqual(null, prefabProject.Name);
             Assert.AreEqual(null, prefabProject.Namespace);
             Assert.NotNull(prefabProject.AvailableVersions);


### PR DESCRIPTION
**Description**
1. To create a prefab, we need to drag drop an entity from designer to the prefab explorer pane.
2. This starts a wizard that goes through several steps and creates the required prefab.
3. This is very complex as it needs to generate data models, identify scripts used, update scripts and move them, etc.
4. There are always edge cases that doesn't work well specially when entity that is used to create prefabs has multiple scripts.
5. We will remove this feature now to avoid complexity

We now have a add button on prefab explorer that creates an empty prefab project for the active application. The prefab project can be setup by editing it and then a publish version can be use in automation project same as before. This also promotes some good practises like avoiding unnecessary fields in prefab data model and declare them in script instead to limit visibility outside prefab process.