### PR TITLE
Editable combo box for screens and show all on clear

### DIFF
--- a/src/Pixel.Automation.AppExplorer.ViewModels/Control/ControlExplorerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/Control/ControlExplorerViewModel.cs
@@ -124,7 +124,12 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Control
             groupedItems.SortDescriptions.Add(new SortDescription(nameof(ControlDescriptionViewModel.ControlName), ListSortDirection.Ascending));
             groupedItems.Filter = new Predicate<object>((a) =>
             {
-                return (a as ControlDescriptionViewModel).ControlName.ToLower().Contains(this.filterText.ToLower());
+                if(a is ControlDescriptionViewModel controlDescription)
+                {
+                    return controlDescription.ControlName.Contains(this.filterText, StringComparison.OrdinalIgnoreCase) ||
+                            controlDescription.GroupName.Contains(this.filterText, StringComparison.OrdinalIgnoreCase);
+                }
+                return false;
             });
         }
 
@@ -236,11 +241,18 @@ namespace Pixel.Automation.AppExplorer.ViewModels.Control
                     this.Controls.Clear();
                     activity?.SetTag("SelectedScreen", selectedScreen?.ScreenName ?? string.Empty);
                     if (selectedScreen != null)
-                    {                       
-                        var controlsForSelectedScreen = LoadControlDetails(this.ActiveApplication, selectedScreen);
-                        this.Controls.Clear();
+                    {  
+                        var controlsForSelectedScreen = LoadControlDetails(this.ActiveApplication, selectedScreen);                       
                         this.Controls.AddRange(controlsForSelectedScreen);                   
-                    }               
+                    }    
+                    else
+                    {
+                        foreach (var screen in this.activeApplication.Screens)
+                        {
+                            var controlsForScren = LoadControlDetails(this.ActiveApplication, screen);
+                            this.Controls.AddRange(controlsForScren);
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml
@@ -146,7 +146,10 @@
             <Separator Width="1" Margin="10,0,10,0" BorderThickness="2" BorderBrush="{DynamicResource MahApps.Brushes.Accent}" DockPanel.Dock="Left"/>
             <!-- Screen management on right-->
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" DockPanel.Dock="Left">
-                <ComboBox x:Name="Screens" ItemsSource="{Binding ScreenCollection.Screens}" SelectedItem="{Binding ScreenCollection.SelectedScreen}" DisplayMemberPath="ScreenName" MinWidth="180" Style="{DynamicResource MahApps.Styles.ComboBox}"/>
+                <ComboBox x:Name="Screens" ItemsSource="{Binding ScreenCollection.Screens}" SelectedItem="{Binding ScreenCollection.SelectedScreen}" 
+                          DisplayMemberPath="ScreenName" MinWidth="180"  controls:TextBoxHelper.UseFloatingWatermark="True"
+                          controls:TextBoxHelper.ClearTextButton="True" IsEditable="True"
+                          Style="{DynamicResource MahApps.Styles.ComboBox}"/>
                 <Separator Width="1" Margin="10,0,0,0" BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
                 <Button x:Name="AddScreenButton" Margin="0,0,2,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"                                          
                                             Height="28" Width="28" ToolTip="Create a new application screen"                                                                                    
@@ -167,7 +170,7 @@
                           ItemTemplate="{StaticResource ControlItemTemplate}"
                           Width="{Binding Path=Width, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}"
                           ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-            <ListBox.GroupStyle>
+            <!--<ListBox.GroupStyle>
                 <GroupStyle>
                     <GroupStyle.HeaderTemplate>
                         <DataTemplate>
@@ -191,7 +194,7 @@
                         </Style>
                     </GroupStyle.ContainerStyle>
                 </GroupStyle>
-            </ListBox.GroupStyle>
+            </ListBox.GroupStyle>-->
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
                     <WrapPanel  IsItemsHost="True"  Width="{Binding Path=Width, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" Orientation="Horizontal"/>

--- a/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml.cs
+++ b/src/Pixel.Automation.AppExplorer.Views/Control/ControlExplorerView.xaml.cs
@@ -1,28 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
-namespace Pixel.Automation.AppExplorer.Views.Control
+namespace Pixel.Automation.AppExplorer.Views.Control;
+
+/// <summary>
+/// Interaction logic for ControlExplorerView.xaml
+/// </summary>
+public partial class ControlExplorerView : UserControl
 {
-    /// <summary>
-    /// Interaction logic for ControlExplorerView.xaml
-    /// </summary>
-    public partial class ControlExplorerView : UserControl
+    public ControlExplorerView()
     {
-        public ControlExplorerView()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
     }
 }

--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml
@@ -162,7 +162,10 @@
             <Separator Width="1" Margin="10,0,10,0" BorderThickness="2" BorderBrush="{DynamicResource MahApps.Brushes.Accent}" DockPanel.Dock="Left"/>
             <!-- Screen management on right-->
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" DockPanel.Dock="Left">
-                <ComboBox x:Name="Screens" ItemsSource="{Binding ScreenCollection.Screens}" SelectedItem="{Binding ScreenCollection.SelectedScreen}" DisplayMemberPath="ScreenName" MinWidth="180" Style="{DynamicResource MahApps.Styles.ComboBox}"/>
+                <ComboBox x:Name="Screens" ItemsSource="{Binding ScreenCollection.Screens}" SelectedItem="{Binding ScreenCollection.SelectedScreen}" 
+                              DisplayMemberPath="ScreenName" MinWidth="180"  controls:TextBoxHelper.UseFloatingWatermark="True"
+                              controls:TextBoxHelper.ClearTextButton="True" IsEditable="True"
+                              Style="{DynamicResource MahApps.Styles.ComboBox}"/>
                 <Separator Width="1" Margin="10,0,0,0" BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Accent}"/>
                 <Button x:Name="AddScreenButton" Margin="0,0,2,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"                                          
                                             Height="28" Width="28" ToolTip="Create a new application screen"                                                                                    
@@ -187,7 +190,7 @@
                           MinHeight="300"
                           HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                           ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-            <ListBox.GroupStyle>
+            <!--<ListBox.GroupStyle>
                 <GroupStyle>
                     <GroupStyle.HeaderTemplate>
                         <DataTemplate>
@@ -211,7 +214,7 @@
                         </Style>
                     </GroupStyle.ContainerStyle>
                 </GroupStyle>
-            </ListBox.GroupStyle>
+            </ListBox.GroupStyle>-->
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
                     <WrapPanel  IsItemsHost="True"  Width="{Binding Path=Width, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" Orientation="Horizontal"/>

--- a/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml.cs
+++ b/src/Pixel.Automation.AppExplorer.Views/Prefab/PrefabExplorerView.xaml.cs
@@ -1,28 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
-namespace Pixel.Automation.AppExplorer.Views.Prefab
+namespace Pixel.Automation.AppExplorer.Views.Prefab;
+
+/// <summary>
+/// Interaction logic for PrefabExplorerView.xaml
+/// </summary>
+public partial class PrefabExplorerView : UserControl
 {
-    /// <summary>
-    /// Interaction logic for PrefabExplorerView.xaml
-    /// </summary>
-    public partial class PrefabExplorerView : UserControl
+    public PrefabExplorerView()
     {
-        public PrefabExplorerView()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
     }
 }


### PR DESCRIPTION
1. Combo box is editable now with auto completion for application screens
2. Clearing the screen will show all controls / prefabs
3. Removed grouping on control and prefab explore as screen serves a similar purpose
4. Filter now matches group name in addition to name for controls and filters