### PR TITLE
Retries with Polly for Playwright plugin

### DIFF
--- a/src/Pixel.Automation.Web.Playwright.Components/Pixel.Automation.Web.Playwright.Components.csproj
+++ b/src/Pixel.Automation.Web.Playwright.Components/Pixel.Automation.Web.Playwright.Components.csproj
@@ -19,7 +19,7 @@
 		<PackageReference Include="Serilog" Version="3.1.1">
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Playwright" Version="1.42.0" />
+		<PackageReference Include="Microsoft.Playwright" Version="1.44.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Pixel.Automation.Web.Scrapper/Pixel.Automation.Web.Scrapper.csproj
+++ b/src/Pixel.Automation.Web.Scrapper/Pixel.Automation.Web.Scrapper.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="Serilog" Version="3.1.1">
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Playwright" Version="1.42.0" />
+		<PackageReference Include="Microsoft.Playwright" Version="1.44.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Lookup with playwright immediately fails if control is not present on the page. Playwright control lookup logic should take retry configurations in to consideration and attempt retries for control lookup.