### PR TITLE
Unsubscribe from event aggregator while closing prefab editor

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabEditorViewModel.cs
@@ -211,9 +211,11 @@ namespace Pixel.Automation.Designer.ViewModels
         {
             try
             {
-                this.Dispose();
-                await this.TryCloseAsync(true);
+                await SetSelectedItem(null);
                 await this.globalEventAggregator.PublishOnUIThreadAsync(new EditorClosedNotification<PrefabProject>(this.PrefabProject));
+                this.globalEventAggregator.Unsubscribe(this);
+                await this.TryCloseAsync(true);              
+                this.Dispose();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
**Description**
Prefab editor doesn't unsubscribes from event aggregator when it is closed and may continue to handle some messages like update in application for a while even after they are closed.