### PR TITLE
New command to import and execute for test runner

### DIFF
--- a/src/Pixel.Automation.Test.Runner/Commands/ExecuteTestFromTemplateCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/ExecuteTestFromTemplateCommand.cs
@@ -1,5 +1,7 @@
 ﻿using Dawn;
 using Pixel.Automation.Core;
+using Pixel.Persistence.Services.Client.Interfaces;
+using Pixel.Persistence.Services.Client;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using System;
@@ -14,7 +16,7 @@ namespace Pixel.Automation.Test.Runner.Commands;
 /// <summary>
 /// Execute test from template command is used to execute tests by specifying a template and optionally project version to use
 /// </summary>
-internal sealed class ExecuteTestFromTemplateCommand : AsyncCommand<ExecuteTestFromTemplateSettings>
+internal sealed class ExecuteTestFromTemplateCommand : RunTestCommand<ExecuteTestFromTemplateSettings>
 {
     public sealed class ExecuteTestFromTemplateSettings : ExecuteTestSettings
     {
@@ -25,24 +27,23 @@ internal sealed class ExecuteTestFromTemplateCommand : AsyncCommand<ExecuteTestF
         [Description("Only list the test cases without executing them")]
         [CommandOption("-l|--list")]
         public bool? List { get; set; }
-
     }
-
-    private readonly IAnsiConsole console;
+  
     private readonly TemplateManager templateManager;
-    private readonly ProjectManager projectManager;
-
-    public ExecuteTestFromTemplateCommand(IAnsiConsole console, TemplateManager templateManager, ProjectManager projectManager)
+   
+    public ExecuteTestFromTemplateCommand(IAnsiConsole console, IApplicationDataManager applicationDataManager,
+      IProjectDataManager projectDataManager, IPrefabDataManager prefabDataManager, ProjectManager projectManager, 
+      TemplateManager templateManager) : base(console, applicationDataManager, projectDataManager, prefabDataManager, projectManager)
     {
-        this.templateManager = Guard.Argument(templateManager, nameof(templateManager)).NotNull();
-        this.projectManager = Guard.Argument(projectManager, nameof(projectManager)).NotNull();
-        this.console = Guard.Argument(console, nameof(console)).NotNull().Value;
+        this.templateManager = Guard.Argument(templateManager, nameof(templateManager)).NotNull();      
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, ExecuteTestFromTemplateSettings settings)
     {
         using (Telemetry.DefaultSource?.StartActivity(nameof(ExecuteAsync), ActivityKind.Internal))
         {
+            await DownloadDataAsync();
+
             var sessionTemplate = await templateManager.GetByNameAsync(settings.TemplateName) ??
                 throw new ArgumentException($"Template with name : {0} doesn't exist", settings.TemplateName);
             await projectManager.LoadProjectAsync(sessionTemplate, sessionTemplate.TargetVersion);

--- a/src/Pixel.Automation.Test.Runner/Commands/ExecuteTestWithImportCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/ExecuteTestWithImportCommand.cs
@@ -1,0 +1,108 @@
+﻿using Dawn;
+using Pixel.Automation.Core;
+using Pixel.Automation.Core.Models;
+using Pixel.Persistence.Services.Client;
+using Pixel.Persistence.Services.Client.Interfaces;
+using Pixel.Persistence.Services.Client.Models;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using static Pixel.Automation.Test.Runner.Commands.ExecuteTestWithImportCommand;
+
+namespace Pixel.Automation.Test.Runner.Commands;
+
+internal class ExecuteTestWithImportCommand : RunTestCommand<ExecuteTestWithImportSettings>
+{
+    private readonly ApplicationSettings appSettings;
+
+    public sealed class ExecuteTestWithImportSettings : ExecuteTestSettings
+    {
+        [Description("Zip file containing the automation process and dependencies")]
+        [CommandArgument(0, "<ImportFile>")]
+        public string ImportFile { get; init; }
+
+        [Description("Test case selector script")]
+        [CommandArgument(2, "<Selector>")]
+        public string Selector { get; init; }
+
+        [Description("Name of the initializer function in initialize environment script file")]
+        [CommandArgument(3, "[InitFunction]")]
+        public string InitFunction { get; init; }
+
+        [Description("Only list the test cases without executing them")]
+        [CommandOption("-l|--list")]
+        public bool? List { get; set; }
+    }
+
+    public ExecuteTestWithImportCommand(IAnsiConsole console, IApplicationDataManager applicationDataManager,
+      IProjectDataManager projectDataManager, IPrefabDataManager prefabDataManager, ProjectManager projectManager,
+      ApplicationSettings appSettings) : base(console, applicationDataManager, projectDataManager, prefabDataManager, projectManager)
+    {      
+        this.appSettings = Guard.Argument(appSettings, nameof(appSettings)).NotNull().Value;
+        appSettings.IsOfflineMode = true;
+        TraceManager.IsEnabled = false;
+    }
+
+    public async override Task<int> ExecuteAsync(CommandContext context, ExecuteTestWithImportSettings settings)
+    {
+        using (Telemetry.DefaultSource?.StartActivity(nameof(ExecuteAsync), ActivityKind.Internal))
+        {
+            if(!File.Exists(settings.ImportFile))
+            {
+                throw new FileNotFoundException($"File : '{settings.ImportFile}' doesn't exist");
+            }
+            if(Directory.Exists(appSettings.ApplicationDirectory))
+            {
+                Directory.Delete(appSettings.ApplicationDirectory, true );
+            }
+            if(Directory.Exists(appSettings.AutomationDirectory))
+            {
+                Directory.Delete(appSettings.AutomationDirectory, true );
+            }
+            ZipFile.ExtractToDirectory(settings.ImportFile, Environment.CurrentDirectory);
+
+            var automationProject = projectDataManager.GetAllProjects().Single();
+            VersionInfo projectVersionToUse = null;
+            foreach(var version in automationProject.AvailableVersions)
+            {
+                if(Directory.Exists(Path.Combine(appSettings.AutomationDirectory, automationProject.ProjectId, version.ToString())))
+                {
+                    projectVersionToUse = version;
+                    break;
+                }
+            }
+            if(projectVersionToUse == null)
+            {
+                throw new Exception($"Project : '{automationProject.Name}' doesn't have any versions available to use");
+            }
+          
+            var sessionTemplate = new SessionTemplate()
+            {
+                Name = Guid.NewGuid().ToString(),
+                ProjectName = automationProject.Name,
+                ProjectId = automationProject.ProjectId,
+                Selector = settings.Selector,
+                InitFunction = settings.InitFunction
+            };
+
+            await projectManager.LoadProjectAsync(sessionTemplate, sessionTemplate.TargetVersion);
+            await projectManager.LoadTestCasesAsync();
+            if (settings.List.GetValueOrDefault())
+            {
+                await projectManager.ListAllAsync(sessionTemplate.Selector, console);
+            }
+            else
+            {
+                await projectManager.RunAllAsync(sessionTemplate.Selector, console);
+            }
+            return 0;
+        }
+    }
+
+}

--- a/src/Pixel.Automation.Test.Runner/Commands/RunTestCommand.cs
+++ b/src/Pixel.Automation.Test.Runner/Commands/RunTestCommand.cs
@@ -1,0 +1,46 @@
+﻿using Pixel.Persistence.Services.Client.Interfaces;
+using Pixel.Persistence.Services.Client;
+using Spectre.Console.Cli;
+using System.Threading.Tasks;
+using Pixel.Automation.Core;
+using System.Diagnostics;
+using Dawn;
+using Spectre.Console;
+
+namespace Pixel.Automation.Test.Runner.Commands;
+
+internal abstract class RunTestCommand<T> : AsyncCommand<T> where T : CommandSettings
+{
+    protected readonly IAnsiConsole console;
+    protected readonly IApplicationDataManager applicationDataManager;
+    protected readonly IProjectDataManager projectDataManager;
+    protected readonly IPrefabDataManager prefabDataManager;
+    protected readonly ProjectManager projectManager;
+
+    public RunTestCommand(IAnsiConsole console, IApplicationDataManager applicationDataManager,
+      IProjectDataManager projectDataManager, IPrefabDataManager prefabDataManager, ProjectManager projectManager)
+    {
+        this.projectManager = Guard.Argument(projectManager, nameof(projectManager)).NotNull();
+        this.console = Guard.Argument(console, nameof(console)).NotNull().Value;
+        this.applicationDataManager = Guard.Argument(applicationDataManager, nameof(applicationDataManager)).NotNull().Value;
+        this.projectDataManager = Guard.Argument(projectDataManager, nameof(projectDataManager)).NotNull().Value;
+        this.prefabDataManager = Guard.Argument(prefabDataManager, nameof(prefabDataManager)).NotNull().Value;
+    }
+
+    protected virtual async Task DownloadDataAsync()
+    {
+        using (Telemetry.DefaultSource?.StartActivity("download-applications-and-controls", ActivityKind.Internal))
+        {
+            await applicationDataManager.DownloadApplicationsWithControlsAsync();
+        }
+        using (Telemetry.DefaultSource?.StartActivity("download-projects", ActivityKind.Internal))
+        {
+            await projectDataManager.DownloadProjectsAsync();
+        }
+        using (Telemetry.DefaultSource?.StartActivity("download-prefabs", ActivityKind.Internal))
+        {
+            await prefabDataManager.DownloadPrefabsAsync();
+        }
+    }
+}
+

--- a/src/Pixel.Automation.Test.Runner/Modules/CommonModule.cs
+++ b/src/Pixel.Automation.Test.Runner/Modules/CommonModule.cs
@@ -29,6 +29,7 @@ namespace Pixel.Automation.Test.Runner.Modules
             Kernel.Bind<ITestSelector>().To<TestSelector>().InSingletonScope();
 
             Kernel.Bind<TemplateManager>().ToSelf();
+            Kernel.Bind<TestSessionManager>().ToSelf();
         }
     }
 }

--- a/src/Pixel.Automation.Test.Runner/Pixel.Automation.Test.Runner.csproj
+++ b/src/Pixel.Automation.Test.Runner/Pixel.Automation.Test.Runner.csproj
@@ -11,6 +11,10 @@
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
+		<UseWPF>true</UseWPF>
+	</PropertyGroup>
+	
 	<PropertyGroup>
 		<OutputPath>..\..\.builds\$(Configuration)\Runner\</OutputPath>	
 		<UseWPF Condition="'$(TargetFramework)' == 'net7.0-windows'">true</UseWPF>

--- a/src/Pixel.Automation.Test.Runner/TestSessionManager.cs
+++ b/src/Pixel.Automation.Test.Runner/TestSessionManager.cs
@@ -1,0 +1,69 @@
+﻿using Dawn;
+using Pixel.Automation.Core;
+using Pixel.Persistence.Services.Client;
+using Pixel.Persistence.Services.Client.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Pixel.Automation.Test.Runner;
+
+public class TestSessionManager
+{
+    private readonly ApplicationSettings appSettings;
+    private readonly ITestSessionClient testSessionClient;
+
+    private TestSession testSession = null;
+    private readonly List<TestResult> testResults = new List<TestResult>();
+
+    bool IsOnlineMode
+    {
+        get => !this.appSettings.IsOfflineMode;
+    }
+
+    public TestSessionManager(ApplicationSettings appSettings, ITestSessionClient testSessionClienet)
+    {
+        this.appSettings = Guard.Argument(appSettings, nameof(appSettings)).NotNull();
+        this.testSessionClient = Guard.Argument(testSessionClienet, nameof(testSessionClienet)).NotNull().Value;
+    }
+
+
+    public async Task<string> AddSessionAsync(TestSession testSession)
+    {
+        if(IsOnlineMode)
+        {
+            return await this.testSessionClient.AddSessionAsync(testSession);
+        }
+        this.testSession = testSession;
+        this.testSession.Id = Guid.NewGuid().ToString();
+        return this.testSession.Id;
+    }
+
+    public async Task UpdateSessionAsync(string sessionId, TestSession testSession)
+    {
+        if(IsOnlineMode)
+        {
+            await this.testSessionClient.UpdateSessionAsync(sessionId, testSession);
+        }
+        this.testSession = testSession;
+    }
+
+    public async Task<TestResult> AddResultAsync(TestResult testResult)
+    {
+        if(IsOnlineMode)
+        {
+            return await this.testSessionClient.AddResultAsync(testResult);
+        }
+        testResult.Id = testResult.TestId;
+        this.testResults.Add(testResult);
+        return testResult;
+    }
+
+    public async Task AddTraceImagesAsync(TestResult testResult, IEnumerable<string> imageFiles)
+    {
+        if(IsOnlineMode)
+        {
+            await this.testSessionClient.AddTraceImagesAsync(testResult, imageFiles);
+        }
+    }
+}


### PR DESCRIPTION
1. Added a new command with-import that can take a zip file with automation process and all it's dependencies and execute the test cases
2. Additionally, fixed an issue where test runne would fail to launch after upgrading to .net 8.0 as it failed to find WindowsBase.dll assembly