### PR TITLE
Changing prefab version should not require to reopen automation process

### DIFF
--- a/Pixel.Automation.sln
+++ b/Pixel.Automation.sln
@@ -83,8 +83,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test.Runner", "Test.Runner"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Automation.Test.Runner", "src\Pixel.Automation.Test.Runner\Pixel.Automation.Test.Runner.csproj", "{F03B95F0-6757-4FBD-887D-A7DDA95DEFCF}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Services", "Services", "{AA656CE2-0BA6-49F0-AD4A-B54BA52DADE5}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{FD0D3A59-9D7D-4C4F-B67F-C779EC7CBEB7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Persistence.Services.Client", "src\Pixel.Persistence.Services.Client\Pixel.Persistence.Services.Client.csproj", "{DC616BF5-7555-4972-99DC-71E208FA3C82}"

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabDropHandlerViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabDropHandlerViewModel.cs
@@ -89,17 +89,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
             var prefabComponentViewModel = this.dropTarget.ComponentCollection.FirstOrDefault(a => a.Model.Equals(this.prefabEntity));
             if (prefabComponentViewModel != null)
             {
-                dropTarget.RemoveComponent(prefabComponentViewModel);
-                var inputMappingScriptFile = Path.Combine(this.projectFileSystem.ScriptsDirectory, Path.GetFileName(this.prefabEntity.InputMappingScriptFile));
-                if (File.Exists(inputMappingScriptFile))
-                {
-                    File.Delete(inputMappingScriptFile);
-                }
-                var ouutpuMappingScriptFile = Path.Combine(this.projectFileSystem.ScriptsDirectory, Path.GetFileName(this.prefabEntity.OutputMappingScriptFile));
-                if (File.Exists(ouutpuMappingScriptFile))
-                {
-                    File.Delete(ouutpuMappingScriptFile);
-                }
+                dropTarget.RemoveComponent(prefabComponentViewModel);              
             }
             await this.TryCloseAsync(false);
         }

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabInputMapper.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabInputMapper.cs
@@ -82,7 +82,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
             Guard.Argument(assignTo).NotNull();
 
             StringBuilder mappingBuilder = new StringBuilder();
-            mappingBuilder.AppendLine($"#r \"{assignTo.Assembly.GetName().Name}.dll\"");
+            //mappingBuilder.AppendLine($"#r \"{assignTo.Assembly.GetName().Name}.dll\"");
             mappingBuilder.AppendLine($"#r \"AutoMapper.dll\" {Environment.NewLine}");
             mappingBuilder.AppendLine($"using AutoMapper;");
             mappingBuilder.AppendLine($"using TestModel = {assignFrom.Namespace};");

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabInputMappingScriptEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabInputMappingScriptEditorViewModel.cs
@@ -17,10 +17,10 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         }
 
         /// <inheritdoc/>   
-        protected override string GetGeneratedCode()
+        protected override async Task<string> GetGeneratedCode()
         {
             var prefabArgumentMapper = new PrefabInputMapper();
-            var assignTo = prefabEntity.GetPrefabDataModelType();
+            var assignTo = await prefabEntity.GetPrefabDataModelType();
             var assignFrom = dropTarget.EntityManager.Arguments.GetType();
             var propertyMappings = prefabArgumentMapper.GenerateMapping(this.scriptEngine, assignFrom, assignTo).ToList();
             string generatedCode = prefabArgumentMapper.GeneratedMappingCode(propertyMappings, assignFrom, assignTo);

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabMappingScriptEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabMappingScriptEditorViewModel.cs
@@ -36,7 +36,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         }
 
         /// <inheritdoc/>       
-        protected override Task OnActivateAsync(CancellationToken cancellationToken)
+        protected override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             string scriptFile = GetScriptFile();
             string generatedCode;
@@ -46,7 +46,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
             }
             else
             {
-                generatedCode = GetGeneratedCode();
+                generatedCode = await GetGeneratedCode();
             }           
             this.ScriptEditor = this.scriptEditorFactory.CreateInlineScriptEditor(new EditorOptions() 
             {
@@ -75,7 +75,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
 
             this.ScriptEditor.Activate();
           
-            return base.OnActivateAsync(cancellationToken);
+            await base.OnActivateAsync(cancellationToken);
         }
 
         protected abstract void AddProject(string[] projectReferences);
@@ -84,7 +84,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         /// Get the generated code for mapping
         /// </summary>
         /// <returns></returns>
-        protected abstract string GetGeneratedCode();
+        protected abstract Task<string> GetGeneratedCode();
 
         /// <summary>
         /// Get the name of the project to which script should be added in the workspace

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabOutputMapper.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabOutputMapper.cs
@@ -78,7 +78,7 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
             Guard.Argument(assignTo).NotNull();
 
             StringBuilder mappingBuilder = new StringBuilder();
-            mappingBuilder.AppendLine($"#r \"{assignFrom.Assembly.GetName().Name}.dll\"");
+            //mappingBuilder.AppendLine($"#r \"{assignFrom.Assembly.GetName().Name}.dll\"");
             mappingBuilder.AppendLine($"#r \"AutoMapper.dll\" {Environment.NewLine}");
             mappingBuilder.AppendLine($"using AutoMapper;");
             mappingBuilder.AppendLine($"using TestModel = {assignTo.Namespace};");

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabOutputMappingScriptEditorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabOutputMappingScriptEditorViewModel.cs
@@ -17,10 +17,10 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         }
 
         /// <inheritdoc/>   
-        protected override string GetGeneratedCode()
+        protected override async Task<string> GetGeneratedCode()
         {
             var prefabArgumentMapper = new PrefabOutputMapper();
-            var assignFrom = prefabEntity.GetPrefabDataModelType();
+            var assignFrom = await prefabEntity.GetPrefabDataModelType();
             var assignTo = dropTarget.EntityManager.Arguments.GetType();
             var propertyMappings = prefabArgumentMapper.GenerateMapping(this.scriptEngine, assignFrom, assignTo).ToList();
             string generatedCode = prefabArgumentMapper.GeneratedMappingCode(propertyMappings, assignFrom, assignTo);

--- a/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabVersionSelectorViewModel.cs
+++ b/src/Pixel.Automation.AppExplorer.ViewModels/PrefabDropHandler/PrefabVersionSelectorViewModel.cs
@@ -108,10 +108,16 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
             }
             else
             {
-                this.SelectedVersion = AvailableVersions.Last();
+                this.SelectedVersion = AvailableVersions.Last();              
+            }
+            if(string.IsNullOrEmpty(this.InputMappingScriptFile))
+            {
                 this.InputMappingScriptFile = Path.GetRelativePath(this.projectFileSystem.WorkingDirectory, Path.Combine(this.projectFileSystem.ScriptsDirectory, $"{Guid.NewGuid()}.csx")).Replace("\\", "/");
-                this.OutputMappingScriptFile = Path.GetRelativePath(this.projectFileSystem.WorkingDirectory, Path.Combine(this.projectFileSystem.ScriptsDirectory, $"{Guid.NewGuid()}.csx")).Replace("\\", "/");              
-            }           
+            }
+            if(string.IsNullOrEmpty(this.OutputMappingScriptFile))
+            {
+                this.OutputMappingScriptFile = Path.GetRelativePath(this.projectFileSystem.WorkingDirectory, Path.Combine(this.projectFileSystem.ScriptsDirectory, $"{Guid.NewGuid()}.csx")).Replace("\\", "/");
+            }
         }
 
         /// <summary>
@@ -227,12 +233,19 @@ namespace Pixel.Automation.AppExplorer.ViewModels.PrefabDropHandler
         private bool ValidateScriptPath(string propertyName, string scriptFile)
         {
             ClearErrors(propertyName);
-            string scriptDirectory = Path.GetDirectoryName(Path.Combine(this.projectFileSystem.WorkingDirectory, scriptFile));
-            if (!(scriptDirectory.Contains(this.projectFileSystem.ScriptsDirectory) || scriptDirectory.Contains(this.projectFileSystem.TestCaseRepository)))
+            if(!string.IsNullOrEmpty(scriptFile))
             {
-                AddOrAppendErrors(propertyName, $"{propertyName} file must be located in a subdirectory of '{this.projectFileSystem.WorkingDirectory}' directory");
-                AddOrAppendErrors("", $"{propertyName} file must be located in a subdirectory of '{this.projectFileSystem.WorkingDirectory}' directory");               
-                return false;
+                string scriptDirectory = Path.GetDirectoryName(Path.Combine(this.projectFileSystem.WorkingDirectory, scriptFile));
+                if (!(scriptDirectory.Contains(this.projectFileSystem.ScriptsDirectory) || scriptDirectory.Contains(this.projectFileSystem.TestCaseRepository)))
+                {
+                    AddOrAppendErrors(propertyName, $"{propertyName} file must be located in a subdirectory of '{this.projectFileSystem.WorkingDirectory}' directory");
+                    AddOrAppendErrors("", $"{propertyName} file must be located in a subdirectory of '{this.projectFileSystem.WorkingDirectory}' directory");
+                    return false;
+                }
+            }
+            else
+            {
+                AddOrAppendErrors(propertyName, $"{propertyName} is required");
             }
             return true;
         }

--- a/src/Pixel.Automation.Core.Components/Prefabs/PrefabEntity.cs
+++ b/src/Pixel.Automation.Core.Components/Prefabs/PrefabEntity.cs
@@ -143,11 +143,11 @@ public class PrefabEntity : Entity
 
     #endregion overridden methods
 
-    public Type GetPrefabDataModelType()
+    public async Task<Type> GetPrefabDataModelType()
     {
         if(this.prefabDataModel == null)
         {
-            this.LoadPrefab();
+            await this.LoadPrefab();
         }
         return this.prefabDataModel.GetType();
     }

--- a/src/Pixel.Automation.Core.Components/Prefabs/PrefabInstance.cs
+++ b/src/Pixel.Automation.Core.Components/Prefabs/PrefabInstance.cs
@@ -1,5 +1,6 @@
 ﻿using Dawn;
 using Pixel.Automation.Core.Interfaces;
+using Pixel.Automation.Core.Models;
 using System;
 using System.IO;
 
@@ -9,16 +10,49 @@ namespace Pixel.Automation.Core.Components.Prefabs;
 /// PrefabInstance is a fully configured ready to use instance of a Prefab process.
 /// </summary>
 public class PrefabInstance : IDisposable
-{       
+{
+    private bool isDisposed = false;
     private readonly IEntityManager prefabEntityManager;
     private readonly IPrefabFileSystem prefabFileSystem;
-    private readonly Type dataModelType;
+  
+    /// <summary>
+    /// Identifier of the Prefab
+    /// </summary>
+    public  string PrefabId { get; init; }
 
-    public PrefabInstance(IEntityManager prefabEntityManager, IPrefabFileSystem prefabFileSystem, Type dataModelType)
-    {          
-        this.prefabEntityManager = Guard.Argument(prefabEntityManager).NotNull().Value;
-        this.prefabFileSystem = Guard.Argument(prefabFileSystem).NotNull().Value;
-        this.dataModelType = Guard.Argument(dataModelType).NotNull().Value;
+    /// <summary>
+    /// Identifier of the application to which prefab belongs
+    /// </summary>
+    public string ApplicationId { get; init; }
+
+    /// <summary>
+    /// Version of the loaded prefab
+    /// </summary>
+    public VersionInfo Version { get; init; }
+    
+    /// <summary>
+    /// DataModel type of the loaded  prefab
+    /// </summary>
+    public Type DataModelType { get; init; }      
+
+    /// <summary>
+    /// constructor
+    /// </summary>
+    /// <param name="applicationId"></param>
+    /// <param name="prefabId"></param>
+    /// <param name="version"></param>
+    /// <param name="dataModelType"></param>
+    /// <param name="prefabEntityManager"></param>
+    /// <param name="prefabFileSystem"></param>
+    public PrefabInstance(string applicationId, string prefabId, VersionInfo version, Type dataModelType,
+        IEntityManager prefabEntityManager, IPrefabFileSystem prefabFileSystem)
+    {
+        this.ApplicationId = Guard.Argument(applicationId, nameof(applicationId)).NotNull().NotEmpty();
+        this.PrefabId = Guard.Argument(prefabId, nameof(prefabId)).NotNull().NotEmpty();
+        this.Version = Guard.Argument(version, nameof(version)).NotNull();
+        this.DataModelType = Guard.Argument(dataModelType, nameof(dataModelType)).NotNull().Value;
+        this.prefabEntityManager = Guard.Argument(prefabEntityManager, nameof(prefabEntityManager)).NotNull().Value;
+        this.prefabFileSystem = Guard.Argument(prefabFileSystem, nameof(prefabFileSystem)).NotNull().Value;      
     }
 
     /// <summary>
@@ -27,6 +61,10 @@ public class PrefabInstance : IDisposable
     /// <returns></returns>
     public Entity GetPrefabRootEntity()
     {
+        if(isDisposed)
+        {
+            throw new ObjectDisposedException($"Version : '{Version}' of Prefab Instance: '{PrefabId}' is already disposed");
+        }
         if (!File.Exists(this.prefabFileSystem.PrefabFile))
         {
             throw new FileNotFoundException($"{this.prefabFileSystem.PrefabFile} not found");
@@ -35,20 +73,12 @@ public class PrefabInstance : IDisposable
         prefabRoot.EntityManager = this.prefabEntityManager;
         this.prefabEntityManager.RestoreParentChildRelation(prefabRoot);
         //Setting argument will initialize all the required services such as script engine, argument processor , etc.
-        var dataModelInstance = Activator.CreateInstance(dataModelType);
+        var dataModelInstance = Activator.CreateInstance(DataModelType);
         this.prefabEntityManager.Arguments = dataModelInstance;
         return prefabRoot;
     }
-  
-    /// <summary>
-    /// Get the data model type for prefab process
-    /// </summary>
-    /// <returns></returns>
-    public Type GetDataModelType()
-    {
-        return this.dataModelType;
-    }
 
+    /// <inheritdoc/>   
     public void Dispose()
     {
         Dispose(true);
@@ -59,7 +89,7 @@ public class PrefabInstance : IDisposable
         if(isDisposing)
         {
             var scriptEngineFactory = this.prefabEntityManager.GetServiceOfType<IScriptEngineFactory>();
-            scriptEngineFactory.RemoveReferences(this.dataModelType.Assembly);
+            scriptEngineFactory.RemoveReferences(this.DataModelType.Assembly);
             this.prefabEntityManager.Dispose();
         }
     }

--- a/src/Pixel.Automation.Core/Interfaces/IPrefabLoader.cs
+++ b/src/Pixel.Automation.Core/Interfaces/IPrefabLoader.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Pixel.Automation.Core.Models;
+using System;
 
 namespace Pixel.Automation.Core.Interfaces
 {
@@ -24,9 +25,24 @@ namespace Pixel.Automation.Core.Interfaces
         Type GetPrefabDataModelType(string applicationId, string prefabId, IEntityManager primaryEntityManager);
 
         /// <summary>
-        /// Clear the prefab loader cache.     
-        /// </summary>
-        void ClearCache();
+        /// Get the loaded version of prefab
+        /// </summary>     
+        /// <param name="prefabId"></param>
+        /// <returns></returns>
+        VersionInfo GetPrefabVersion(string prefabId);
 
+        /// <summary>
+        /// Check if specified version of prefab is already loaded by PrefabLoader
+        /// </summary>
+        /// <param name="applicationId"></param>      
+        /// <returns></returns>
+        bool IsPrefabLoaded(string prefabId);
+
+        /// <summary>
+        /// Unload the specified veresion of prefab and dispose it
+        /// </summary>
+        /// <param name="applicationId"></param>      
+        void UnloadAndDispose(string prefabId);
+               
     }
 }

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationEditorViewModel.cs
@@ -298,7 +298,7 @@ namespace Pixel.Automation.Designer.ViewModels
                 try
                 {
                     var projectFileSystem = this.projectManager.GetProjectFileSystem() as IProjectFileSystem;
-                    var versionManager = this.versionManagerFactory.CreatePrefabReferenceManager(this.projectManager.GetReferenceManager());
+                    var versionManager = this.versionManagerFactory.CreatePrefabReferenceManager(this.projectManager.GetReferenceManager() , (p) => { this.projectManager.OnPrefabVersionChanged(p); });
                     await this.windowManager.ShowDialogAsync(versionManager);
                 }
                 catch (Exception ex)

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -156,6 +156,25 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             var entity = this.Load<Entity>(this.projectFileSystem.ProcessFile);         
             return entity;
         }
+   
+        public void OnPrefabVersionChanged(IEnumerable<PrefabReference> prefabs)
+        {
+            var prefabLoader = this.entityManager.GetServiceOfType<IPrefabLoader>();
+            foreach (var prefab in prefabs)
+            {
+                if(prefabLoader.IsPrefabLoaded(prefab.PrefabId))
+                {
+                    //Remove loaded assembly from script editor and script engine
+                    var prefabDataModel = prefabLoader.GetPrefabDataModelType(prefab.ApplicationId, prefab.PrefabId, this.entityManager);
+                    this.scriptEditorFactory.RemoveAssemblyReference(prefabDataModel.Assembly);
+                    this.scriptEngineFactory.RemoveReferences(prefabDataModel.Assembly);
+                    
+                    //unload and dispose the prefab. Subsequent use will load the recent version again and 
+                    //configure script editor and script engine
+                    prefabLoader.UnloadAndDispose(prefab.PrefabId);
+                }              
+            }
+        }
 
         /// <summary>
         /// Save and load project again. Update services to use new data model . One time registration of services is skipped unlike load.

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/DesignTimePrefabLoader.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/DesignTimePrefabLoader.cs
@@ -23,8 +23,9 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             //Script editor when working with prefab input and output mapping script should be able to resolve references from prefab references folder
             //at design time
             var scriptEditorFactory = parentEntityManager.GetServiceOfType<IScriptEditorFactory>();
+            scriptEditorFactory.AddAssemblyReference(prefabAssembly);
             scriptEditorFactory.AddSearchPaths(prefabFileSystem.ReferencesDirectory);
-        }    
+        }
     }
 
 }

--- a/src/Pixel.Automation.Designer.ViewModels/Factory/VersionManagerFactory.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/Factory/VersionManagerFactory.cs
@@ -59,9 +59,9 @@ namespace Pixel.Automation.Designer.ViewModels.Factory
                this.eventAggregator, this.notificationManager, this.applicationSettings);
         }
 
-        public IVersionManager CreatePrefabReferenceManager(IReferenceManager referenceManager)
+        public IVersionManager CreatePrefabReferenceManager(IReferenceManager referenceManager, Action<IEnumerable<PrefabReference>> onVersionChanged)
         {
-            return new PrefabReferenceManagerViewModel(this.prefabDataManager, referenceManager, this.notificationManager);
+            return new PrefabReferenceManagerViewModel(this.prefabDataManager, referenceManager, this.notificationManager, onVersionChanged);
         }
 
         public IVersionManager CreateControlReferenceManager(IReferenceManager referenceManager)

--- a/src/Pixel.Automation.Designer.ViewModels/VersionManager/PrefabReferenceManagerViewModel.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/VersionManager/PrefabReferenceManagerViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Dawn;
 using Notifications.Wpf.Core;
+using Pixel.Automation.Core.Models;
 using Pixel.Automation.Editor.Core.Helpers;
 using Pixel.Automation.Editor.Core.Interfaces;
 using Pixel.Automation.Reference.Manager;
@@ -18,6 +19,7 @@ namespace Pixel.Automation.Designer.ViewModels.VersionManager
         private readonly ILogger logger = Log.ForContext<PrefabReferenceManagerViewModel>();
         private readonly IReferenceManager referenceManager;
         private readonly INotificationManager notificationManager;
+        private readonly Action<IEnumerable<PrefabReference>> onVersionChanged;
         public readonly PrefabReferences prefabReferences;
 
         /// <summary>
@@ -45,11 +47,12 @@ namespace Pixel.Automation.Designer.ViewModels.VersionManager
         }
 
         public PrefabReferenceManagerViewModel(IPrefabDataManager prefabDataManager, IReferenceManager referenceManager,
-            INotificationManager notificationManager)
+            INotificationManager notificationManager, Action<IEnumerable<PrefabReference>> onVersionChanged)
         {
             this.DisplayName = "Manage Prefab References";
             this.referenceManager = Guard.Argument(referenceManager, nameof(referenceManager)).NotNull().Value;
             this.notificationManager = Guard.Argument(notificationManager, nameof(notificationManager)).NotNull().Value;
+            this.onVersionChanged = Guard.Argument(onVersionChanged, nameof(onVersionChanged)).NotNull();
             this.prefabReferences = this.referenceManager.GetPrefabReferences();
 
             var applications = this.prefabReferences.References.Select(r => r.ApplicationId).Distinct();
@@ -92,6 +95,7 @@ namespace Pixel.Automation.Designer.ViewModels.VersionManager
                 if (modifiedReferences.Any())
                 {
                     await this.referenceManager.UpdatePrefabReferencesAsync(modifiedReferences);
+                    this.onVersionChanged(modifiedReferences);
                 }
                 await this.TryCloseAsync(true);
             }

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IProjectManager.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IProjectManager.cs
@@ -2,6 +2,7 @@
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.Models;
 using Pixel.Automation.Reference.Manager.Contracts;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Pixel.Automation.Editor.Core.Interfaces
@@ -82,7 +83,18 @@ namespace Pixel.Automation.Editor.Core.Interfaces
     /// </summary>
     public interface IAutomationProjectManager: IProjectManager
     {
+        /// <summary>
+        /// Load specified version of the automation project
+        /// </summary>
+        /// <param name="activeProject"></param>
+        /// <param name="versionToLoad"></param>
+        /// <returns></returns>
         Task<Entity> Load(AutomationProject activeProject, VersionInfo versionToLoad);
+
+        /// <summary>
+        /// Update the state of script engine and script editors whenever version of prefab is changed
+        /// </summary>       
+        void OnPrefabVersionChanged(IEnumerable<PrefabReference> prefabs);
     }
     
     /// <summary>
@@ -90,6 +102,12 @@ namespace Pixel.Automation.Editor.Core.Interfaces
     /// </summary>
     public interface IPrefabProjectManager : IProjectManager
     {
+        /// <summary>
+        /// Load specified version of the prefab project
+        /// </summary>
+        /// <param name="prefabProject"></param>
+        /// <param name="versionInfo"></param>
+        /// <returns></returns>
         Task<Entity> Load(PrefabProject prefabProject, VersionInfo versionInfo);
     }
 }

--- a/src/Pixel.Automation.Editor.Core/Interfaces/IVersionManager.cs
+++ b/src/Pixel.Automation.Editor.Core/Interfaces/IVersionManager.cs
@@ -2,6 +2,8 @@
 using Pixel.Automation.Core.Interfaces;
 using Pixel.Automation.Core.Models;
 using Pixel.Automation.Reference.Manager.Contracts;
+using System;
+using System.Collections.Generic;
 
 namespace Pixel.Automation.Editor.Core.Interfaces
 {
@@ -15,7 +17,7 @@ namespace Pixel.Automation.Editor.Core.Interfaces
 
         IVersionManager CreatePrefabVersionManager(PrefabProject prefabProject);
 
-        IVersionManager CreatePrefabReferenceManager(IReferenceManager referenceManager);
+        IVersionManager CreatePrefabReferenceManager(IReferenceManager referenceManager, Action<IEnumerable<PrefabReference>> OnPrefabsChanged);
 
         IVersionManager CreateControlReferenceManager(IReferenceManager referenceManager);
 

--- a/src/Pixel.Scripting.Common.CSharp/WorkspaceManagers/AdhocWorkspaceManager.cs
+++ b/src/Pixel.Scripting.Common.CSharp/WorkspaceManagers/AdhocWorkspaceManager.cs
@@ -30,7 +30,7 @@ namespace Pixel.Scripting.Common.CSharp.WorkspaceManagers
         private string workingDirectory;
         protected AdhocWorkspace workspace = default;
         protected readonly IHostServicesProvider hostServicesProvider = new RoslynFeaturesHostServicesProvider(AssemblyLoader.Instance);
-        protected List<MetadataReference> additionalReferences;     
+        protected readonly List<MetadataReference> additionalReferences = new();     
         protected readonly DocumentationProviderService documentationProviderService = new ();       
 
         public AdhocWorkspaceManager(string workingDirectory)
@@ -49,8 +49,7 @@ namespace Pixel.Scripting.Common.CSharp.WorkspaceManagers
             workspace = new AdhocWorkspace(HostServices);
             var solution = workspace.AddSolution(SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Create()));
             solution = solution.AddAnalyzerReferences(GetSolutionAnalyzerReferences());
-            workspace.TryApplyChanges(solution);
-            this.additionalReferences = new List<MetadataReference>();
+            workspace.TryApplyChanges(solution);           
         }
 
         protected virtual CSharpCompilationOptions CreateCompilationOptions()
@@ -370,6 +369,17 @@ namespace Pixel.Scripting.Common.CSharp.WorkspaceManagers
             {
                 var metaDataReference = MetadataReference.CreateFromFile(assembly.Location, documentation: documentationProviderService.GetDocumentationProvider(assembly.Location));
                 this.additionalReferences.Add(metaDataReference);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void RemoveAssemblyReference(Assembly assemblyReference)
+        {
+            Guard.Argument(assemblyReference, nameof(assemblyReference)).NotNull();          
+            if (this.additionalReferences.Any(a => a.Display.Equals(assemblyReference.Location)))
+            {
+                var referenceToRemove = this.additionalReferences.Single(r => r.Display.Equals(assemblyReference.Location));
+                this.additionalReferences.Remove(referenceToRemove);
             }
         }
     

--- a/src/Pixel.Scripting.Editor.Core/Contracts/IEditorFactory.cs
+++ b/src/Pixel.Scripting.Editor.Core/Contracts/IEditorFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Pixel.Scripting.Editor.Core.Contracts
 {
@@ -118,6 +119,20 @@ namespace Pixel.Scripting.Editor.Core.Contracts
         /// </summary>
         /// <param name="identifier"></param>
         void RemoveInlineScriptEditor(string identifier);
+
+        /// <summary>
+        /// Add a reference to specified assembly. Any new projets created will have 
+        /// this reference added automatically. Existing projects are not impacted.
+        /// </summary>
+        /// <param name="assembly">Assembly to add</param>
+        void AddAssemblyReference(Assembly assembly);
+
+        /// <summary>
+        /// Remove reference of an existing assembly. Any new project created will not have 
+        /// this assembly reference. Existing projects will not be impacted.
+        /// </summary>
+        /// <param name="assembly">Assembly to remove</param>
+        void RemoveAssemblyReference(Assembly assembly);
 
         /// <summary>
         /// Add additional locations from which #r assemblies can be resolved from.

--- a/src/Pixel.Scripting.Editor.Core/Contracts/IWorkspaceManager.cs
+++ b/src/Pixel.Scripting.Editor.Core/Contracts/IWorkspaceManager.cs
@@ -142,6 +142,12 @@ namespace Pixel.Scripting.Editor.Core.Contracts
         /// <param name="assemblyReferences"></param>
         void WithAssemblyReferences(Assembly[] assemblyReferences);
 
+        /// <summary>
+        /// Remove an assembly reference from the workspace. Any existing project which already references the assembly will not be impacted
+        /// </summary>
+        /// <param name="assemblyReference">Assembly to remove</param>
+        void RemoveAssemblyReference(Assembly assemblyReference);
+
 
     }
 

--- a/src/Pixel.Scripting.Script.Editor/EditorFactory/ScriptEditorFactory.cs
+++ b/src/Pixel.Scripting.Script.Editor/EditorFactory/ScriptEditorFactory.cs
@@ -4,6 +4,7 @@ using Pixel.Scripting.Script.Editor.Script;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Pixel.Scripting.Script.Editor
 {
@@ -50,7 +51,7 @@ namespace Pixel.Scripting.Script.Editor
         {
             this.editorService.SwitchToDirectory(workingDirectory);
         }
-
+     
         public IInlineScriptEditor CreateInlineScriptEditor()
         {
             EnsureInitialized();
@@ -163,6 +164,22 @@ namespace Pixel.Scripting.Script.Editor
             Guard.Argument(searchPaths).NotEmpty();
             var workSpaceManager = GetWorkspaceManager();
             workSpaceManager.RemoveSearchPaths(searchPaths);
+        }
+
+        public void AddAssemblyReference(Assembly assembly)
+        {
+            Guard.Argument(assembly, nameof(assembly)).NotNull();
+            var workSpaceManager = GetWorkspaceManager();
+            workSpaceManager.WithAssemblyReferences(new[] { assembly });
+            logger.Information($"Assembly : '{assembly.FullName}' reference was added to script editor worksapce");
+        }
+
+        public void RemoveAssemblyReference(Assembly assembly)
+        {
+            Guard.Argument(assembly, nameof(assembly)).NotNull();
+            var workSpaceManager = GetWorkspaceManager();
+            workSpaceManager.RemoveAssemblyReference(assembly);
+            logger.Information($"Assembly : '{assembly.FullName}' reference was removed from script editor worksapce");
         }
 
         public void Dispose()

--- a/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Prefabs/PrefabEntityTest.cs
+++ b/src/Unit.Tests/Pixel.Automation.Core.Components.Tests/Prefabs/PrefabEntityTest.cs
@@ -52,7 +52,7 @@ namespace Pixel.Automation.Core.Components.Tests
 
             await prefabEntity.BeforeProcessAsync();
             await scriptEngine.Received(1).CreateDelegateAsync<Action<object>>(Arg.Is("InputMappingScript.csx"));
-            Assert.AreEqual(typeof(Person), prefabEntity.GetPrefabDataModelType());
+            Assert.AreEqual(typeof(Person), await prefabEntity.GetPrefabDataModelType());
 
             Assert.AreEqual(1, prefabEntity.Components.Count);
 


### PR DESCRIPTION
**Description**
When changing a prefab version, we need to close and reopen the automation process. This is because the script editor and script engine holds reference to a different version of prefab assembly. Additionally, prefab input and output scripts had a #r reference to specific version of assembly which will have to be edited every time prefab version was change.
It is possible now to change the prefab version without having to close and reopen automation process. Input and output mapping script don't have a #r reference to prefab assembly as well and hence don't require an edit.
Input and output mapping scripts might have to be updated however if data model or mapping has changed.
