### PR TITLE
Fixed an issue with script editor where it can't see changes to data model assembly

### DIFF
--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/AutomationProjectManager.cs
@@ -194,7 +194,10 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
 
                 //Dispose any inline editors that might be present and clean up script editor and script engine
                 this.RootEntity.DisposeEditors();
+
                 this.scriptEditorFactory.RemoveProject(RootEntity.Id);
+                this.scriptEditorFactory.RemoveAssemblyReference(this.entityManager.Arguments.GetType().Assembly);
+               
                 this.scriptEngineFactory.RemoveReferences(this.entityManager.Arguments.GetType().Assembly);
 
                 var reference = this.fileSystem.LoadFile<ProjectReferences>(this.fileSystem.ReferencesFile);
@@ -202,9 +205,10 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                
                 var dataModel = CompileAndCreateDataModel(Constants.AutomationProcessDataModelName);              
                 this.entityManager.Arguments = dataModel; // Setting up a new model will also configure script engine to use new assembly
-              
+
+                this.scriptEditorFactory.AddAssemblyReference(dataModel.GetType().Assembly);
+
                 this.scriptEngineFactory.WithAdditionalAssemblyReferences(this.entityManager.Arguments.GetType().Assembly);  
-                this.ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);              
            
                 this.Initialize();
                 this.SetupInitializationScriptProject(dataModel);

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/PrefabProjectManager.cs
@@ -229,7 +229,10 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
                 await this.Save();
 
                 this.RootEntity.DisposeEditors();
+               
                 this.scriptEditorFactory.RemoveProject(RootEntity.Id);
+                this.scriptEditorFactory.RemoveAssemblyReference(this.entityManager.Arguments.GetType().Assembly);
+             
                 this.scriptEngineFactory.RemoveReferences(this.entityManager.Arguments.GetType().Assembly);
 
                 var reference = this.fileSystem.LoadFile<ProjectReferences>(this.fileSystem.ReferencesFile);
@@ -237,6 +240,8 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
               
                 var dataModel = CompileAndCreateDataModel(Constants.PrefabDataModelName);
                 this.entityManager.Arguments = dataModel; // Setting up a new model will also configure script engine to use new assembly
+
+                this.scriptEditorFactory.AddAssemblyReference(dataModel.GetType().Assembly);
 
                 this.scriptEngineFactory.WithAdditionalAssemblyReferences(this.entityManager.Arguments.GetType().Assembly);
                 this.ConfigureArgumentTypeProvider(this.entityManager.Arguments.GetType().Assembly);

--- a/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
+++ b/src/Pixel.Automation.Designer.ViewModels/AutomationBuilder/ProjectManager.cs
@@ -163,8 +163,10 @@ namespace Pixel.Automation.Designer.ViewModels.AutomationBuilder
             using (var activity = Telemetry.DefaultSource?.StartActivity(nameof(ConfigureScriptEditor), ActivityKind.Internal))
             {
                 logger.Information($"Trying to configure script editor for project  : {this.GetProjectName()}.");
-                var assemblyReferences = new List<string>(referenceManager.GetScriptEditorReferences());
-                assemblyReferences.Add(dataModel.GetType().Assembly.Location);
+                var assemblyReferences = new List<string>(referenceManager.GetScriptEditorReferences())
+                {
+                    dataModel.GetType().Assembly.Location
+                };
                 this.scriptEditorFactory.Initialize(this.fileSystem.WorkingDirectory, assemblyReferences, referenceManager.GetImportsForScripts());
                 this.scriptEditorFactory.AddSearchPaths(Directory.GetDirectories(Path.Combine(AppContext.BaseDirectory, "Plugins")));
                 logger.Information($"Configure script editor for project  : {this.GetProjectName()} completed.");

--- a/src/Pixel.Scripting.Common.CSharp/WorkspaceManagers/AdhocWorkspaceManager.cs
+++ b/src/Pixel.Scripting.Common.CSharp/WorkspaceManagers/AdhocWorkspaceManager.cs
@@ -368,7 +368,10 @@ namespace Pixel.Scripting.Common.CSharp.WorkspaceManagers
             foreach (var assembly in assemblyReferences)
             {
                 var metaDataReference = MetadataReference.CreateFromFile(assembly.Location, documentation: documentationProviderService.GetDocumentationProvider(assembly.Location));
-                this.additionalReferences.Add(metaDataReference);
+                if(!this.additionalReferences.Any(a => a.Display.Equals(assembly.Location)))
+                {
+                    this.additionalReferences.Add(metaDataReference);
+                }
             }
         }
 


### PR DESCRIPTION
**Description**
Coded test data source script doesn't recognize types.

**Step to Repro issue**
1. Add a new type e.g. Messages by editing the data model and save changes. Data model assembly is recompiled and project is reloaded.
2. Add a new code test data source and select type as Messages.
3. Select next on the new test data source screen
4. Script editor is opened
5. Script editor doesn't recognise the Messages data type

**Fix**
We need to remove the last assembly and add new assembly every time datamodel is edited to the script editor factory so that script editor factory can see changes in the data model.