### PR TITLE
Trace image for prefab components are not captured

### DIFF
--- a/src/Pixel.Automation.Appium.Components/ActorComponents/AppiumActorComponent.cs
+++ b/src/Pixel.Automation.Appium.Components/ActorComponents/AppiumActorComponent.cs
@@ -37,34 +37,7 @@ public abstract class AppiumActorComponent : ActorComponent
     protected AppiumActorComponent(string name = "", string tag = "") : base(name, tag)
     {
 
-    }
-
-    /// <summary>
-    /// Take a screen shot if capturing screenshot is enabled after Act method finishes
-    /// </summary>
-    /// <returns></returns>
-    public override async Task OnCompletionAsync()
-    {
-        if (TraceManager.IsEnabled)
-        {
-            await CaptureScreenShotAsync();
-        }
-    }
-
-    /// <summary>
-    /// Capture screenshot of the active page
-    /// </summary>
-    /// <returns></returns>
-    public async Task CaptureScreenShotAsync()
-    {
-        var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
-        if (TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
-        {
-            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");
-            await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
-            TraceManager.AddImage(Path.GetFileName(imageFile));
-        }       
-    }
+    }   
 }
 
 /// <summary>

--- a/src/Pixel.Automation.Input.Devices.Components/InputDeviceActor.cs
+++ b/src/Pixel.Automation.Input.Devices.Components/InputDeviceActor.cs
@@ -86,18 +86,7 @@ public abstract class InputDeviceActor : ActorComponent
         }
 
         throw new ElementNotFoundException("Control could not be located");
-    }
-
-    public override async Task OnCompletionAsync()
-    {
-        var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
-        if (TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
-        {
-            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");                
-            await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
-            TraceManager.AddImage(Path.GetFileName(imageFile));
-        }
-    }
+    }  
 
     protected void ThrowIfMissingControlEntity()
     {

--- a/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/JABActorComponent.cs
+++ b/src/Pixel.Automation.Java.Access.Bridge.Components/ActorComponents/JABActorComponent.cs
@@ -5,7 +5,6 @@ using Pixel.Automation.Core.Exceptions;
 using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-using System.IO;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using WindowsAccessBridgeInterop;
@@ -70,34 +69,7 @@ namespace Pixel.Automation.Java.Access.Bridge.Components
 
             AccessibleContextNode control = targetControl.GetApiControl<AccessibleContextNode>();
             return (targetControl.ControlName, control);
-        }
-
-        /// <summary>
-        /// Take a screen shot if capturing screenshot is enabled after Act method finishes
-        /// </summary>
-        /// <returns></returns>
-        public override async Task OnCompletionAsync()
-        {
-            if (TraceManager.IsEnabled)
-            {
-                await CaptureScreenShotAsync();
-            }
-        }
-
-        /// <summary>
-        /// Capture screenshot of the active page
-        /// </summary>
-        /// <returns></returns>
-        public async Task CaptureScreenShotAsync()
-        {
-            var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
-            if (TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
-            {
-                string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");
-                await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
-                TraceManager.AddImage(Path.GetFileName(imageFile));
-            }
-        }
+        }        
 
         protected void ThrowIfMissingControlEntity()
         {

--- a/src/Pixel.Automation.UIA.Components/ActorComponents/UIAActorComponent.cs
+++ b/src/Pixel.Automation.UIA.Components/ActorComponents/UIAActorComponent.cs
@@ -2,13 +2,12 @@
 using Pixel.Automation.Core.Arguments;
 using Pixel.Automation.Core.Controls;
 using Pixel.Automation.Core.Exceptions;
+using Pixel.Windows.Automation;
 using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
-using Pixel.Windows.Automation;
-using System.IO;
 
 namespace Pixel.Automation.UIA.Components
 {
@@ -73,34 +72,7 @@ namespace Pixel.Automation.UIA.Components
             AutomationElement control = targetControl.GetApiControl<AutomationElement>();
             return (targetControl.ControlName, control);
         }
-
-        /// <summary>
-        /// Take a screen shot if capturing screenshot is enabled after Act method finishes
-        /// </summary>
-        /// <returns></returns>
-        public override async Task OnCompletionAsync()
-        {
-            if (TraceManager.IsEnabled)
-            {
-                await CaptureScreenShotAsync();
-            }
-        }
-
-        /// <summary>
-        /// Capture screenshot of the active page
-        /// </summary>
-        /// <returns></returns>
-        public async Task CaptureScreenShotAsync()
-        {
-            var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
-            if (TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
-            {
-                string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");
-                await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
-                TraceManager.AddImage(Path.GetFileName(imageFile));
-            }
-        }
-
+        
         /// <summary>
         /// Throw <see cref="ConfigurationException"/> if ControlEntity is missing.
         /// </summary>

--- a/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/PlaywrightActorComponent.cs
+++ b/src/Pixel.Automation.Web.Playwright.Components/ActorComponents/PlaywrightActorComponent.cs
@@ -73,34 +73,7 @@ public abstract class PlaywrightActorComponent : ActorComponent
         }
 
         return (targetControl.ControlName, targetControl.GetApiControl<ILocator>());
-    }
-
-    /// <summary>
-    /// Take a screen shot if capturing screenshot is enabled after Act method finishes
-    /// </summary>
-    /// <returns></returns>
-    public override async Task OnCompletionAsync()
-    {
-        if (TraceManager.IsEnabled)
-        {
-            await CaptureScreenShotAsync();
-        }
-    }
-
-    /// <summary>
-    /// Capture screenshot of the active page
-    /// </summary>
-    /// <returns></returns>
-    public async Task CaptureScreenShotAsync()
-    {
-        var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
-        if (TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
-        {
-            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");
-            await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
-            TraceManager.AddImage(Path.GetFileName(imageFile));
-        }     
-    }
+    } 
 
     protected void ThrowIfMissingControlEntity()
     {

--- a/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/SeleniumActorComponent.cs
+++ b/src/Pixel.Automation.Web.Selenium.Components/ActorComponents/SeleniumActorComponent.cs
@@ -37,34 +37,7 @@ public abstract class SeleniumActorComponent : ActorComponent
     protected SeleniumActorComponent(string name = "", string tag = "") : base(name, tag)
     {
 
-    }
-
-    /// <summary>
-    /// Take a screen shot if capturing screenshot is enabled after Act method finishes
-    /// </summary>
-    /// <returns></returns>
-    public override async Task OnCompletionAsync()
-    {
-        if (TraceManager.IsEnabled)
-        {
-            await CaptureScreenShotAsync();
-        }
-    }
-
-    /// <summary>
-    /// Capture screenshot of the active page
-    /// </summary>
-    /// <returns></returns>
-    public async Task CaptureScreenShotAsync()
-    {
-        var ownerApplicationEntity = this.EntityManager.GetApplicationEntity(this);
-        if(TraceManager.IsEnabled && ownerApplicationEntity.AllowCaptureScreenshot)
-        {
-            string imageFile = Path.Combine(this.EntityManager.GetCurrentFileSystem().TempDirectory, $"{Path.GetRandomFileName()}.jpeg");
-            await ownerApplicationEntity.CaptureScreenShotAsync(imageFile);
-            TraceManager.AddImage(Path.GetFileName(imageFile));
-        }       
-    }
+    }    
 }
 
 /// <summary>


### PR DESCRIPTION
**Description**
Trace image for components belonging to a prefab are not uploaded. This was happening because the trace image for prefabs were getting saved to prefabs temp directory instead of the automation process temp directory.