### PR TITLE
Reset components where required

### DIFF
--- a/src/Pixel.Automation.Core.Components/Loops/DoWhileLoopEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Loops/DoWhileLoopEntity.cs
@@ -74,11 +74,7 @@ public class DoWhileLoopEntity : Entity, ILoop
                 break;
             }
 
-            //Reset any inner loop before running next iteration
-            foreach (var loop in this.GetInnerLoops())
-            {
-                (loop as Entity).ResetHierarchy();
-            }
+            this.ResetDescendants();
 
             iteration++;
         }

--- a/src/Pixel.Automation.Core.Components/Loops/ForEachLoopEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Loops/ForEachLoopEntity.cs
@@ -110,6 +110,7 @@ public class ForEachLoopEntity : Entity, ILoop , IScopedEntity
 
     public override void ResetComponent()
     {
+        base.ResetComponent();
         this.ExitCriteriaSatisfied = false;
     }
 

--- a/src/Pixel.Automation.Core.Components/Loops/ForEachLoopEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Loops/ForEachLoopEntity.cs
@@ -96,11 +96,7 @@ public class ForEachLoopEntity : Entity, ILoop , IScopedEntity
                     yield return iterator.Current;
                 }
 
-                //Reset any inner loop before running next iteration
-                foreach (var loop in this.GetInnerLoops())
-                {
-                    (loop as Entity).ResetHierarchy();
-                }
+                this.ResetDescendants();
             }
             index++;
         }

--- a/src/Pixel.Automation.Core.Components/Loops/ForLoopEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Loops/ForLoopEntity.cs
@@ -97,11 +97,7 @@ public class ForLoopEntity : Entity, ILoop
                 yield return iterator.Current;
             }
 
-            //Reset any inner loop before running next iteration
-            foreach (var loop in this.GetInnerLoops())
-            {
-                (loop as Entity).ResetHierarchy();
-            }
+            this.ResetDescendants();
 
             iteration++;
 

--- a/src/Pixel.Automation.Core.Components/Loops/WhileLoopEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Loops/WhileLoopEntity.cs
@@ -74,12 +74,8 @@ public class WhileLoopEntity : Entity, ILoop
             {
                 yield return iterator.Current;                   
             }
-            
-            //Reset any inner loop before running next iteration
-            foreach (var loop in this.GetInnerLoops())
-            {                   
-                (loop as Entity).ResetHierarchy();
-            }
+
+            this.ResetDescendants();
 
             iteration++;
         }

--- a/src/Pixel.Automation.Core.Components/Processors/SequentialEntityProcessor.cs
+++ b/src/Pixel.Automation.Core.Components/Processors/SequentialEntityProcessor.cs
@@ -36,9 +36,10 @@ public class SequentialEntityProcessor : EntityProcessor
     /// <inheritdoc/>
     public override async Task BeginProcessAsync()
     {
-        await ConfigureDelay();
-        await ProcessEntity(this);
+        ResetComponents();
         ResetDelay();
+        await ConfigureDelay();
+        await ProcessEntity(this);       
     }
 
     private async Task ConfigureDelay()

--- a/src/Pixel.Automation.Core.Components/Sequences/RetrySequence.cs
+++ b/src/Pixel.Automation.Core.Components/Sequences/RetrySequence.cs
@@ -62,6 +62,7 @@ public class RetrySequence : EntityProcessor
             }              
             var retry = this.GetComponentsByName("Retry", Enums.SearchScope.Children).FirstOrDefault() as Entity;
             await this.ProcessEntity(retry);
+            ResetComponents();
             logger.Information($"Number of remaining attempts is {retryCount - currentAttempt}");
         });
 

--- a/src/Pixel.Automation.Core/Component/EntityHelpers.cs
+++ b/src/Pixel.Automation.Core/Component/EntityHelpers.cs
@@ -4,7 +4,6 @@ using Pixel.Automation.Core.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Pixel.Automation.Core
 {
@@ -300,35 +299,23 @@ namespace Pixel.Automation.Core
             }
             rootEntity.ResetComponent();
         }
-       
+
         /// <summary>
-        /// Get all child components that implement ILoop
+        /// Reset all the descendant components of the entity but not the entity itself
         /// </summary>
         /// <param name="rootEntity"></param>
-        /// <returns></returns>
-        public static IEnumerable<ILoop> GetInnerLoops(this Entity rootEntity)
-        {
+        public static void ResetDescendants(this Entity rootEntity)
+        {            
             foreach (var component in rootEntity.Components)
             {
-                if (!component.IsEnabled)
+                component.ResetComponent();
+                if (component is Entity)
                 {
+                    (component as Entity).ResetDescendants();
                     continue;
                 }
-
-                if (component is ILoop loopComponent)
-                {
-                    yield return loopComponent;
-                    continue;
-                }
-
-                if (component is Entity entity)
-                {
-                    foreach (var item in GetInnerLoops(entity))
-                    {
-                        yield return item;
-                    }
-                }
-            }
+               
+            }           
         }
 
         /// <summary>

--- a/src/Unit.Tests/Pixel.Automation.Core.Tests/Component/EntityHelperFixture.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Tests/Component/EntityHelperFixture.cs
@@ -221,14 +221,36 @@ namespace Pixel.Automation.Core.Tests
             componentTwo.Received(1).ResetComponent();
         }
 
+
         [Test]
-        public void ValidateThatComponentsThatImplementILoopCanBeRetrieved()
+        public void ValidateThatResetDescendantsResetsAllComponentsButSelf()
         {
-            var foundComponents = rootEntity.GetInnerLoops();
+            IEntityManager entityManager = Substitute.For<IEntityManager>();
 
-            Assert.AreEqual(1, foundComponents.Count());
+            Entity rootEntity = Substitute.ForPartsOf<Entity>();
+            rootEntity.EntityManager = entityManager;
+            rootEntity.When(x => x.ResetComponent()).Do(x => { });
+
+            Entity childEntity = Substitute.ForPartsOf<Entity>();
+            childEntity.When(x => x.ResetComponent()).Do(x => { });
+
+            IComponent componentOne = Substitute.For<IComponent>();
+            componentOne.When(x => x.ResetComponent()).Do(x => { });
+            rootEntity.AddComponent(componentOne);
+            rootEntity.AddComponent(childEntity);
+
+            IComponent componentTwo = Substitute.For<IComponent>();
+            componentTwo.When(x => x.ResetComponent()).Do(x => { });
+            childEntity.AddComponent(componentTwo);
+
+
+            rootEntity.ResetDescendants();
+
+            rootEntity.Received(0).ResetComponent();
+            childEntity.Received(1).ResetComponent();
+            componentOne.Received(1).ResetComponent();
+            componentTwo.Received(1).ResetComponent();
         }
-
 
         /// <summary>
         /// Validate that ancestor component of a requested type can be retreived


### PR DESCRIPTION
**Description**
1. Sequential entity processors are used in prefab designers and must reset all the components before they are executed.  Unless a reset it done, subsequent execution fails to work when there are components like loops which have a state that needs to be cleared from previous run.

2. Rest components before each retry attempt for retry component for same reasons as 1.
3. Removed Index input argument from repeat until processor as it is not required. Repeat until will always run until criteria is satisfied and doesn't require a starting index.
4. Refactored loop components to reset descendant components on each iteration.