### PR TITLE
Load all test cases on show usage

### DIFF
--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
@@ -219,18 +219,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                 }
             }          
         }
-
-        private bool canLoadAllTestCases = true;
-        public bool CanLoadAllTestCases
-        {
-            get => this.canLoadAllTestCases;
-            set
-            {
-                this.canLoadAllTestCases = value;
-                NotifyOfPropertyChange();
-            }
-        }
-
+      
         /// <summary>
         /// Load test cases for all the fixtures
         /// </summary>
@@ -245,8 +234,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                     {
                         await LoadTestCasesForFixture(fixtureViewModel);
                     }
-                }
-                this.CanLoadAllTestCases = false;
+                }                
             }           
         }
 
@@ -1476,6 +1464,10 @@ namespace Pixel.Automation.TestExplorer.ViewModels
         /// <returns></returns>
         public async Task HandleAsync(TestFilterNotification message, CancellationToken cancellationToken)
         {
+            if(this.TestFixtures.Any(a => !a.Tests.Any()))
+            {
+                await LoadAllTestCases();
+            }
             this.FilterText = message?.FilterText ?? string.Empty;
             await Task.CompletedTask;
         }

--- a/src/Pixel.Automation.TestExplorer.Views/TestExplorerView.xaml
+++ b/src/Pixel.Automation.TestExplorer.Views/TestExplorerView.xaml
@@ -286,13 +286,7 @@
                                             IsEnabled="{Binding CanSaveAll, FallbackValue=false}"                                          
                                             cal:Message.Attach="[Event Click] = [Action SaveAllOpenTests()]"                       
                                             Style="{StaticResource EditControlButtonStyle}"
-                                            Content="{iconPacks:MaterialLight ContentSaveAll}"/>
-                <Button x:Name="LoadAllTestCases" Margin="0,0,2,0" HorizontalAlignment="Right"  VerticalAlignment="Center"
-                               Height="20" Width="20" ToolTip="Load all the test cases"    
-                               IsEnabled="{Binding CanLoadAllTestCases, FallbackValue=false}"                                          
-                               cal:Message.Attach="[Event Click] = [Action LoadAllTestCases()]"                       
-                               Style="{StaticResource EditControlButtonStyle}"
-                               Content="{iconPacks:Material CircleExpand}"/>
+                                            Content="{iconPacks:MaterialLight ContentSaveAll}"/>             
             </StackPanel>
         </StackPanel>
 


### PR DESCRIPTION
1. Remove the load all button added earlier on test explorer to load all test cases
2. All the test cases will be loaded by default when show usage option is used on any control or prefab