### PR TITLE
update actions/cache to v4

### DIFF
--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -19,7 +19,7 @@ jobs:
       with:
        dotnet-version: ${{ matrix.dotnet-version }}
     - name : Cache nuget packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}

--- a/.github/workflows/build-pixel-designer.yml
+++ b/.github/workflows/build-pixel-designer.yml
@@ -64,7 +64,7 @@ jobs:
         dotnet-version: ${{ matrix.dotnet-version }}
 
     - name : Cache nuget packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}

--- a/.github/workflows/build-pixel-runner.yml
+++ b/.github/workflows/build-pixel-runner.yml
@@ -64,7 +64,7 @@ jobs:
        dotnet-version: ${{ matrix.dotnet-version }}
 
     - name : Cache nuget packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}


### PR DESCRIPTION
Updated actions/cache to v4 as v2 was deprecated and builds were failing.