### PR TITLE
Fix reload on updating data model

### DIFF
--- a/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
+++ b/src/Pixel.Automation.TestExplorer.ViewModels/TestExplorerViewModel.cs
@@ -540,7 +540,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                     throw new ArgumentException($"Test fixture with Id : '{fixtureId}' was not found.");
                 if (fixtureToClose != null)
                 {
-                    await CloseTestFixtureAsync(fixtureToClose, true);
+                    await CloseTestFixtureAsync(fixtureToClose, autoSave: true);
                 }
             }
             catch (Exception ex)
@@ -959,7 +959,7 @@ namespace Pixel.Automation.TestExplorer.ViewModels
                     {
                         if (test.TestCaseId.Equals(testCaseId))
                         {
-                            await CloseTestCaseAsync(test, true);
+                            await CloseTestCaseAsync(test, autoSave: true);
                             break;
                         }
                     }

--- a/src/Pixel.Scripting.Editor.Core/Contracts/IEditorFactory.cs
+++ b/src/Pixel.Scripting.Editor.Core/Contracts/IEditorFactory.cs
@@ -37,6 +37,12 @@ namespace Pixel.Scripting.Editor.Core.Contracts
         void RemoveDocument(string documentName, string projectName);
 
         /// <summary>
+        /// Check if a project by given name already exists in worksapce
+        /// </summary>
+        /// <param name="projectName"></param>
+        bool HasProject(string projectName);
+
+        /// <summary>
         /// Remove project from solution
         /// </summary>
         /// <param name="projectName"></param>

--- a/src/Pixel.Scripting.Script.Editor/EditorFactory/CodeEditorFactory.cs
+++ b/src/Pixel.Scripting.Script.Editor/EditorFactory/CodeEditorFactory.cs
@@ -87,6 +87,11 @@ namespace Pixel.Scripting.Script.Editor
             throw new Exception($"{nameof(ICodeWorkspaceManager)} is not available");
         }
 
+        public bool HasProject(string projectName)
+        {
+            return GetWorkspaceManager().HasProject(projectName);
+        }
+
         public void AddProject(string projectName, string defaultNameSpace, string[] projectreferences)
         {
             var workSpaceManager = GetWorkspaceManager();

--- a/src/Pixel.Scripting.Script.Editor/EditorFactory/REPLEditorFactory.cs
+++ b/src/Pixel.Scripting.Script.Editor/EditorFactory/REPLEditorFactory.cs
@@ -51,6 +51,11 @@ namespace Pixel.Scripting.Script.Editor
                 throw new InvalidOperationException($"{nameof(REPLEditorFactory)} is not yet initialized");
         }
 
+        public bool HasProject(string projectName)
+        {
+            throw new NotImplementedException();
+        }
+
         public void AddProject(string projectName, string[] projectreferences)
         {
             throw new NotImplementedException();

--- a/src/Pixel.Scripting.Script.Editor/EditorFactory/ScriptEditorFactory.cs
+++ b/src/Pixel.Scripting.Script.Editor/EditorFactory/ScriptEditorFactory.cs
@@ -113,6 +113,11 @@ namespace Pixel.Scripting.Script.Editor
             throw new Exception($"{nameof(IScriptWorkspaceManager)} is not available");
         }
 
+        public bool HasProject(string projectName)
+        {
+            return GetWorkspaceManager().HasProject(projectName);
+        }
+
         public void AddProject(string projectName, string[] projectreferences, Type globalsType)
         {
             var workSpaceManager = GetWorkspaceManager();


### PR DESCRIPTION
**Description**
Fixed an issue where changing the data model leaves the automation and prefab projects in inconsistent state with a mix of old and new data assembly. The reload that happens after saving the changes in data model should cause reloaded project to correctly use the updated data model.