### PR TITLE
Load fixtures and data sources on project loaded event

### DIFF
--- a/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataRepositoryViewModel.cs
+++ b/src/Pixel.Automation.TestData.Repository.ViewModels/TestDataRepositoryViewModel.cs
@@ -95,6 +95,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
 
         internal async Task OnProjectLoaded(object sender, ProjectLoadedEventArgs e)
         {
+            await DownloadDataSourcesAsync();
             var referenceManager = this.projectManager.GetReferenceManager();
             this.Groups.AddRange(referenceManager.GetTestDataSourceGroups());
             //Create an empty data source if no data source exist in any of the groups
@@ -585,19 +586,7 @@ namespace Pixel.Automation.TestData.Repository.ViewModels
 
         #endregion Edit Data Source
 
-        #region life cycle
-
-        /// <summary>
-        /// Called just before view is activiated for the first time.
-        /// Available TestDataSource are loaded from local storage during initialization.
-        /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        protected override async Task OnInitializeAsync(CancellationToken cancellationToken)
-        {
-            await DownloadDataSourcesAsync();           
-            await base.OnInitializeAsync(cancellationToken);
-        }
+        #region life cycle             
 
         /// <summary>
         /// Download and load the available TestDataSources

--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
@@ -161,6 +161,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
             {
                 try
                 {
+                    await DownloadFixturesAndTestsAsync();
                     var referenceManager = this.projectManager.GetReferenceManager();
                     foreach(var fixtureId in referenceManager.GetAllFixtures())
                     {
@@ -1410,20 +1411,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
         #endregion Execute       
 
         #region life cycle
-
-
-        /// <summary>
-        /// Called just before view is activiated for the first time.
-        /// Fixtures and TestCases are loaded from local storage during initialization.
-        /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        protected override async Task OnInitializeAsync(CancellationToken cancellationToken)
-        {
-            await DownloadFixturesAndTestsAsync();
-            await base.OnInitializeAsync(cancellationToken);
-        }
-
+               
         /// <summary>
         /// Download all the fixtures and test cases
         /// </summary>


### PR DESCRIPTION
After upgrading to .net 8, it seems project loaded event is triggered before initialize on the viewmodels and as a result loading of data fails as they are yet to be downloaded. Refactored code to download data when project loaded event happens as well.