### PR TITLE
Missing Initialization script file when trying to create a new project

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
@@ -180,6 +180,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             {
                 this.scriptEditorFactory.AddProject(RootEntity.Id, Array.Empty<string>(), dataModel.GetType());
                 var scriptFile = Path.Combine(fileSystem.ScriptsDirectory, Constants.InitializeEnvironmentScript);
+                CreateInitializationScriptFile(scriptFile);
                 this.scriptEditorFactory.AddDocument(scriptFile, RootEntity.Id, this.fileSystem.ReadAllText(scriptFile));
             }          
         }
@@ -212,8 +213,7 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             try
             {
                 var fileSystem = this.entityManager.GetCurrentFileSystem();
-                var scriptFile = Path.Combine(fileSystem.ScriptsDirectory, Constants.InitializeEnvironmentScript);
-                CreateInitializationScriptFile(scriptFile);
+                var scriptFile = Path.Combine(fileSystem.ScriptsDirectory, Constants.InitializeEnvironmentScript);           
                 var scriptEngine = this.entityManager.GetScriptEngine();
                 await scriptEngine.ExecuteFileAsync(scriptFile);
                 logger.Information("Executed initialize environment script : {scriptFile}", scriptFile);


### PR DESCRIPTION
**Description**
Project fails to load when a new project is created as it doesn't find the Initialization script file. Initialize script file should be created during SetupInitializationScriptProject().